### PR TITLE
Formalize Trello live target blocker

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -282,16 +282,33 @@ Allowed enum values:
 ### BL-20260324-014
 - title: Run a clean Trello preview-creation smoke against an unseen live card or scope
 - type: mainline
-- status: planned
-- phase: next
+- status: blocked
+- phase: now
 - priority: p1
 - owner: Oscarling
-- depends_on: BL-20260324-012
-- start_when: Prep-helper queue pollution is fixed and the next blocker is no longer local sample contamination
+- depends_on: BL-20260324-012, BL-20260324-015
+- start_when: Prep-helper queue pollution is fixed and at least one approved live Trello card or scope is outside local dedupe history
 - done_when: A governed real Trello preview smoke targets an unseen live card or narrower live scope and truthfully records whether a new preview is created
-- source: `TRELLO_READONLY_PREP_QUEUE_HARDENING_REPORT.md` on 2026-03-24 confirmed `processing_recovered=0` but the live fetched cards still hit existing dedupe history
-- link: /Users/lingguozhong/openclaw-team/TRELLO_READONLY_PREP_QUEUE_HARDENING_REPORT.md
-- issue: deferred:promote-when-fresh-live-sample-plan-is-ready
-- evidence: -
+- source: `TRELLO_LIVE_TARGET_DISCOVERY_REPORT.md` on 2026-03-24 confirmed the current board scope still has `unseen_cards=0`
+- link: /Users/lingguozhong/openclaw-team/TRELLO_LIVE_TARGET_DISCOVERY_REPORT.md
+- issue: https://github.com/Oscarling/openclaw-team/issues/22
+- evidence: `TRELLO_LIVE_TARGET_DISCOVERY_REPORT.md` records a read-only discovery rerun with `open_board_cards=6`, `unseen_cards=0`, and no list containing unseen cards, so the smoke is currently blocked by live sample freshness
+- last_reviewed_at: 2026-03-24
+- opened_at: 2026-03-24
+
+### BL-20260324-015
+- title: Provide an unseen live Trello card or alternate live scope for the preview smoke
+- type: blocker
+- status: blocked
+- phase: now
+- priority: p1
+- owner: Oscarling
+- depends_on: -
+- start_when: `BL-20260324-014` discovery has confirmed that the current configured board scope contains no unseen open cards outside local dedupe history
+- done_when: At least one approved live Trello card or alternate board/list scope exists whose mapped origin id is not already present in local dedupe history and can be used for a governed rerun of `BL-20260324-014`
+- source: `TRELLO_LIVE_TARGET_DISCOVERY_REPORT.md` on 2026-03-24 recorded `seen_trello_origin_ids=8`, `open_board_cards=6`, and `unseen_cards=0` for the current board scope
+- link: /Users/lingguozhong/openclaw-team/TRELLO_LIVE_TARGET_DISCOVERY_REPORT.md
+- issue: https://github.com/Oscarling/openclaw-team/issues/23
+- evidence: `TRELLO_LIVE_TARGET_DISCOVERY_REPORT.md` shows the current scope has no unseen live card and no list with unseen cards, so a fresh card or alternate scope must be provided before the mainline smoke can continue
 - last_reviewed_at: 2026-03-24
 - opened_at: 2026-03-24

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -805,3 +805,54 @@ Verification snapshot on 2026-03-24:
   - `duplicate_skipped = 3`
   - `preview_created = 0`
   - `processing_recovered = 0`
+
+### 24. Live Trello Target Discovery And Blocker Formalization
+
+User objective:
+
+- continue the standard-process next step after the queue-pollution fix
+- verify whether the current live Trello scope contains any unseen card for a
+  clean preview-creation smoke
+- record the blocker truthfully instead of retrying random live runs
+
+Main work areas:
+
+- kept `BL-20260324-014` as the active mainline thread long enough to perform a
+  read-only live discovery
+- confirmed the first sandboxed discovery attempt failed with DNS resolution to
+  `api.trello.com`
+- reran the same discovery with approved escalated network access
+- compared current live Trello card origins against local dedupe history loaded
+  from `preview/`, `processed/`, and `rejected/`
+- converted the result into a formal blocker `BL-20260324-015` and mirrored it
+  to GitHub issue #23
+
+Primary output:
+
+- [TRELLO_LIVE_TARGET_DISCOVERY_REPORT.md](/Users/lingguozhong/openclaw-team/TRELLO_LIVE_TARGET_DISCOVERY_REPORT.md)
+
+Key result:
+
+- the current configured board scope still has no unseen open Trello card
+- the clean live preview smoke remains blocked by sample availability, not by
+  queue contamination or another newly proven code defect
+- `BL-20260324-014` is now formally tracked as blocked behind `BL-20260324-015`
+  instead of being left ambiguously active
+
+Verification snapshot on 2026-03-24:
+
+- sandboxed read-only discovery failed with `NameResolutionError` while
+  resolving `api.trello.com`
+- the approved escalated rerun returned:
+  - `scope_kind = board`
+  - `seen_trello_origin_ids = 8`
+  - `open_board_cards = 6`
+  - `unseen_cards = 0`
+  - `lists_with_unseen_cards = {}`
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed and confirmed:
+  - `BL-20260324-014 -> #22`
+  - `BL-20260324-015 -> #23`
+- `bash scripts/premerge_check.sh` passed with `Warnings: 0` and `Failures: 0`
+- `BL-20260324-014` remains mirrored to GitHub issue #22
+- `BL-20260324-015` is mirrored to GitHub issue #23

--- a/TRELLO_LIVE_TARGET_DISCOVERY_REPORT.md
+++ b/TRELLO_LIVE_TARGET_DISCOVERY_REPORT.md
@@ -1,0 +1,97 @@
+# Trello Live Target Discovery Report
+
+## Scope
+
+This report covers the follow-up discovery step after
+[TRELLO_READONLY_PREP_QUEUE_HARDENING_REPORT.md](/Users/lingguozhong/openclaw-team/TRELLO_READONLY_PREP_QUEUE_HARDENING_REPORT.md).
+
+Problem:
+
+- prep-helper queue pollution is already fixed
+- the last governed rerun still produced `preview_created = 0`
+- before retrying another live preview smoke, the repo needs to confirm whether
+  the current live Trello scope still contains any unseen card outside local
+  dedupe history
+
+Goal:
+
+- compare the current read-only live Trello scope against local dedupe history
+- determine whether `BL-20260324-014` can proceed or is blocked by sample
+  freshness
+- keep the step read-only and evidence-backed
+
+## Gstack Checkpoint Decision
+
+Explicit skip rationale:
+
+- no extra gstack skill was used for this phase because the work is a narrow
+  read-only discovery step
+- the blocker is external live sample availability, not an unproven software
+  defect or architecture question
+- standard local verification plus one approved read-only network rerun were
+  sufficient for this scope
+
+## Discovery Procedure
+
+Commands run:
+
+```bash
+source /tmp/trello_env.sh && python3 - <<'PY'
+# read-only discovery:
+# 1. load local seen dedupe keys from preview/processed/rejected evidence
+# 2. GET current open cards from the configured Trello board scope
+# 3. compare each card's origin key origin:trello:{card_id} against local history
+# 4. summarize unseen-card counts and list distribution
+PY
+```
+
+Observed runtime notes:
+
+- the first sandboxed attempt failed with DNS resolution to `api.trello.com`
+- the same read-only discovery was rerun with approved escalated network access
+- no Trello write operation, no preview execution, and no git finalization step
+  was used
+
+## Observed Result
+
+- `scope_kind = board`
+- `seen_trello_origin_ids = 8`
+- `open_board_cards = 6`
+- `unseen_cards = 0`
+- `lists_with_unseen_cards = {}`
+
+## Local Verification
+
+Commands run:
+
+```bash
+python3 scripts/backlog_lint.py
+python3 scripts/backlog_sync.py
+bash scripts/premerge_check.sh
+```
+
+Observed result:
+
+- backlog lint passed
+- backlog sync passed and confirmed:
+  - `BL-20260324-014 -> #22`
+  - `BL-20260324-015 -> #23`
+- `premerge_check.sh` passed with `Warnings: 0` and `Failures: 0`
+
+## Interpretation
+
+- the current configured live board scope has no open card whose mapped origin
+  is outside local dedupe history
+- there is also no narrower open-list slice on that board that currently exposes
+  an unseen card
+- `BL-20260324-014` is blocked by live sample availability, not by queue
+  contamination or another proven code defect
+
+## Next Required Input
+
+The mainline smoke can continue only after one of these becomes true:
+
+- a new live Trello card is added within the approved board scope and remains
+  outside local dedupe history
+- an alternate approved board/list scope is provided that currently contains at
+  least one unseen card


### PR DESCRIPTION
## Summary
- record the live Trello discovery result showing the current board scope has no unseen open cards
- mark BL-20260324-014 as blocked and add BL-20260324-015 as the explicit sample-availability blocker
- add the discovery report and current-state ledger entry so the blocker is preserved in repo truth

## Verification
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh