### PR TITLE
Harden Trello read-only ingress test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           python3 -m unittest -v tests/test_backlog_lint.py
           python3 -m unittest -v tests/test_backlog_sync.py
           python3 -m unittest -v tests/test_pin_trello_done_list.py
+          python3 -m unittest -v tests/test_trello_readonly_ingress.py
           python3 -m unittest -v tests/test_argus_hardening.py
           python3 -m unittest -v tests/test_processed_finalization.py
 

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -210,3 +210,20 @@ Allowed enum values:
 - evidence: -
 - last_reviewed_at: 2026-03-24
 - opened_at: 2026-03-24
+
+### BL-20260324-010
+- title: Harden Trello read-only ingress with dependency-safe tests
+- type: mainline
+- status: done
+- phase: now
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260324-005
+- start_when: Governance gates are live on `main` and the next mainline step needs a safer, testable Trello read-only entry before more real smokes
+- done_when: `skills/trello_readonly_prep.py` and the Trello read-only ingestion path can be tested without a hard `requests` import dependency, new unit coverage is enforced in local premerge and CI, and the current-state ledger reflects the hardened path
+- source: Post-governance backlog sweep on 2026-03-24 identified that the Trello read-only entry path has no dedicated unit coverage and still relies on a hard `requests` import
+- link: /Users/lingguozhong/openclaw-team/TRELLO_READONLY_INGRESS_HARDENING_REPORT.md
+- issue: https://github.com/Oscarling/openclaw-team/issues/15
+- evidence: `TRELLO_READONLY_INGRESS_HARDENING_REPORT.md` records the hardening pass; `tests/test_trello_readonly_ingress.py` was added; `scripts/premerge_check.sh` and `.github/workflows/ci.yml` now enforce that coverage; local validation passed for backlog lint/sync plus the new Trello and existing finalization tests
+- last_reviewed_at: 2026-03-24
+- opened_at: 2026-03-24

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -644,3 +644,40 @@ Verification snapshot on 2026-03-24:
   - stale review dismissal enabled
   - admin enforcement enabled
   - required conversation resolution enabled
+
+### 20. Trello Read-Only Ingress Hardening
+
+User objective:
+
+- continue under the standard workflow after governance stabilization
+- choose the next smallest real mainline step instead of starting another broad phase
+- harden the Trello read-only entry path before more real smoke work
+
+Main work areas:
+
+- ran a backlog sweep and registered the phase as `BL-20260324-010`
+- mirrored that backlog item to GitHub issue #15
+- removed the hard import-time `requests` dependency from:
+  - `skills/trello_readonly_prep.py`
+  - `skills/ingest_tasks.py`
+- added dedicated unit coverage for Trello read-only smoke and ingest behavior
+- wired the new test coverage into local `premerge_check` and CI
+- updated workflow docs so the enforced gate matches the documented baseline
+
+Primary output:
+
+- [TRELLO_READONLY_INGRESS_HARDENING_REPORT.md](/Users/lingguozhong/openclaw-team/TRELLO_READONLY_INGRESS_HARDENING_REPORT.md)
+
+Key result:
+
+- the Trello read-only entry path is now testable without relying on an implicit
+  `requests` install at import time
+- the repo has a dedicated regression guard for Trello read-only ingress
+- this pass did not expand scope into execute, finalization, or Trello writeback
+
+Verification snapshot on 2026-03-24:
+
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed and confirmed issue mirror for `BL-20260324-010 -> #15`
+- `python3 -m unittest -v tests/test_trello_readonly_ingress.py` passed `6/6`
+- `python3 -m unittest -v tests/test_processed_finalization.py tests/test_pin_trello_done_list.py` passed `12/12`

--- a/TRELLO_READONLY_INGRESS_HARDENING_REPORT.md
+++ b/TRELLO_READONLY_INGRESS_HARDENING_REPORT.md
@@ -1,0 +1,65 @@
+# Trello Readonly Ingress Hardening Report
+
+## Scope
+
+This report covers a narrow hardening pass on the Trello read-only entry path:
+
+- [skills/trello_readonly_prep.py](/Users/lingguozhong/openclaw-team/skills/trello_readonly_prep.py)
+- [skills/ingest_tasks.py](/Users/lingguozhong/openclaw-team/skills/ingest_tasks.py)
+
+The goal was not to expand the control chain. The goal was to make the Trello
+read-only path safer to validate and maintain by removing the hard import-time
+dependency on `requests`, adding dedicated unit coverage, and wiring that
+coverage into the normal premerge / CI gates.
+
+## Implemented
+
+- `skills/trello_readonly_prep.py` now tolerates a missing `requests` install at
+  import time and accepts an injected `requests_get` callable for tests.
+- `skills/ingest_tasks.py` now uses the same dependency-safe pattern for the
+  Trello read-only HTTP entry point.
+- Added
+  [tests/test_trello_readonly_ingress.py](/Users/lingguozhong/openclaw-team/tests/test_trello_readonly_ingress.py)
+  to cover:
+  - missing credentials blocking before HTTP
+  - successful read-only smoke with mapped preview output
+  - forbidden board access classification
+  - inbox payload creation from Trello cards
+  - missing `requests` dependency surfacing as a clear runtime error
+  - HTTP error preview propagation
+- Added the new test file to:
+  - [scripts/premerge_check.sh](/Users/lingguozhong/openclaw-team/scripts/premerge_check.sh)
+  - [.github/workflows/ci.yml](/Users/lingguozhong/openclaw-team/.github/workflows/ci.yml)
+- Updated
+  [docs/ENGINEERING_WORKFLOW.md](/Users/lingguozhong/openclaw-team/docs/ENGINEERING_WORKFLOW.md)
+  so the enforced baseline matches the repo's real test gate.
+
+## Validation
+
+Commands run locally:
+
+```bash
+python3 scripts/backlog_lint.py
+python3 scripts/backlog_sync.py
+python3 -m unittest -v tests/test_trello_readonly_ingress.py
+python3 -m unittest -v tests/test_processed_finalization.py tests/test_pin_trello_done_list.py
+```
+
+Observed result:
+
+- all commands passed
+- the new Trello read-only ingress tests passed `6/6`
+- existing finalization and Done-list pinning tests remained green
+
+## Non-Goals
+
+- no real Trello smoke run was added in this pass
+- no execute / approval semantics changed
+- no finalization / Trello writeback behavior changed
+
+## Remaining Gaps
+
+- real Trello read-only connectivity still depends on valid runtime credentials
+  and scope ids
+- this pass hardens testability and guardrails, but it does not itself prove live
+  Trello availability on the target runtime

