### PR TITLE
Record successful live Trello preview smoke

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -282,33 +282,50 @@ Allowed enum values:
 ### BL-20260324-014
 - title: Run a clean Trello preview-creation smoke against an unseen live card or scope
 - type: mainline
-- status: blocked
+- status: done
 - phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260324-012, BL-20260324-015
 - start_when: Prep-helper queue pollution is fixed and at least one approved live Trello card or scope is outside local dedupe history
 - done_when: A governed real Trello preview smoke targets an unseen live card or narrower live scope and truthfully records whether a new preview is created
-- source: `TRELLO_LIVE_TARGET_DISCOVERY_REPORT.md` on 2026-03-24 confirmed the current board scope still has `unseen_cards=0`
-- link: /Users/lingguozhong/openclaw-team/TRELLO_LIVE_TARGET_DISCOVERY_REPORT.md
+- source: `TRELLO_LIVE_PREVIEW_CREATION_SMOKE_REPORT.md` on 2026-03-24 recorded a list-scoped rerun against a fresh unseen card
+- link: /Users/lingguozhong/openclaw-team/TRELLO_LIVE_PREVIEW_CREATION_SMOKE_REPORT.md
 - issue: https://github.com/Oscarling/openclaw-team/issues/22
-- evidence: `TRELLO_LIVE_TARGET_DISCOVERY_REPORT.md` records a read-only discovery rerun with `open_board_cards=6`, `unseen_cards=0`, and no list containing unseen cards, so the smoke is currently blocked by live sample freshness
+- evidence: `TRELLO_LIVE_PREVIEW_CREATION_SMOKE_REPORT.md` records a governed list-scoped rerun with `preview_created=1`, `processing_recovered=0`, and preview `preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de` created in pending-approval state
 - last_reviewed_at: 2026-03-24
 - opened_at: 2026-03-24
 
 ### BL-20260324-015
 - title: Provide an unseen live Trello card or alternate live scope for the preview smoke
 - type: blocker
-- status: blocked
+- status: done
 - phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: -
 - start_when: `BL-20260324-014` discovery has confirmed that the current configured board scope contains no unseen open cards outside local dedupe history
 - done_when: At least one approved live Trello card or alternate board/list scope exists whose mapped origin id is not already present in local dedupe history and can be used for a governed rerun of `BL-20260324-014`
-- source: `TRELLO_LIVE_TARGET_DISCOVERY_REPORT.md` on 2026-03-24 recorded `seen_trello_origin_ids=8`, `open_board_cards=6`, and `unseen_cards=0` for the current board scope
-- link: /Users/lingguozhong/openclaw-team/TRELLO_LIVE_TARGET_DISCOVERY_REPORT.md
+- source: User created a fresh live card on 2026-03-24 and `TRELLO_LIVE_PREVIEW_CREATION_SMOKE_REPORT.md` confirmed it was reachable in list `待办`
+- link: /Users/lingguozhong/openclaw-team/TRELLO_LIVE_PREVIEW_CREATION_SMOKE_REPORT.md
 - issue: https://github.com/Oscarling/openclaw-team/issues/23
-- evidence: `TRELLO_LIVE_TARGET_DISCOVERY_REPORT.md` shows the current scope has no unseen live card and no list with unseen cards, so a fresh card or alternate scope must be provided before the mainline smoke can continue
+- evidence: `TRELLO_LIVE_PREVIEW_CREATION_SMOKE_REPORT.md` records the new card `trello:69c24cd3c1a2359ddd7a1bf8` in list `待办` with `open_list_cards=5`, `unseen_cards=1`, and a successful governed rerun that used that card to create a new preview
+- last_reviewed_at: 2026-03-24
+- opened_at: 2026-03-24
+
+### BL-20260324-016
+- title: Decide the disposition of the fresh Trello preview created by the governed smoke
+- type: mainline
+- status: planned
+- phase: next
+- priority: p2
+- owner: Oscarling
+- depends_on: BL-20260324-014
+- start_when: A fresh live Trello preview has been created in pending-approval state and the user wants to decide whether to keep it as smoke evidence or continue into an explicit approval/execution phase
+- done_when: The repo truthfully records one of two outcomes for preview `preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de`: it either remains intentionally unapproved as smoke evidence, or a new governed phase is opened to review, approve, and execute it
+- source: `TRELLO_LIVE_PREVIEW_CREATION_SMOKE_REPORT.md` on 2026-03-24 created a fresh pending-approval preview from live Trello card `69c24cd3c1a2359ddd7a1bf8`
+- link: /Users/lingguozhong/openclaw-team/TRELLO_LIVE_PREVIEW_CREATION_SMOKE_REPORT.md
+- issue: deferred:phase=next until the user chooses whether to continue beyond preview smoke
+- evidence: -
 - last_reviewed_at: 2026-03-24
 - opened_at: 2026-03-24

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -856,3 +856,57 @@ Verification snapshot on 2026-03-24:
 - `bash scripts/premerge_check.sh` passed with `Warnings: 0` and `Failures: 0`
 - `BL-20260324-014` remains mirrored to GitHub issue #22
 - `BL-20260324-015` is mirrored to GitHub issue #23
+
+### 25. Fresh Live Trello Preview Smoke Success
+
+User objective:
+
+- continue after creating a fresh live Trello sample card
+- identify the exact Trello list containing that card
+- rerun the clean preview-creation smoke against a scope that now includes one
+  unseen live card
+
+Main work areas:
+
+- opened a new branch for the rerun phase
+- performed a read-only title lookup and identified the new card in list `待办`
+- confirmed the narrower list scope had exactly one unseen card outside local
+  dedupe history
+- ran the governed list-scoped Trello read-only ingest smoke
+- converted the successful rerun into report, backlog, and next-step governance
+
+Primary output:
+
+- [TRELLO_LIVE_PREVIEW_CREATION_SMOKE_REPORT.md](/Users/lingguozhong/openclaw-team/TRELLO_LIVE_PREVIEW_CREATION_SMOKE_REPORT.md)
+
+Key result:
+
+- the fresh live card created a new preview successfully
+- the preview-control invariant held:
+  the new preview is pending approval and did not auto-execute
+- `BL-20260324-015` is resolved and `BL-20260324-014` is complete
+- the next decision is whether to leave the preview as smoke evidence or open a
+  new governed approval/execution phase, which is now tracked as `BL-20260324-016`
+
+Verification snapshot on 2026-03-24:
+
+- read-only card lookup matched:
+  - `card_id = 69c24cd3c1a2359ddd7a1bf8`
+  - `list_name = 待办`
+  - `list_id = 69be462743bfa0038ca10f8f`
+- list-scope confirmation returned:
+  - `open_list_cards = 5`
+  - `unseen_cards = 1`
+- `source /tmp/trello_env.sh && python3 skills/ingest_tasks.py --once --trello-readonly-once --trello-list-id 69be462743bfa0038ca10f8f --trello-limit 10`
+  completed with:
+  - `processed = 1`
+  - `duplicate_skipped = 4`
+  - `preview_created = 1`
+  - `processing_recovered = 0`
+- created preview:
+  - `preview_id = preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de`
+  - `approved = false`
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed with no remaining `phase=now`
+  actionable items requiring mirrored issues
+- `bash scripts/premerge_check.sh` passed with `Warnings: 0` and `Failures: 0`

--- a/TRELLO_LIVE_PREVIEW_CREATION_SMOKE_REPORT.md
+++ b/TRELLO_LIVE_PREVIEW_CREATION_SMOKE_REPORT.md
@@ -1,0 +1,148 @@
+# Trello Live Preview Creation Smoke Report
+
+## Scope
+
+This report covers the governed rerun of the live Trello preview smoke after a
+fresh sample card was intentionally created to unblock
+[TRELLO_LIVE_TARGET_DISCOVERY_REPORT.md](/Users/lingguozhong/openclaw-team/TRELLO_LIVE_TARGET_DISCOVERY_REPORT.md).
+
+Target path:
+
+`Trello read-only -> adapter mapping -> inbox -> preview-only ingest`
+
+Out of scope:
+
+- approval
+- execute
+- git finalization
+- Trello writeback / Done
+
+## Pre-Run Gate
+
+Checked before the real run:
+
+- reviewed
+  [PROJECT_CHAT_AND_WORK_LOG.md](/Users/lingguozhong/openclaw-team/PROJECT_CHAT_AND_WORK_LOG.md)
+- reviewed
+  [BASELINE_FREEZE_NOTE.md](/Users/lingguozhong/openclaw-team/BASELINE_FREEZE_NOTE.md)
+- `git status --short` was clean before the run
+- runtime directories had no unclassified tracked residue in git status
+- `/tmp/trello_env.sh` exposed Trello read-only credentials without revealing
+  secret values
+- exact command and evidence file were fixed before execution
+- retry path was explicit:
+  if the fresh card still did not create a preview, record the blocker truthfully
+  and stop instead of guessing around the result
+
+## Live Target Confirmation
+
+Read-only lookup by exact title found the newly created card:
+
+- title:
+  `BL-20260324-014 live preview smoke sample 2026-03-24`
+- card id: `69c24cd3c1a2359ddd7a1bf8`
+- list name: `待办`
+- list id: `69be462743bfa0038ca10f8f`
+
+Read-only list-scope confirmation then showed:
+
+- `open_list_cards = 5`
+- `unseen_cards = 1`
+- the only unseen card in that list matched the newly created sample card
+
+Interpretation:
+
+- the blocker in `BL-20260324-015` was genuinely resolved by a fresh live card
+- a narrower list scope now exists that can be used for a governed rerun of
+  `BL-20260324-014`
+
+## Gstack Checkpoint Decision
+
+Explicit skip rationale:
+
+- no extra gstack skill was used for this phase because the work is a governed
+  live smoke rerun with no architecture change and no code modification
+- the scope is operational verification, not a new plan, investigation, or
+  merge-critical runtime refactor
+
+## Command Run
+
+```bash
+source /tmp/trello_env.sh && python3 skills/ingest_tasks.py --once --trello-readonly-once --trello-list-id 69be462743bfa0038ca10f8f --trello-limit 10
+```
+
+## Observed Result
+
+Result summary from `skills/ingest_tasks.py`:
+
+- `processed = 1`
+- `rejected = 4`
+- `duplicate_skipped = 4`
+- `preview_created = 1`
+- `inbox_claimed = 5`
+- `processing_recovered = 0`
+
+Live Trello read-only fetch summary:
+
+- `scope_kind = list`
+- `read_count = 5`
+- `inbox_written = 5`
+
+Duplicate cards still present in the same list scope:
+
+- `trello:69be5555fb0f701594fe0f21`
+- `trello:69bfdffc66d1cb5436b1d3a1`
+- `trello:69bfe9adbc5abeaca98fc60b`
+- `trello:69bff951f79026ca5f386743`
+
+New preview successfully created for the fresh card:
+
+- `origin_id = trello:69c24cd3c1a2359ddd7a1bf8`
+- `preview_id = preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de`
+- preview file:
+  [preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de.json](/Users/lingguozhong/openclaw-team/preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de.json)
+- processed result sidecar:
+  [processed/trello-readonly-69c24cd3c1a2359ddd7a1bf8.json.result.json](/Users/lingguozhong/openclaw-team/processed/trello-readonly-69c24cd3c1a2359ddd7a1bf8.json.result.json)
+
+Concrete preview-state truth:
+
+- `approved = false`
+- decision:
+  `preview_created_pending_approval`
+
+## Interpretation
+
+- the current Trello read-only path can now create a new preview when the scope
+  contains at least one unseen live card
+- the preview-control invariant still holds:
+  the new preview is pending explicit approval and did not auto-execute
+- no Trello writeback / Done behavior was entered
+- no git finalization behavior was entered
+
+## Local Verification
+
+Commands run:
+
+```bash
+python3 scripts/backlog_lint.py
+python3 scripts/backlog_sync.py
+bash scripts/premerge_check.sh
+```
+
+Observed result:
+
+- backlog lint passed
+- backlog sync passed with:
+  - no phase=`now` actionable items still requiring mirrored issues
+- `premerge_check.sh` passed with `Warnings: 0` and `Failures: 0`
+
+## Conclusion
+
+This governed rerun completed the original clean preview-creation smoke goal.
+The prior blocker was not a hidden code failure. It was simply the absence of an
+unseen live Trello card in scope.
+
+`BL-20260324-015` is now resolved, and `BL-20260324-014` is complete.
+The next decision is product/process, not ingestion correctness:
+either leave the new preview unapproved as smoke evidence, or explicitly open a
+new governed phase if the user wants to approve and execute it.


### PR DESCRIPTION
## Summary
- record the successful list-scoped Trello live preview smoke against the fresh sample card
- mark BL-20260324-014 and BL-20260324-015 done and add BL-20260324-016 for the preview disposition decision
- update the work log and evidence report with the created preview and gating results

## Verification
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh