### PR TITLE
Record real Trello read-only preview smoke

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -227,3 +227,37 @@ Allowed enum values:
 - evidence: `TRELLO_READONLY_INGRESS_HARDENING_REPORT.md` records the hardening pass; `tests/test_trello_readonly_ingress.py` was added; `scripts/premerge_check.sh` and `.github/workflows/ci.yml` now enforce that coverage; local validation passed for backlog lint/sync plus the new Trello and existing finalization tests
 - last_reviewed_at: 2026-03-24
 - opened_at: 2026-03-24
+
+### BL-20260324-011
+- title: Run a governed real Trello read-only smoke through preview generation
+- type: mainline
+- status: done
+- phase: now
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260324-010
+- start_when: Trello read-only ingress hardening is merged and the runtime environment still exposes valid read-only credentials
+- done_when: A real Trello read-only run is executed under the pre-run gate, the outcome is captured in a repo evidence report, and the current-state ledger truthfully records whether the live run created a new preview or was blocked by dedupe/runtime state
+- source: Standard post-merge flow on 2026-03-24 after BL-20260324-010 landed identified the next smallest mainline step as one real Trello read-only smoke to preview
+- link: /Users/lingguozhong/openclaw-team/TRELLO_READONLY_PREVIEW_SMOKE_REPORT.md
+- issue: https://github.com/Oscarling/openclaw-team/issues/17
+- evidence: `TRELLO_READONLY_PREVIEW_SMOKE_REPORT.md` records a real GET-only Trello smoke pass plus a preview-only ingest run with `processed=0`, `duplicate_skipped=4`, and `preview_created=0`; the live fetched cards were all already present in local dedupe history and one extra duplicate came from `trello_readonly_mapped_sample.json` being recovered from `processing/`
+- last_reviewed_at: 2026-03-24
+- opened_at: 2026-03-24
+
+### BL-20260324-012
+- title: Stop trello_readonly_prep smoke output from polluting the live processing queue
+- type: debt
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260324-011
+- start_when: The real preview smoke has confirmed that `skills/trello_readonly_prep.py` still writes a recoverable sample file under `processing/`
+- done_when: Running `skills/trello_readonly_prep.py --smoke-read` no longer creates recoverable live-queue input under `processing/`, and the behavior is covered by tests and reflected in the phase evidence
+- source: `TRELLO_READONLY_PREVIEW_SMOKE_REPORT.md` on 2026-03-24 showed `processing_recovered=1` because `trello_readonly_mapped_sample.json` was picked up during the real ingest run
+- link: /Users/lingguozhong/openclaw-team/skills/trello_readonly_prep.py
+- issue: deferred:promote-after-phase8h-closeout
+- evidence: -
+- last_reviewed_at: 2026-03-24
+- opened_at: 2026-03-24

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -681,3 +681,52 @@ Verification snapshot on 2026-03-24:
 - `python3 scripts/backlog_sync.py` passed and confirmed issue mirror for `BL-20260324-010 -> #15`
 - `python3 -m unittest -v tests/test_trello_readonly_ingress.py` passed `6/6`
 - `python3 -m unittest -v tests/test_processed_finalization.py tests/test_pin_trello_done_list.py` passed `12/12`
+
+### 21. Governed Real Trello Read-Only Preview Smoke
+
+User objective:
+
+- continue from the newly hardened Trello read-only ingress under the standard
+  workflow
+- run one real Trello read-only smoke under the pre-run gate
+- stop at preview generation and record the live result truthfully
+
+Main work areas:
+
+- opened `BL-20260324-011` and mirrored it to GitHub issue #17
+- reviewed the current-state ledger and baseline freeze note before the run
+- confirmed the runtime worktree was clean and `/tmp/trello_env.sh` still exposed
+  Trello read-only credentials plus board scope
+- ran one real GET-only Trello smoke
+- ran one real preview-only ingest against live Trello cards
+
+Primary output:
+
+- [TRELLO_READONLY_PREVIEW_SMOKE_REPORT.md](/Users/lingguozhong/openclaw-team/TRELLO_READONLY_PREVIEW_SMOKE_REPORT.md)
+
+Key result:
+
+- live Trello read-only GET access is currently working
+- this exact preview smoke produced no new preview because the fetched live cards
+  all matched existing local dedupe history
+- no approval, execute, git finalization, or Trello writeback behavior was entered
+
+Newly exposed follow-up:
+
+- `skills/trello_readonly_prep.py --smoke-read` still writes a sample-mapped file
+  under `processing/`
+- the subsequent real ingest run recovered that file and rejected it as another
+  duplicate
+- this was converted into backlog item `BL-20260324-012` instead of being left as
+  shell-only knowledge
+
+Verification snapshot on 2026-03-24:
+
+- `source /tmp/trello_env.sh && python3 skills/trello_readonly_prep.py --smoke-read --limit 1`
+  passed with live board GET access
+- `source /tmp/trello_env.sh && python3 skills/ingest_tasks.py --once --trello-readonly-once --trello-limit 3`
+  completed with:
+  - `processed = 0`
+  - `duplicate_skipped = 4`
+  - `preview_created = 0`
+  - `processing_recovered = 1`