--- a/docs/ENGINEERING_WORKFLOW.md
+++ b/docs/ENGINEERING_WORKFLOW.md
@@ -188,6 +188,7 @@ The current repo-level minimum command set is:
 
 ```bash
 python3 scripts/backlog_lint.py
+python3 -m unittest -v tests/test_trello_readonly_ingress.py
 python3 -m unittest -v tests/test_backlog_lint.py
 python3 -m unittest -v tests/test_argus_hardening.py
 python3 -m unittest -v tests/test_processed_finalization.py
@@ -205,6 +206,7 @@ scripts/preflight_finalization_check.sh <preview_json_path>
 The repository should keep a minimal CI job that runs:
 
 - `python3 scripts/backlog_lint.py`
+- `python3 -m unittest -v tests/test_trello_readonly_ingress.py`
 - `python3 -m unittest -v tests/test_backlog_lint.py`
 - `python3 -m unittest -v tests/test_argus_hardening.py`
 - `python3 -m unittest -v tests/test_processed_finalization.py`

--- a/docs/PRE_MERGE_CHECKLIST.md
+++ b/docs/PRE_MERGE_CHECKLIST.md
@@ -11,6 +11,8 @@ step complete.
 - [ ] Phase-specific smoke and regression runs passed
 - [ ] If this change touched finalization behavior, I ran:
       `python3 -m unittest -v tests/test_processed_finalization.py`
+- [ ] If this change touched Trello read-only ingress behavior, I ran:
+      `python3 -m unittest -v tests/test_trello_readonly_ingress.py`
 - [ ] If this change touched the control chain, I ran:
       `python3 -m unittest -v tests/test_argus_hardening.py`
 - [ ] If this change touched real Git / Trello integration, the pre-run checklist

--- a/scripts/premerge_check.sh
+++ b/scripts/premerge_check.sh
@@ -129,6 +129,12 @@ else
   fail "tests/test_pin_trello_done_list.py failed."
 fi
 
+if python3 -m unittest -v tests/test_trello_readonly_ingress.py; then
+  pass "tests/test_trello_readonly_ingress.py passed."
+else
+  fail "tests/test_trello_readonly_ingress.py failed."
+fi
+
 if python3 -m unittest -v tests/test_argus_hardening.py; then
   pass "tests/test_argus_hardening.py passed."
 else

--- a/skills/ingest_tasks.py
+++ b/skills/ingest_tasks.py
@@ -8,9 +8,12 @@ import shutil
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
-import requests
+try:
+    import requests as REQUESTS_MODULE
+except ModuleNotFoundError:
+    REQUESTS_MODULE = None
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
@@ -26,6 +29,18 @@ PROCESSING_DIR = REPO_ROOT / "processing"
 PROCESSED_DIR = REPO_ROOT / "processed"
 REJECTED_DIR = REPO_ROOT / "rejected"
 PREVIEW_DIR = REPO_ROOT / "preview"
+
+
+def _missing_requests_dependency(*_args: Any, **_kwargs: Any) -> Any:
+    raise RuntimeError(
+        "Missing Python dependency 'requests'. Install it before using Trello read-only HTTP calls."
+    )
+
+
+def _default_requests_get(*args: Any, **kwargs: Any) -> Any:
+    if REQUESTS_MODULE is None:
+        return _missing_requests_dependency(*args, **kwargs)
+    return REQUESTS_MODULE.get(*args, **kwargs)
 
 
 def utc_now() -> str:
@@ -90,6 +105,7 @@ def ingest_trello_readonly_once(
     board_id_override: str | None,
     list_id_override: str | None,
     limit: int,
+    requests_get: Callable[..., Any] = _default_requests_get,
 ) -> dict[str, Any]:
     auth = _trello_auth_env()
     api_key = auth["api_key"]
@@ -120,8 +136,10 @@ def ingest_trello_readonly_once(
     }
 
     try:
-        response = requests.get(url, params=params, timeout=20)
-    except requests.RequestException as exc:
+        response = requests_get(url, params=params, timeout=20)
+    except RuntimeError as exc:
+        raise RuntimeError(str(exc)) from exc
+    except Exception as exc:
         raise RuntimeError(
             f"Trello read-only request failed before HTTP response: {exc.__class__.__name__}"
         ) from exc

--- a/skills/trello_readonly_prep.py
+++ b/skills/trello_readonly_prep.py
@@ -6,9 +6,12 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
-import requests
+try:
+    import requests as REQUESTS_MODULE
+except ModuleNotFoundError:
+    REQUESTS_MODULE = None
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
@@ -18,6 +21,18 @@ from adapters.trello_readonly_adapter import (  # noqa: E402
     map_trello_card_to_external_input,
     required_readonly_env,
 )
+
+
+def _missing_requests_dependency(*_args: Any, **_kwargs: Any) -> Any:
+    raise RuntimeError(
+        "Missing Python dependency 'requests'. Install it before using Trello read-only HTTP calls."
+    )
+
+
+def _default_requests_get(*args: Any, **kwargs: Any) -> Any:
+    if REQUESTS_MODULE is None:
+        return _missing_requests_dependency(*args, **kwargs)
+    return REQUESTS_MODULE.get(*args, **kwargs)
 
 
 def parse_args() -> argparse.Namespace:
@@ -105,7 +120,13 @@ def _redact_sensitive(text: str, api_key: str | None, api_token: str | None) -> 
     return out
 
 
-def smoke_read_trello(list_id: str | None, board_id: str | None, limit: int) -> dict[str, Any]:
+def smoke_read_trello(
+    list_id: str | None,
+    board_id: str | None,
+    limit: int,
+    *,
+    requests_get: Callable[..., Any] = _default_requests_get,
+) -> dict[str, Any]:
     api_key, key_source = _pick_env("TRELLO_API_KEY", "TRELLO_KEY")
     api_token, token_source = _pick_env("TRELLO_API_TOKEN", "TRELLO_TOKEN")
     env_presence = _presence_map(
@@ -156,12 +177,19 @@ def smoke_read_trello(list_id: str | None, board_id: str | None, limit: int) -> 
         url = f"https://api.trello.com/1/boards/{board_id}/cards"
 
     try:
-        resp = requests.get(url, params=params, timeout=20)
-    except requests.RequestException as exc:
+        resp = requests_get(url, params=params, timeout=20)
+    except RuntimeError as exc:
+        return {
+            "status": "blocked",
+            "reason": f"Read-only Trello request dependency unavailable: {exc}",
+            "error_type": "missing_dependency",
+            "auth_env": auth_env,
+        }
+    except Exception as exc:
         return {
             "status": "blocked",
             "reason": f"Read-only Trello request failed before HTTP response: {exc.__class__.__name__}",
-            "error_type": "request_exception",
+            "error_type": exc.__class__.__name__,
             "response_preview": _redact_sensitive(str(exc), api_key, api_token)[:300],
             "auth_env": auth_env,
         }

--- a/tests/test_trello_readonly_ingress.py
+++ b/tests/test_trello_readonly_ingress.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+from skills import ingest_tasks
+from skills import trello_readonly_prep
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, payload: object) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = payload if isinstance(payload, str) else json.dumps(payload, ensure_ascii=False)
+
+    def json(self) -> object:
+        return self._payload
+
+
+class TrelloReadonlyIngressTests(unittest.TestCase):
+    ENV_NAMES = (
+        "TRELLO_API_KEY",
+        "TRELLO_API_TOKEN",
+        "TRELLO_KEY",
+        "TRELLO_TOKEN",
+        "TRELLO_BOARD_ID",
+        "TRELLO_LIST_ID",
+    )
+
+    def setUp(self) -> None:
+        self._old_env = {name: os.environ.get(name) for name in self.ENV_NAMES}
+        for name in self.ENV_NAMES:
+            os.environ.pop(name, None)
+
+    def tearDown(self) -> None:
+        for name, value in self._old_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+    def test_smoke_read_reports_missing_credentials_before_http(self) -> None:
+        result = trello_readonly_prep.smoke_read_trello(
+            list_id="list-123",
+            board_id=None,
+            limit=1,
+        )
+
+        self.assertEqual(result["status"], "blocked")
+        self.assertIn("Missing Trello credentials", result["reason"])
+
+    def test_smoke_read_passes_with_injected_http_and_maps_first_card(self) -> None:
+        os.environ["TRELLO_API_KEY"] = "key-123"
+        os.environ["TRELLO_API_TOKEN"] = "token-456"
+
+        def fake_get(url: str, params: dict[str, object], timeout: int) -> FakeResponse:
+            self.assertEqual(url, "https://api.trello.com/1/boards/board-123/cards")
+            self.assertEqual(timeout, 20)
+            self.assertEqual(params["limit"], 1)
+            return FakeResponse(
+                200,
+                [
+                    {
+                        "id": "card-123",
+                        "idShort": 7,
+                        "name": "Sample card",
+                        "desc": "Convert this PDF.",
+                        "idBoard": "board-123",
+                        "idList": "list-456",
+                        "dateLastActivity": "2026-03-24T10:00:00.000Z",
+                        "labels": [{"name": "Finance"}],
+                    }
+                ],
+            )
+
+        result = trello_readonly_prep.smoke_read_trello(
+            list_id=None,
+            board_id="board-123",
+            limit=1,
+            requests_get=fake_get,
+        )
+
+        self.assertEqual(result["status"], "pass")
+        self.assertEqual(result["read_count"], 1)
+        self.assertEqual(result["mapped_preview"]["origin_id"], "trello:card-123")
+        self.assertEqual(result["mapped_preview"]["source"]["mode"], "readonly")
+
+    def test_smoke_read_classifies_forbidden_board_access(self) -> None:
+        os.environ["TRELLO_API_KEY"] = "key-123"
+        os.environ["TRELLO_API_TOKEN"] = "token-456"
+
+        def fake_get(_url: str, params: dict[str, object], timeout: int) -> FakeResponse:
+            self.assertEqual(timeout, 20)
+            self.assertEqual(params["limit"], 1)
+            return FakeResponse(403, "forbidden")
+
+        result = trello_readonly_prep.smoke_read_trello(
+            list_id=None,
+            board_id="board-123",
+            limit=1,
+            requests_get=fake_get,
+        )
+
+        self.assertEqual(result["status"], "blocked")
+        self.assertEqual(result["error_code"], "token_no_board_access")
+
+    def test_ingest_trello_readonly_writes_inbox_payload(self) -> None:
+        os.environ["TRELLO_API_KEY"] = "key-123"
+        os.environ["TRELLO_API_TOKEN"] = "token-456"
+
+        repo_root = Path(tempfile.mkdtemp(prefix="trello-readonly-ingest-"))
+        original_paths = (
+            ingest_tasks.REPO_ROOT,
+            ingest_tasks.INBOX_DIR,
+            ingest_tasks.PROCESSING_DIR,
+            ingest_tasks.PROCESSED_DIR,
+            ingest_tasks.REJECTED_DIR,
+            ingest_tasks.PREVIEW_DIR,
+        )
+
+        def fake_get(url: str, params: dict[str, object], timeout: int) -> FakeResponse:
+            self.assertEqual(url, "https://api.trello.com/1/boards/board-123/cards")
+            self.assertEqual(timeout, 20)
+            self.assertEqual(params["limit"], 1)
+            return FakeResponse(
+                200,
+                [
+                    {
+                        "id": "card-abc",
+                        "idShort": 11,
+                        "name": "Weekly PDF batch",
+                        "desc": "Please extract the attached PDFs.",
+                        "idBoard": "board-123",
+                        "idList": "list-456",
+                        "dateLastActivity": "2026-03-24T11:00:00.000Z",
+                        "labels": [{"name": "Ops"}],
+                    }
+                ],
+            )
+
+        try:
+            ingest_tasks.REPO_ROOT = repo_root
+            ingest_tasks.INBOX_DIR = repo_root / "inbox"
+            ingest_tasks.PROCESSING_DIR = repo_root / "processing"
+            ingest_tasks.PROCESSED_DIR = repo_root / "processed"
+            ingest_tasks.REJECTED_DIR = repo_root / "rejected"
+            ingest_tasks.PREVIEW_DIR = repo_root / "preview"
+            ingest_tasks.ensure_dirs()
+
+            result = ingest_tasks.ingest_trello_readonly_once(
+                board_id_override="board-123",
+                list_id_override=None,
+                limit=1,
+                requests_get=fake_get,
+            )
+        finally:
+            (
+                ingest_tasks.REPO_ROOT,
+                ingest_tasks.INBOX_DIR,
+                ingest_tasks.PROCESSING_DIR,
+                ingest_tasks.PROCESSED_DIR,
+                ingest_tasks.REJECTED_DIR,
+                ingest_tasks.PREVIEW_DIR,
+            ) = original_paths
+
+        self.assertEqual(result["status"], "done")
+        self.assertEqual(result["read_count"], 1)
+        self.assertEqual(result["inbox_written"], 1)
+
+        written_path = Path(result["inbox_files"][0])
+        self.assertTrue(written_path.exists())
+        payload = json.loads(written_path.read_text(encoding="utf-8"))
+        self.assertEqual(payload["origin_id"], "trello:card-abc")
+        self.assertEqual(payload["source"]["provider"], "trello")
+
+    def test_ingest_trello_readonly_surfaces_missing_dependency_clearly(self) -> None:
+        os.environ["TRELLO_API_KEY"] = "key-123"
+        os.environ["TRELLO_API_TOKEN"] = "token-456"
+
+        def missing_requests(_url: str, params: dict[str, object], timeout: int) -> FakeResponse:
+            self.assertEqual(timeout, 20)
+            self.assertEqual(params["limit"], 1)
+            raise RuntimeError(
+                "Missing Python dependency 'requests'. Install it before using Trello read-only HTTP calls."
+            )
+
+        with self.assertRaisesRegex(RuntimeError, "Missing Python dependency 'requests'"):
+            ingest_tasks.ingest_trello_readonly_once(
+                board_id_override="board-123",
+                list_id_override=None,
+                limit=1,
+                requests_get=missing_requests,
+            )
+
+    def test_ingest_trello_readonly_surfaces_http_error_preview(self) -> None:
+        os.environ["TRELLO_API_KEY"] = "key-123"
+        os.environ["TRELLO_API_TOKEN"] = "token-456"
+
+        def fake_get(_url: str, params: dict[str, object], timeout: int) -> FakeResponse:
+            self.assertEqual(timeout, 20)
+            self.assertEqual(params["limit"], 1)
+            return FakeResponse(401, "invalid token")
+
+        with self.assertRaisesRegex(RuntimeError, "HTTP 401"):
+            ingest_tasks.ingest_trello_readonly_once(
+                board_id_override="board-123",
+                list_id_override=None,
+                limit=1,
+                requests_get=fake_get,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- harden Trello read-only prep and ingest paths so they no longer rely on an import-time requests dependency
- add dedicated Trello read-only ingress tests and enforce them in premerge and CI
- record BL-20260324-010 and the phase evidence/report in repo docs

## Backlog and issue
- BL-20260324-010
- Closes #15

## Validation
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- python3 -m unittest -v tests/test_trello_readonly_ingress.py
- python3 -m unittest -v tests/test_processed_finalization.py tests/test_pin_trello_done_list.py
- bash scripts/premerge_check.sh