### PR TITLE
Freeze preview disposition at smoke stage

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -316,16 +316,16 @@ Allowed enum values:
 ### BL-20260324-016
 - title: Decide the disposition of the fresh Trello preview created by the governed smoke
 - type: mainline
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p2
 - owner: Oscarling
 - depends_on: BL-20260324-014
-- start_when: A fresh live Trello preview has been created in pending-approval state and the user wants to decide whether to keep it as smoke evidence or continue into an explicit approval/execution phase
+- start_when: A fresh live Trello preview has been created in pending-approval state and the repo needs a standard-process decision on whether to stop at smoke evidence or open a new approval/execution phase
 - done_when: The repo truthfully records one of two outcomes for preview `preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de`: it either remains intentionally unapproved as smoke evidence, or a new governed phase is opened to review, approve, and execute it
-- source: `TRELLO_LIVE_PREVIEW_CREATION_SMOKE_REPORT.md` on 2026-03-24 created a fresh pending-approval preview from live Trello card `69c24cd3c1a2359ddd7a1bf8`
+- source: User asked on 2026-03-24 which standard-process path should be taken next if the order does not materially affect later work
 - link: /Users/lingguozhong/openclaw-team/TRELLO_LIVE_PREVIEW_CREATION_SMOKE_REPORT.md
-- issue: deferred:phase=next until the user chooses whether to continue beyond preview smoke
-- evidence: -
+- issue: -
+- evidence: `TRELLO_LIVE_PREVIEW_CREATION_SMOKE_REPORT.md` now records the default closeout path: preview `preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de` is intentionally left unapproved as smoke evidence, and no approval/execute phase is opened automatically
 - last_reviewed_at: 2026-03-24
 - opened_at: 2026-03-24

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -910,3 +910,38 @@ Verification snapshot on 2026-03-24:
 - `python3 scripts/backlog_sync.py` passed with no remaining `phase=now`
   actionable items requiring mirrored issues
 - `bash scripts/premerge_check.sh` passed with `Warnings: 0` and `Failures: 0`
+
+### 26. Preview Disposition Frozen At Smoke-Evidence Boundary
+
+User objective:
+
+- determine the standard-process default after the successful live preview smoke
+- avoid an unnecessary follow-up question if the safe default would not damage
+  later work
+
+Main work areas:
+
+- evaluated the two possible follow-ups already tracked in `BL-20260324-016`
+- chose the lower-risk default path because approval / execute would create a
+  new state transition beyond the completed smoke scope
+- formalized that decision in repo truth instead of leaving it only in chat
+
+Primary output:
+
+- [TRELLO_LIVE_PREVIEW_CREATION_SMOKE_REPORT.md](/Users/lingguozhong/openclaw-team/TRELLO_LIVE_PREVIEW_CREATION_SMOKE_REPORT.md)
+
+Key result:
+
+- the fresh preview remains intentionally unapproved as smoke evidence
+- no approval / execute phase was opened automatically
+- a later approval / execute attempt is still possible, but it must start as a
+  separate governed phase
+- `BL-20260324-016` is complete under the safer default disposition
+
+Verification snapshot on 2026-03-24:
+
+- preview
+  `preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de`
+  remains `approved = false`
+- backlog policy remains consistent:
+  - no phase=`now` actionable items require mirrored issues after this closeout

--- a/TRELLO_LIVE_PREVIEW_CREATION_SMOKE_REPORT.md
+++ b/TRELLO_LIVE_PREVIEW_CREATION_SMOKE_REPORT.md
@@ -143,6 +143,11 @@ The prior blocker was not a hidden code failure. It was simply the absence of an
 unseen live Trello card in scope.
 
 `BL-20260324-015` is now resolved, and `BL-20260324-014` is complete.
-The next decision is product/process, not ingestion correctness:
-either leave the new preview unapproved as smoke evidence, or explicitly open a
-new governed phase if the user wants to approve and execute it.
+For the default closeout path, the repo intentionally stops here:
+
+- the new preview remains unapproved as smoke evidence
+- no approval / execute phase is opened automatically
+- any later approval / execute work must start as a separate governed phase
+
+This is the lower-risk default because it preserves the successful smoke result
+without advancing into a new state transition.


### PR DESCRIPTION
## Summary
- formalize the standard-process default after the successful live preview smoke
- mark BL-20260324-016 done by intentionally leaving the created preview unapproved as smoke evidence
- record that any later approval/execute work must start as a separate governed phase

## Verification
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh