### PR TITLE
Sync repo docs to single-maintainer policy

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -93,7 +93,7 @@ Allowed enum values:
 - opened_at: 2026-03-24
 
 ### BL-20260324-003
-- title: Enable branch protection for the primary branch with required CI and review
+- title: Enable branch protection for the primary branch with required CI and PR gating
 - type: blocker
 - status: done
 - phase: now
@@ -101,11 +101,11 @@ Allowed enum values:
 - owner: Oscarling
 - depends_on: BL-20260324-001, BL-20260324-002, BL-20260324-006
 - start_when: Governance and smoke-hardening PR branches are ready to enter normal merge flow and GitHub plan/public-visibility limits no longer block branch protection
-- done_when: The primary branch rejects direct push and requires passing CI plus at least one review for non-admin merges, with the current solo-maintainer exception explicitly recorded
+- done_when: The primary branch rejects direct push and requires pull-request based changes, up-to-date CI, and conversation resolution under the chosen single-maintainer policy
 - source: PROJECT_CHAT_AND_WORK_LOG.md
 - link: https://github.com/Oscarling/openclaw-team/settings/branches
 - issue: https://github.com/Oscarling/openclaw-team/issues/5
-- evidence: Branch protection is enabled on `main` with required checks `baseline-tests` and `shell-checks`, one approving review, stale review dismissal, required conversation resolution, and `enforce_admins=false` so the repo owner can merge in the current solo-maintainer workflow
+- evidence: Branch protection is enabled on `main` with strict required checks `baseline-tests` and `shell-checks`, stale review dismissal, required conversation resolution, `required_approving_review_count=0`, `enforce_admins=true`, and force-push/deletion blocked under the final single-maintainer policy
 - last_reviewed_at: 2026-03-24
 - opened_at: 2026-03-24
 
@@ -178,18 +178,35 @@ Allowed enum values:
 - opened_at: 2026-03-24
 
 ### BL-20260324-008
-- title: Formalize the solo-maintainer review-bypass policy or restore full reviewer enforcement
+- title: Finalize the long-term single-maintainer branch protection policy
 - type: debt
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p2
 - owner: Oscarling
 - depends_on: BL-20260324-003
-- start_when: The repository owner wants to harden review governance beyond the current solo-maintainer operating mode
-- done_when: The branch-protection policy is explicitly settled as either true second-party review enforcement or a documented long-term solo-maintainer exception
-- source: GitHub merge attempt for PR #1 on 2026-03-24 failed because one approving review from a writer was required; `main` protection was then changed to `enforce_admins=false`
+- start_when: The repository owner confirms there is only one human maintainer and wants GitHub policy to match the actual operating model
+- done_when: `main` enforces PR-based changes, strict CI, conversation resolution, and admin enforcement with `required_approving_review_count=0` until a second human maintainer actually joins
+- source: User clarification on 2026-03-24 that the project currently has one human maintainer only and AI assistance does not count as a second reviewer
 - link: https://github.com/Oscarling/openclaw-team/settings/branches
-- issue: deferred:after-review-policy-decision
+- issue: -
+- evidence: `gh api repos/Oscarling/openclaw-team/branches/main/protection` now reports `required_approving_review_count=0`, `enforce_admins.enabled=true`, required checks `baseline-tests`/`shell-checks`, and required conversation resolution enabled
+- last_reviewed_at: 2026-03-24
+- opened_at: 2026-03-24
+
+### BL-20260324-009
+- title: Revisit reviewer-count enforcement if a second human maintainer joins
+- type: future
+- status: planned
+- phase: later
+- priority: p3
+- owner: Oscarling
+- depends_on: BL-20260324-008
+- start_when: A second human maintainer is actively landing changes and can perform independent code review
+- done_when: Branch protection is recalibrated to require non-zero human approvals and the governance docs are updated to match
+- source: Single-maintainer policy finalization on 2026-03-24
+- link: https://github.com/Oscarling/openclaw-team/settings/branches
+- issue: deferred:activate-when-second-human-maintainer-joins
 - evidence: -
 - last_reviewed_at: 2026-03-24
 - opened_at: 2026-03-24

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -551,11 +551,11 @@ Main work areas:
 - changed finalization tests to work with injected fake HTTP callables even when `requests` is not installed
 - propagated that same CI fix to the affected open PR branches
 - merged PR #1, PR #2, PR #7, and PR #10 into `main`
-- updated `main` branch protection from admin-enforced review to the current solo-maintainer policy:
-  - required CI remains enforced
-  - required conversation resolution remains enforced
-  - required review remains configured for non-admin merges
-  - `enforce_admins` was turned off so the repository owner can complete merges in the current single-maintainer setup
+- updated `main` branch protection from admin-enforced review to an interim solo-maintainer merge policy needed to land the blocked stack:
+  - required CI remained enforced
+  - required conversation resolution remained enforced
+  - one approving review remained configured
+  - `enforce_admins` was turned off temporarily so the repository owner could complete the pending merges
 
 Merged PR results on 2026-03-24:
 
@@ -577,11 +577,8 @@ Key result:
 
 Current governance note:
 
-- the review rule is no longer "admin-enforced one-review policy"
-- the truthful current policy is:
-  - one approving review is still configured
-  - admins are allowed to bypass that review gate
-  - this is a deliberate solo-maintainer exception and should be revisited when a second reviewer is available
+- that interim admin-bypass policy was later retired
+- the truthful current policy is recorded in section 19
 
 ### 18. Trello Done List Pinning For Formal Runtime
 
@@ -610,3 +607,40 @@ Verification snapshot on 2026-03-24:
 - `python3 scripts/pin_trello_done_list.py --env-file /tmp/trello_env.sh` resolved the Done list successfully
 - `python3 scripts/pin_trello_done_list.py --env-file /tmp/trello_env.sh --apply` updated the env file and created `/private/tmp/trello_env.sh.bak-20260324T064207Z`
 - `/tmp/trello_env.sh` now contains an explicit `export TRELLO_DONE_LIST_ID=...` line
+
+### 19. Single-Maintainer Policy Finalization And Post-PR-13 State Sync
+
+User objective:
+
+- align the GitHub governance policy with the actual one-human-maintainer operating model
+- keep a standard PR-based workflow without inventing a fake second reviewer
+- preserve the latest merged runtime-hardening state in the repo ledger
+
+Main work areas:
+
+- confirmed with the repository owner that there is only one human maintainer and AI assistance does not count as a second reviewer
+- verified that PR #13 for formal runtime Trello Done-list pinning had merged into `main`
+- re-queried live GitHub branch protection for `main`
+- replaced the temporary admin-bypass configuration with the final single-maintainer policy:
+  - pull-request based changes remain required
+  - strict required checks remain `baseline-tests` and `shell-checks`
+  - required conversation resolution remains enabled
+  - required approving review count was set to `0`
+  - `enforce_admins` was turned back on
+  - force-push and branch deletion remain blocked
+
+Key result:
+
+- the repo policy now matches the real staffing model: one human maintainer, PR-based changes, and mandatory CI
+- the previous "one approval with admin bypass" stopgap no longer exists
+- future reviewer enforcement only needs to be revisited if a second human maintainer actually joins
+
+Verification snapshot on 2026-03-24:
+
+- `gh pr view 13 --json number,state,mergeCommit,headRefName,baseRefName,title` reports PR #13 `feat/pin-trello-done-list-id -> main` as `MERGED` with merge commit `fa6263d787baee793736407b2e2178da8991dd1b`
+- `gh api repos/Oscarling/openclaw-team/branches/main/protection` reports:
+  - strict required checks `baseline-tests` and `shell-checks`
+  - `required_approving_review_count = 0`
+  - stale review dismissal enabled
+  - admin enforcement enabled
+  - required conversation resolution enabled


### PR DESCRIPTION
## Summary
- sync backlog and work log to the final single-maintainer branch protection policy
- record that PR #13 merged and that admin bypass has been removed
- add a future backlog item to revisit human review count only if a second human maintainer joins

## Validation
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- python3 -m unittest -v tests/test_backlog_lint.py tests/test_backlog_sync.py
- bash scripts/premerge_check.sh