### PR TITLE
Pin Trello Done list id for formal runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         run: |
           python3 -m unittest -v tests/test_backlog_lint.py
           python3 -m unittest -v tests/test_backlog_sync.py
+          python3 -m unittest -v tests/test_pin_trello_done_list.py
           python3 -m unittest -v tests/test_argus_hardening.py
           python3 -m unittest -v tests/test_processed_finalization.py
 

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -129,8 +129,8 @@ Allowed enum values:
 ### BL-20260324-005
 - title: Pin TRELLO_DONE_LIST_ID in the formal runtime environment
 - type: debt
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p2
 - owner: Oscarling
 - depends_on: BL-20260324-002
@@ -138,8 +138,8 @@ Allowed enum values:
 - done_when: Formal finalization no longer depends on list-name lookup for the Done list
 - source: PROCESSED_FINALIZATION_REPORT.md
 - link: /tmp/trello_env.sh
-- issue: deferred:after-formal-preview-hardening-merges
-- evidence: -
+- issue: https://github.com/Oscarling/openclaw-team/issues/12
+- evidence: `scripts/pin_trello_done_list.py` was added, `/tmp/trello_env.sh` now exports `TRELLO_DONE_LIST_ID`, and `/private/tmp/trello_env.sh.bak-20260324T064207Z` preserves the prior runtime env file
 - last_reviewed_at: 2026-03-24
 - opened_at: 2026-03-24
 

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -582,3 +582,31 @@ Current governance note:
   - one approving review is still configured
   - admins are allowed to bypass that review gate
   - this is a deliberate solo-maintainer exception and should be revisited when a second reviewer is available
+
+### 18. Trello Done List Pinning For Formal Runtime
+
+User objective:
+
+- remove the remaining dependence on Trello Done list name lookup during formal finalization
+- turn the preferred runtime convention into an explicit, repeatable, repo-supported step
+
+Main work areas:
+
+- confirmed that `/tmp/trello_env.sh` had Trello credentials and board id but no `TRELLO_DONE_LIST_ID`
+- added `scripts/pin_trello_done_list.py` to resolve the Done list id from the board and pin it into a shell env file
+- designed the tool to archive the previous env file before writing changes
+- added `tests/test_pin_trello_done_list.py`
+- tightened `scripts/preflight_finalization_check.sh` so missing `TRELLO_DONE_LIST_ID` is now a failure for formal runs
+- updated `docs/PRE_RUN_CHECKLIST.md` and baseline CI/premerge coverage for the new pinning tool
+- ran the tool against the active runtime env file and wrote the pinned `TRELLO_DONE_LIST_ID` into `/tmp/trello_env.sh`
+
+Key result:
+
+- formal finalization no longer depends on Done-list name lookup in the active runtime environment
+- the runtime env change is archived, reproducible, and backed by a repo-side tool plus tests
+
+Verification snapshot on 2026-03-24:
+
+- `python3 scripts/pin_trello_done_list.py --env-file /tmp/trello_env.sh` resolved the Done list successfully
+- `python3 scripts/pin_trello_done_list.py --env-file /tmp/trello_env.sh --apply` updated the env file and created `/private/tmp/trello_env.sh.bak-20260324T064207Z`
+- `/tmp/trello_env.sh` now contains an explicit `export TRELLO_DONE_LIST_ID=...` line

--- a/docs/PRE_RUN_CHECKLIST.md
+++ b/docs/PRE_RUN_CHECKLIST.md
@@ -43,8 +43,9 @@ This checklist is mandatory before:
 
 ## Additional Checks For Trello Done / Writeback Runs
 
-- [ ] `TRELLO_DONE_LIST_ID` is set, or I have documented why list-name resolution
-      is acceptable for this run
+- [ ] `TRELLO_DONE_LIST_ID` is set for the formal runtime environment
+- [ ] If it is missing, I have pinned it first with:
+      `python3 scripts/pin_trello_done_list.py --env-file /tmp/trello_env.sh --apply`
 
 ## Minimum Commands
 

--- a/scripts/pin_trello_done_list.py
+++ b/scripts/pin_trello_done_list.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+
+DONE_LIST_NAME_CANDIDATES = ("done", "完成", "completed", "complete")
+EXPORT_PATTERN = re.compile(r"^(?P<prefix>\s*export\s+)(?P<name>[A-Za-z_][A-Za-z0-9_]*)=(?P<value>.*?)(?P<suffix>\s*)$")
+VAR_REFERENCE_PATTERN = re.compile(r"^\$(?:\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)\}|(?P<plain>[A-Za-z_][A-Za-z0-9_]*))$")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Resolve the Trello Done list id for a board and pin it into a shell env file "
+            "such as /tmp/trello_env.sh."
+        )
+    )
+    parser.add_argument(
+        "--env-file",
+        default="/tmp/trello_env.sh",
+        help="Shell env file containing Trello credentials and board id.",
+    )
+    parser.add_argument("--board-id", default=None, help="Explicit Trello board id override.")
+    parser.add_argument("--done-list-id", default=None, help="Explicit Done list id override. Skips API lookup.")
+    parser.add_argument("--done-list-name", default=None, help="Preferred Done list name when resolving by board.")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write the resolved TRELLO_DONE_LIST_ID into the env file and archive the prior file first.",
+    )
+    return parser.parse_args()
+
+
+def utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _strip_shell_quotes(value: str) -> str:
+    stripped = value.strip()
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}:
+        return stripped[1:-1]
+    return stripped
+
+
+def parse_exports(env_file: Path) -> tuple[list[str], dict[str, str]]:
+    text = env_file.read_text(encoding="utf-8")
+    lines = text.splitlines(keepends=True)
+    exports: dict[str, str] = {}
+    for line in lines:
+        match = EXPORT_PATTERN.match(line.rstrip("\n"))
+        if not match:
+            continue
+        exports[match.group("name")] = _strip_shell_quotes(match.group("value"))
+    return lines, exports
+
+
+def _resolve_export_reference(name: str, exports: dict[str, str], seen: set[str] | None = None) -> str | None:
+    if seen is None:
+        seen = set()
+    if name in seen:
+        return None
+    seen.add(name)
+    raw = exports.get(name)
+    if raw is None:
+        return None
+    match = VAR_REFERENCE_PATTERN.match(raw)
+    if not match:
+        return raw
+    target = match.group("braced") or match.group("plain")
+    if not target:
+        return raw
+    return _resolve_export_reference(target, exports, seen)
+
+
+def _pick_env_from_exports(exports: dict[str, str], primary: str, alias: str) -> tuple[str | None, str]:
+    primary_val = _resolve_export_reference(primary, exports)
+    if primary_val:
+        return primary_val, primary
+    alias_val = _resolve_export_reference(alias, exports)
+    if alias_val:
+        return alias_val, alias
+    return None, "missing"
+
+
+def _normalize_list_name(name: str) -> str:
+    return "".join(str(name or "").strip().lower().split())
+
+
+def _shell_single_quote(value: str) -> str:
+    return "'" + str(value).replace("'", "'\"'\"'") + "'"
+
+
+def _fetch_board_lists(
+    *,
+    board_id: str,
+    api_key: str,
+    api_token: str,
+    urlopen: Callable[..., Any],
+) -> list[dict[str, Any]]:
+    query = urllib.parse.urlencode(
+        {
+            "key": api_key,
+            "token": api_token,
+            "fields": "id,name,closed,pos",
+        }
+    )
+    url = f"https://api.trello.com/1/boards/{board_id}/lists?{query}"
+    request = urllib.request.Request(url, method="GET")
+    try:
+        with urlopen(request, timeout=20) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(
+            f"Unable to resolve Trello Done list: HTTP {exc.code}; response_preview={body[:300]}"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(
+            f"Unable to resolve Trello Done list before HTTP response: {exc.__class__.__name__}: {exc.reason}"
+        ) from exc
+
+    payload = json.loads(body)
+    if not isinstance(payload, list):
+        raise RuntimeError("Unexpected Trello list response shape")
+    normalized: list[dict[str, Any]] = []
+    for item in payload:
+        if isinstance(item, dict):
+            normalized.append(item)
+    return normalized
+
+
+def resolve_done_list(
+    *,
+    exports: dict[str, str],
+    board_id_override: str | None,
+    done_list_id_override: str | None,
+    done_list_name_override: str | None,
+    urlopen: Callable[..., Any] = urllib.request.urlopen,
+) -> dict[str, Any]:
+    board_id = (board_id_override or _resolve_export_reference("TRELLO_BOARD_ID", exports) or "").strip()
+    if done_list_id_override:
+        return {
+            "done_list_id": done_list_id_override.strip(),
+            "done_list_name": done_list_name_override,
+            "board_id": board_id or None,
+            "resolution": "explicit_done_list_id",
+            "credential_source": "not_needed",
+        }
+
+    api_key, key_source = _pick_env_from_exports(exports, "TRELLO_API_KEY", "TRELLO_KEY")
+    api_token, token_source = _pick_env_from_exports(exports, "TRELLO_API_TOKEN", "TRELLO_TOKEN")
+    if not api_key or not api_token:
+        raise RuntimeError("Missing Trello credentials in env file: expected TRELLO_API_KEY/TRELLO_API_TOKEN or aliases")
+    if not board_id:
+        raise RuntimeError("Missing TRELLO_BOARD_ID in env file and no --board-id override was supplied")
+
+    lists = _fetch_board_lists(
+        board_id=board_id,
+        api_key=api_key,
+        api_token=api_token,
+        urlopen=urlopen,
+    )
+    target_names: list[str] = []
+    if done_list_name_override:
+        target_names.append(_normalize_list_name(done_list_name_override))
+    target_names.extend(_normalize_list_name(name) for name in DONE_LIST_NAME_CANDIDATES)
+    deduped_targets = [name for i, name in enumerate(target_names) if name and name not in target_names[:i]]
+
+    for candidate in lists:
+        if candidate.get("closed"):
+            continue
+        current_name = _normalize_list_name(str(candidate.get("name") or ""))
+        if current_name in deduped_targets:
+            done_list_id = str(candidate.get("id") or "").strip()
+            if not done_list_id:
+                raise RuntimeError("Resolved Trello Done list id is empty")
+            return {
+                "done_list_id": done_list_id,
+                "done_list_name": candidate.get("name"),
+                "board_id": board_id,
+                "resolution": "board_list_lookup",
+                "credential_source": f"{key_source}+{token_source}",
+            }
+
+    raise RuntimeError("Unable to resolve Trello Done list from board lists")
+
+
+def render_updated_env(lines: list[str], *, done_list_id: str) -> str:
+    rendered = list(lines)
+    export_line = f"export TRELLO_DONE_LIST_ID={_shell_single_quote(done_list_id)}\n"
+    for index, line in enumerate(rendered):
+        match = EXPORT_PATTERN.match(line.rstrip("\n"))
+        if match and match.group("name") == "TRELLO_DONE_LIST_ID":
+            rendered[index] = export_line
+            break
+    else:
+        if rendered and not rendered[-1].endswith("\n"):
+            rendered[-1] = rendered[-1] + "\n"
+        rendered.append(export_line)
+    return "".join(rendered)
+
+
+def pin_done_list_id(
+    env_file: Path,
+    *,
+    board_id_override: str | None,
+    done_list_id_override: str | None,
+    done_list_name_override: str | None,
+    apply: bool,
+    urlopen: Callable[..., Any] = urllib.request.urlopen,
+) -> dict[str, Any]:
+    if not env_file.exists():
+        raise RuntimeError(f"Env file does not exist: {env_file}")
+
+    lines, exports = parse_exports(env_file)
+    resolved = resolve_done_list(
+        exports=exports,
+        board_id_override=board_id_override,
+        done_list_id_override=done_list_id_override,
+        done_list_name_override=done_list_name_override,
+        urlopen=urlopen,
+    )
+    updated_text = render_updated_env(lines, done_list_id=resolved["done_list_id"])
+
+    result = {
+        "status": "resolved" if not apply else "updated",
+        "env_file": str(env_file),
+        "board_id": resolved.get("board_id"),
+        "done_list_id": resolved["done_list_id"],
+        "done_list_name": resolved.get("done_list_name"),
+        "resolution": resolved["resolution"],
+        "credential_source": resolved["credential_source"],
+        "applied": apply,
+    }
+
+    if not apply:
+        return result
+
+    backup_path = env_file.with_name(f"{env_file.name}.bak-{utc_stamp()}")
+    shutil.copy2(env_file, backup_path)
+    env_file.write_text(updated_text, encoding="utf-8")
+    result["backup_file"] = str(backup_path)
+    return result
+
+
+def main() -> int:
+    args = parse_args()
+    result = pin_done_list_id(
+        Path(args.env_file).expanduser().resolve(),
+        board_id_override=args.board_id,
+        done_list_id_override=args.done_list_id,
+        done_list_name_override=args.done_list_name,
+        apply=args.apply,
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/preflight_finalization_check.sh
+++ b/scripts/preflight_finalization_check.sh
@@ -98,7 +98,7 @@ fi
 if [[ -n "${TRELLO_DONE_LIST_ID:-}" ]]; then
   pass "TRELLO_DONE_LIST_ID is set."
 else
-  warn "TRELLO_DONE_LIST_ID is not set. List-name resolution may be acceptable for smoke, but explicit ID is preferred."
+  fail "TRELLO_DONE_LIST_ID is not set. Pin it before formal finalization runs."
 fi
 
 if [[ -n "$preview_path" && -f "$preview_path" ]]; then

--- a/scripts/premerge_check.sh
+++ b/scripts/premerge_check.sh
@@ -123,6 +123,12 @@ else
   fail "tests/test_backlog_sync.py failed."
 fi
 
+if python3 -m unittest -v tests/test_pin_trello_done_list.py; then
+  pass "tests/test_pin_trello_done_list.py passed."
+else
+  fail "tests/test_pin_trello_done_list.py failed."
+fi
+
 if python3 -m unittest -v tests/test_argus_hardening.py; then
   pass "tests/test_argus_hardening.py passed."
 else

--- a/tests/test_pin_trello_done_list.py
+++ b/tests/test_pin_trello_done_list.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+from urllib.error import URLError
+
+from scripts import pin_trello_done_list
+
+
+class FakeHTTPResponse:
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+
+    def __enter__(self) -> "FakeHTTPResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload, ensure_ascii=False).encode("utf-8")
+
+
+class PinTrelloDoneListTests(unittest.TestCase):
+    def _write_env(self, text: str) -> Path:
+        tmpdir = Path(tempfile.mkdtemp(prefix="pin-trello-done-list-"))
+        env_file = tmpdir / "trello_env.sh"
+        env_file.write_text(textwrap.dedent(text).lstrip(), encoding="utf-8")
+        return env_file
+
+    def test_lookup_writes_done_list_id_and_backup(self) -> None:
+        env_file = self._write_env(
+            """
+            export TRELLO_API_KEY='key-123'
+            export TRELLO_API_TOKEN='token-456'
+            export TRELLO_BOARD_ID='board-789'
+            """
+        )
+
+        def fake_urlopen(_request, timeout=20):  # type: ignore[no-untyped-def]
+            self.assertEqual(timeout, 20)
+            return FakeHTTPResponse(
+                [
+                    {"id": "list-todo", "name": "待办", "closed": False},
+                    {"id": "list-done", "name": "完成", "closed": False},
+                ]
+            )
+
+        result = pin_trello_done_list.pin_done_list_id(
+            env_file,
+            board_id_override=None,
+            done_list_id_override=None,
+            done_list_name_override="完成",
+            apply=True,
+            urlopen=fake_urlopen,
+        )
+
+        updated_text = env_file.read_text(encoding="utf-8")
+        self.assertEqual(result["status"], "updated")
+        self.assertIn("export TRELLO_DONE_LIST_ID='list-done'\n", updated_text)
+        self.assertTrue(Path(result["backup_file"]).exists())
+        self.assertNotIn("TRELLO_DONE_LIST_ID", Path(result["backup_file"]).read_text(encoding="utf-8"))
+
+    def test_explicit_done_list_id_skips_lookup(self) -> None:
+        env_file = self._write_env(
+            """
+            export TRELLO_KEY='key-only'
+            export TRELLO_TOKEN='token-only'
+            export TRELLO_BOARD_ID='board-789'
+            """
+        )
+
+        def unexpected_urlopen(_request, timeout=20):  # type: ignore[no-untyped-def]
+            raise AssertionError("urlopen should not be called when done-list-id is explicit")
+
+        result = pin_trello_done_list.pin_done_list_id(
+            env_file,
+            board_id_override=None,
+            done_list_id_override="manual-done-id",
+            done_list_name_override=None,
+            apply=True,
+            urlopen=unexpected_urlopen,
+        )
+
+        self.assertEqual(result["resolution"], "explicit_done_list_id")
+        self.assertIn("export TRELLO_DONE_LIST_ID='manual-done-id'\n", env_file.read_text(encoding="utf-8"))
+
+    def test_missing_credentials_raise_clear_error(self) -> None:
+        env_file = self._write_env(
+            """
+            export TRELLO_BOARD_ID='board-789'
+            """
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "Missing Trello credentials in env file"):
+            pin_trello_done_list.pin_done_list_id(
+                env_file,
+                board_id_override=None,
+                done_list_id_override=None,
+                done_list_name_override=None,
+                apply=False,
+            )
+
+    def test_network_error_is_reported(self) -> None:
+        env_file = self._write_env(
+            """
+            export TRELLO_API_KEY='key-123'
+            export TRELLO_API_TOKEN='token-456'
+            export TRELLO_BOARD_ID='board-789'
+            """
+        )
+
+        def failing_urlopen(_request, timeout=20):  # type: ignore[no-untyped-def]
+            raise URLError("boom")
+
+        with self.assertRaisesRegex(RuntimeError, "Unable to resolve Trello Done list before HTTP response"):
+            pin_trello_done_list.pin_done_list_id(
+                env_file,
+                board_id_override=None,
+                done_list_id_override=None,
+                done_list_name_override=None,
+                apply=False,
+                urlopen=failing_urlopen,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a repo-side tool to resolve and pin `TRELLO_DONE_LIST_ID` into the formal runtime env file with archival backup
- tighten formal finalization preflight and checklist so missing `TRELLO_DONE_LIST_ID` is no longer accepted for formal runs
- add baseline test coverage for the pinning tool and sync backlog/work-log state for BL-20260324-005

## Runtime action already performed
- resolved the active Trello board's Done list from the current runtime env file
- wrote `TRELLO_DONE_LIST_ID` into `/tmp/trello_env.sh`
- archived the prior env file before mutation

## Verification
- python3 scripts/pin_trello_done_list.py --env-file /tmp/trello_env.sh
- python3 scripts/pin_trello_done_list.py --env-file /tmp/trello_env.sh --apply
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- python3 -m unittest -v tests/test_backlog_lint.py tests/test_backlog_sync.py tests/test_pin_trello_done_list.py tests/test_processed_finalization.py
- scripts/premerge_check.sh