--- a/TRELLO_READONLY_PREVIEW_SMOKE_REPORT.md
+++ b/TRELLO_READONLY_PREVIEW_SMOKE_REPORT.md
@@ -1,0 +1,115 @@
+# Trello Readonly Preview Smoke Report
+
+## Scope
+
+This report covers one governed real Trello read-only smoke after the Trello
+ingress hardening work landed on `main`.
+
+Target path:
+
+`Trello read-only -> adapter mapping -> inbox -> preview-only ingest`
+
+Out of scope:
+
+- approval
+- execute
+- git finalization
+- Trello writeback / Done
+
+## Pre-Run Gate
+
+Checked before the real run:
+
+- reviewed
+  [PROJECT_CHAT_AND_WORK_LOG.md](/Users/lingguozhong/openclaw-team/PROJECT_CHAT_AND_WORK_LOG.md)
+- reviewed
+  [BASELINE_FREEZE_NOTE.md](/Users/lingguozhong/openclaw-team/BASELINE_FREEZE_NOTE.md)
+- `git status --short` was clean before the run
+- runtime directories had no unclassified tracked residue in git status
+- `/tmp/trello_env.sh` exposed Trello read-only credentials and board scope
+  without needing to reveal secret values
+- exact commands were fixed before execution
+
+## Commands Run
+
+```bash
+source /tmp/trello_env.sh && python3 skills/trello_readonly_prep.py --smoke-read --limit 1
+source /tmp/trello_env.sh && python3 skills/ingest_tasks.py --once --trello-readonly-once --trello-limit 3
+```
+
+## Observed Result
+
+### 1. Read-only GET smoke
+
+Result:
+
+- status: `pass`
+- scope kind: `board`
+- read count: `1`
+- auth env selection:
+  - key: `TRELLO_API_KEY`
+  - token: `TRELLO_API_TOKEN`
+- mapped first live card:
+  - `origin_id = trello:69c1fff1b3339965c25783b7`
+  - `list_id = 69be462743bfa0038ca10f91`
+
+Interpretation:
+
+- live Trello read-only connectivity is currently real and working
+- the current runtime env is sufficient for GET-only board access
+
+### 2. Preview-only ingest run
+
+Result summary from `skills/ingest_tasks.py`:
+
+- `processed = 0`
+- `rejected = 4`
+- `duplicate_skipped = 4`
+- `preview_created = 0`
+- `inbox_claimed = 3`
+- `processing_recovered = 1`
+
+Live Trello cards fetched in this smoke all hit existing dedupe history:
+
+- `trello:69bff951f79026ca5f386743`
+- `trello:69c1229edc9b8ec895640c5b`
+- `trello:69c1fff1b3339965c25783b7`
+
+Concrete evidence:
+
+- [rejected/trello-readonly-69c1fff1b3339965c25783b7.json.result.json](/Users/lingguozhong/openclaw-team/rejected/trello-readonly-69c1fff1b3339965c25783b7.json.result.json)
+  records `decision = duplicate_skipped` with
+  `keys=origin:trello:69c1fff1b3339965c25783b7`
+
+Interpretation:
+
+- the real Trello read-only path is live
+- this exact smoke did not create a new preview because the fetched live cards
+  were already present in local dedupe state
+- the no-execute invariant held: no approval or execution path was entered
+
+## Newly Exposed Side Effect
+
+One additional duplicate came from a recovered local sample file rather than from
+the live Trello fetch:
+
+- [rejected/trello_readonly_mapped_sample.json.result.json](/Users/lingguozhong/openclaw-team/rejected/trello_readonly_mapped_sample.json.result.json)
+
+What happened:
+
+- `skills/trello_readonly_prep.py --smoke-read` still wrote its fixture-mapped
+  sample output to `processing/trello_readonly_mapped_sample.json`
+- the subsequent real ingest run recovered that file as live processing input
+- that sample then got rejected as another duplicate
+
+This does not invalidate the live Trello result, but it does mean the prep helper
+still contaminates the live processing queue during smoke workflows.
+
+## Conclusion
+
+The real read-only Trello integration is currently usable for GET-only access, but
+the current board slice surfaced only cards already known to the repo's dedupe
+history, so this smoke produced no new preview.
+
+The next follow-up should not guess around that result. It should explicitly fix
+the prep-helper queue pollution first, then rerun a clean preview smoke.


### PR DESCRIPTION
## Summary
- record one governed real Trello read-only smoke under the pre-run gate
- capture that live GET access worked but the preview-only ingest produced duplicate skips rather than a new preview
- add the next backlog item for the prep-helper queue-pollution follow-up

## Backlog and issue
- BL-20260324-011
- Closes #17
- Follow-up: BL-20260324-012

## Validation
- source /tmp/trello_env.sh && python3 skills/trello_readonly_prep.py --smoke-read --limit 1
- source /tmp/trello_env.sh && python3 skills/ingest_tasks.py --once --trello-readonly-once --trello-limit 3
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh