### PR TITLE
Record governed Trello preview execution

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -329,3 +329,37 @@ Allowed enum values:
 - evidence: `TRELLO_LIVE_PREVIEW_CREATION_SMOKE_REPORT.md` now records the default closeout path: preview `preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de` is intentionally left unapproved as smoke evidence, and no approval/execute phase is opened automatically
 - last_reviewed_at: 2026-03-24
 - opened_at: 2026-03-24
+
+### BL-20260324-017
+- title: Review, explicitly approve, and run one governed execution of the fresh Trello preview
+- type: mainline
+- status: done
+- phase: now
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260324-014, BL-20260324-016
+- start_when: The user has explicitly chosen to continue beyond the smoke-evidence boundary and preview `preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de` is still pending approval
+- done_when: The repo truthfully records one explicit approval decision and one governed execution result for preview `preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de`, without expanding scope into Git finalization or Trello Done
+- source: User request on 2026-03-24 to continue after the smoke phase closeout
+- link: /Users/lingguozhong/openclaw-team/TRELLO_LIVE_PREVIEW_EXECUTION_REPORT.md
+- issue: https://github.com/Oscarling/openclaw-team/issues/27
+- evidence: `TRELLO_LIVE_PREVIEW_EXECUTION_REPORT.md` records one explicit approval decision, one initial sandboxed execute failure before worker launch, one elevated replay in real mode, and the final governed result `rejected` with `critic_verdict=needs_revision`
+- last_reviewed_at: 2026-03-24
+- opened_at: 2026-03-24
+
+### BL-20260324-018
+- title: Address the artifact-quality findings exposed by the governed fresh-preview execution
+- type: debt
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260324-017
+- start_when: The governed execution report has confirmed the control chain works, but the Critic still returned `needs_revision` for artifact-quality reasons
+- done_when: The repo either fixes or intentionally accepts the fresh-review findings around output format fidelity, path portability, traceability, and runtime evidence expectations before another approval/execute attempt
+- source: `TRELLO_LIVE_PREVIEW_EXECUTION_REPORT.md` on 2026-03-24 captured Critic findings about fake `.xlsx` output semantics, hardcoded input path, truncated description context, and missing runtime output evidence
+- link: /Users/lingguozhong/openclaw-team/TRELLO_LIVE_PREVIEW_EXECUTION_REPORT.md
+- issue: deferred:phase=next until the user chooses to address the review findings
+- evidence: -
+- last_reviewed_at: 2026-03-24
+- opened_at: 2026-03-24

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -945,3 +945,68 @@ Verification snapshot on 2026-03-24:
   remains `approved = false`
 - backlog policy remains consistent:
   - no phase=`now` actionable items require mirrored issues after this closeout
+
+### 27. Governed Approval And Real Execute Of The Fresh Trello Preview
+
+User objective:
+
+- continue beyond the smoke-only boundary
+- review the fresh preview, explicitly approve it, and run one governed execute
+- stop before git finalization or Trello writeback
+
+Main work areas:
+
+- opened `BL-20260324-017` and mirrored it to GitHub issue #27
+- reviewed the pending preview state and validated both internal tasks before
+  approval
+- wrote one explicit approval file for the target preview
+- ran the first real execute attempt with explicit host-path and OpenAI env
+  injection
+- detected that the sandboxed attempt failed before worker launch because Python
+  Docker client initialization was blocked
+- reran the same execute once with elevated Docker access and explicit
+  `--allow-replay`
+- captured the final real outcome and converted the exposed Critic findings into
+  backlog debt item `BL-20260324-018`
+
+Primary output:
+
+- [TRELLO_LIVE_PREVIEW_EXECUTION_REPORT.md](/Users/lingguozhong/openclaw-team/TRELLO_LIVE_PREVIEW_EXECUTION_REPORT.md)
+
+Key result:
+
+- the approval gate and execute path both worked
+- the final outcome for the fresh preview is `rejected`, but for a truthful
+  business-review reason:
+  `critic_verdict = needs_revision`
+- this is not a control-chain failure
+- no git finalization or Trello writeback was entered
+
+Verification snapshot on 2026-03-24:
+
+- preview pre-run state:
+  - `approved = false`
+  - `execution.status = pending_approval`
+  - `attempts = 0`
+- initial sandboxed real execute returned:
+  - `rejected = 1`
+  - `decision_reason = Failed to initialize docker client from environment. Ensure Docker access is available or pass docker_client explicitly.`
+- elevated replay with `--allow-replay` returned:
+  - `processed = 0`
+  - `rejected = 1`
+  - `critic_verdict = needs_revision`
+- automation worker output:
+  - `status = success`
+  - artifact: `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`
+- critic worker output:
+  - `status = success`
+  - verdict: `needs_revision`
+  - artifact: `artifacts/reviews/pdf_to_excel_ocr_inbox_review.md`
+- final preview state:
+  - `approved = true`
+  - `execution.status = rejected`
+  - `execution.attempts = 2`
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed with no remaining `phase=now`
+  actionable items requiring mirrored issues
+- `bash scripts/premerge_check.sh` passed with `Warnings: 0` and `Failures: 0`

--- a/TRELLO_LIVE_PREVIEW_EXECUTION_REPORT.md
+++ b/TRELLO_LIVE_PREVIEW_EXECUTION_REPORT.md
@@ -1,0 +1,221 @@
+# Trello Live Preview Execution Report
+
+## Scope
+
+This report covers one governed continuation phase after the successful live
+preview smoke:
+
+`pending preview -> explicit approval -> one governed execute`
+
+Target preview:
+
+- preview id: `preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de`
+- origin id: `trello:69c24cd3c1a2359ddd7a1bf8`
+
+Out of scope:
+
+- git finalization
+- Trello Done / writeback
+- replay beyond the one infrastructure retry required to escape sandboxed Docker
+  client failure
+- widening execution to any other preview
+
+## Pre-Run Gate
+
+Checked before writing approval and running execute:
+
+- reviewed
+  [PROJECT_CHAT_AND_WORK_LOG.md](/Users/lingguozhong/openclaw-team/PROJECT_CHAT_AND_WORK_LOG.md)
+- reviewed
+  [BASELINE_FREEZE_NOTE.md](/Users/lingguozhong/openclaw-team/BASELINE_FREEZE_NOTE.md)
+- verified target preview still existed with:
+  - `approved = false`
+  - `execution.status = pending_approval`
+  - `executed = false`
+  - `attempts = 0`
+- validated both internal tasks with `validate_task(...)` and observed no task
+  schema errors
+- confirmed local OpenAI secret files existed under `secrets/`
+- confirmed Docker CLI access existed on the host
+- detected that shell env did not expose `ARGUS_APP_HOST_PATH` or
+  `ARGUS_SECRETS_HOST_PATH`, so the real execute command was fixed to inject them
+  explicitly
+- exact evidence file and retry path were fixed before execution
+
+## Gstack Checkpoint Decision
+
+Checkpoint used:
+
+- `careful`
+
+Why:
+
+- this phase crosses the approval / execute boundary and can modify real runtime
+  state
+- no destructive command was needed, but safety-sensitive handling was still the
+  correct checkpoint
+
+## Approval Written
+
+Approval file created:
+
+- [approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de.json](/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de.json)
+
+Approval fields:
+
+- `approved = true`
+- `approved_by = Oscarling`
+- `approved_at = 2026-03-24T08:59:04Z`
+- note limited the phase to one governed execute with no git finalization or
+  Trello Done
+
+## Attempt 1: Sandboxed Execute
+
+Command run:
+
+```bash
+ARGUS_BASE_DIR=/Users/lingguozhong/openclaw-team \
+ARGUS_APP_HOST_PATH=/Users/lingguozhong/openclaw-team \
+ARGUS_SECRETS_HOST_PATH=/Users/lingguozhong/openclaw-team/secrets \
+OPENAI_API_KEY="$(cat secrets/openai_api_key.txt)" \
+OPENAI_API_BASE="$(cat secrets/openai_api_base.txt)" \
+OPENAI_MODEL_NAME="$(cat secrets/openai_model_name.txt)" \
+python3 skills/execute_approved_previews.py --once \
+  --preview-id preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de \
+  --test-mode off
+```
+
+Observed result:
+
+- command returned `rejected = 1`
+- decision reason:
+  `Failed to initialize docker client from environment. Ensure Docker access is available or pass docker_client explicitly.`
+
+Interpretation:
+
+- this first attempt failed before worker launch
+- the failure was environmental / sandbox-related, not a proved business result
+- a single replay with elevated Docker access was justified and explicitly
+  limited with `--allow-replay`
+
+## Attempt 2: Elevated Replay
+
+Replay command run:
+
+```bash
+ARGUS_BASE_DIR=/Users/lingguozhong/openclaw-team \
+ARGUS_APP_HOST_PATH=/Users/lingguozhong/openclaw-team \
+ARGUS_SECRETS_HOST_PATH=/Users/lingguozhong/openclaw-team/secrets \
+OPENAI_API_KEY="$(cat secrets/openai_api_key.txt)" \
+OPENAI_API_BASE="$(cat secrets/openai_api_base.txt)" \
+OPENAI_MODEL_NAME="$(cat secrets/openai_model_name.txt)" \
+python3 skills/execute_approved_previews.py --once \
+  --preview-id preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de \
+  --test-mode off --allow-replay
+```
+
+Observed result:
+
+- `processed = 0`
+- `rejected = 1`
+- `skipped = 0`
+- `test_mode = off`
+- `allow_replay = true`
+- final decision reason:
+  `critic_verdict=needs_revision`
+
+## Worker Results
+
+Automation:
+
+- output:
+  [workspaces/automation/AUTO-20260324-854/output.json](/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260324-854/output.json)
+- status: `success`
+- artifact:
+  [artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py](/Users/lingguozhong/openclaw-team/artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py)
+
+Critic:
+
+- output:
+  [workspaces/critic/CRITIC-20260324-275/output.json](/Users/lingguozhong/openclaw-team/workspaces/critic/CRITIC-20260324-275/output.json)
+- status: `success`
+- verdict: `needs_revision`
+- review artifact:
+  [artifacts/reviews/pdf_to_excel_ocr_inbox_review.md](/Users/lingguozhong/openclaw-team/artifacts/reviews/pdf_to_excel_ocr_inbox_review.md)
+
+Approval result sidecar:
+
+- [approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de.result.json](/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de.result.json)
+
+Updated preview state:
+
+- [preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de.json](/Users/lingguozhong/openclaw-team/preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de.json)
+
+Key final fields:
+
+- `approved = true`
+- `execution.status = rejected`
+- `execution.executed = true`
+- `execution.attempts = 2`
+- `execution.decision_reason = critic_verdict=needs_revision`
+
+## Review Findings That Matter
+
+The Critic review did not report a chain fault. It reported revision-level
+artifact concerns:
+
+- output path ends with `.xlsx`, but the script writes SpreadsheetML XML text
+  directly rather than a true XLSX container
+- `INPUT_DIR` is hardcoded to `~/Desktop/pdf样本`, which weakens portability
+- input description/context was truncated to `Purpose:`, weakening traceability
+- runtime evidence of produced workbook output was not included alongside the
+  script for the review
+
+## Interpretation
+
+- the approval gate worked
+- the execute path worked once Docker access was available
+- automation and critic both completed successfully in real mode
+- the final `rejected` status is a business / review outcome driven by
+  `critic_verdict=needs_revision`, not a control-chain failure
+- no git finalization or Trello writeback was entered
+
+## Runtime Artifact Policy
+
+This phase changed tracked files under `artifacts/`:
+
+- `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`
+- `artifacts/reviews/pdf_to_excel_ocr_inbox_review.md`
+
+Per merge policy, these runtime-generated tracked artifacts are only allowed back
+to `main` through a dedicated evidence PR. This phase uses that dedicated path.
+
+## Local Verification
+
+Commands run:
+
+```bash
+python3 scripts/backlog_lint.py
+python3 scripts/backlog_sync.py
+bash scripts/premerge_check.sh
+```
+
+Observed result:
+
+- backlog lint passed
+- backlog sync passed with:
+  - no remaining `phase=now` actionable items requiring mirrored issues
+- `premerge_check.sh` passed with `Warnings: 0` and `Failures: 0`
+
+## Conclusion
+
+`BL-20260324-017` is complete:
+
+- one explicit approval decision was written
+- one governed execute result was recorded truthfully
+- the final outcome for this preview is `rejected` because the Critic returned
+  `needs_revision`
+
+The next follow-up is not to rerun blindly. The next follow-up is to decide
+whether to address the exposed artifact-quality findings before another approval
+/ execute attempt.

--- a/artifacts/reviews/pdf_to_excel_ocr_inbox_review.md
+++ b/artifacts/reviews/pdf_to_excel_ocr_inbox_review.md
@@ -1,21 +1,21 @@
 # Review: pdf_to_excel_ocr_inbox_runner.py
 
 ## Scope
-Reviewed the provided automation artifact `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py` using the embedded snapshot content only. The review assessed whether the script delivers a deterministic, reviewable local-only result consistent with the request for a best-effort PDF inventory manifest, without unsupported OCR or extraction claims.
+Review of the automation artifact `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py` against the stated best-effort, evidence-backed, readonly Trello smoke objective for PDF extraction/conversion preview output.
 
 ## Findings
-- The script is runnable Python and uses standard library modules for core behavior.
-- It scans the configured local directory `~/Desktop/pdf样本` recursively for `.pdf` files.
-- It builds a deterministic manifest ordered by normalized relative path.
-- For each PDF, it records reviewable inventory metadata including relative path, file name, size, UTC modified time, first-1MB SHA-256 hash, and header bytes.
-- It explicitly marks `text_extraction_performed=false` and `ocr_performed=false`, which is aligned with the evidence-backed/no-overclaim requirement.
-- It attempts to write a true XLSX only if `openpyxl` is locally available; otherwise it writes a clearly labeled CSV fallback at the requested output path and discloses that limitation.
-- The script prints a run summary and limitations, making the result reviewable.
-- The implementation remains local-only and does not introduce network or external service behavior.
-- One caveat: the fallback writes CSV text to a `.xlsx` path, which is disclosed in-file but may still confuse downstream consumers expecting a true XLSX binary.
+- The script is grounded in local-only behavior and does not perform Trello writeback. It uses fixed metadata fields and reads PDFs from a local desktop directory.
+- It detects local tools (`pdftotext`, `pdfinfo`, `pdftoppm`, `tesseract`) and records tool paths in output, which supports evidence-backed reviewability.
+- It avoids claiming OCR success without extracted text evidence. OCR success is only marked when text is actually recovered.
+- It emits a spreadsheet-like output containing extraction status, method, notes, and text preview, which aligns with the requirement for reviewable intermediate artifacts.
+- If no PDFs are present, it still writes a header-only workbook and warns accordingly, which is consistent with best-effort behavior.
+- However, the declared output path is `artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx`, but the writer generates SpreadsheetML XML text directly via `write_text`. This is not a real XLSX container and may mislead downstream consumers expecting a true `.xlsx` file.
+- The script hardcodes `INPUT_DIR` to `~/Desktop/pdf样本`, which reduces determinism/portability in managed automation contexts and may not match declared local artifacts unless the environment is prepared exactly.
+- The description field from input metadata is truncated to `"Purpose:"` rather than preserving the fuller task context, weakening traceability.
+- No execution evidence or produced output workbook artifact was provided alongside the script, so review is limited to code inspection rather than validation of runtime behavior.
 
 ## Verdict
-**pass**
+**needs_revision**
 
 ## Rationale
-The artifact satisfies the stated best-effort contract as a deterministic local PDF inventory manifest generator. It does not falsely claim OCR or PDF text extraction success, and it provides explicit limitations and a reviewable fallback path when XLSX generation is unavailable. The noted fallback-extension mismatch is a usability concern, but it is transparently documented and does not invalidate the core objective as described.
+The script shows good-faith alignment with the readonly, best-effort, evidence-backed extraction objective and includes review-oriented status reporting. But it has material issues that prevent a full pass: the `.xlsx` extension does not match the actual file format produced, the local input path is overly environment-specific, and there is no runtime evidence demonstrating that the artifact successfully produced the intended reviewable output in this pipeline run. These are revision-level issues rather than a complete failure because the core extraction/review logic is present and generally honest about limitations.

--- a/artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
+++ b/artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
@@ -1,215 +1,277 @@
 #!/usr/bin/env python3
-"""
-Best-effort local PDF inventory manifest generator.
-
-Purpose:
-- Scan a local input directory for PDF files.
-- Produce a deterministic, reviewable manifest at the requested output path.
-- Avoid unsupported OCR or extraction claims.
-- Remain runnable with standard library only; optionally writes true XLSX if
-  openpyxl is available locally.
-
-Configured from task parameters:
-- input_dir: ~/Desktop/pdf样本
-- output_xlsx: artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx
-- ocr: auto (recorded as metadata only; no unsupported OCR is performed)
-- dry_run: false
-- origin_id: trello:69c1229edc9b8ec895640c5b
-"""
-
-from __future__ import annotations
-
-import csv
-import hashlib
-import json
+import datetime
 import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import xml.sax.saxutils as saxutils
+import zipfile
 from pathlib import Path
-from typing import Dict, Iterable, List, Tuple
 
-INPUT_DIR_RAW = "~/Desktop/pdf样本"
-OUTPUT_XLSX_RAW = "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx"
+INPUT_DIR = os.path.expanduser("~/Desktop/pdf样本")
+OUTPUT_XLSX = "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx"
 OCR_MODE = "auto"
 DRY_RUN = False
-ORIGIN_ID = "trello:69c1229edc9b8ec895640c5b"
-TITLE = "Generate one local PDF inventory manifest script (best-effort reviewable attempt)"
-DESCRIPTION = (
-    "Use ~/Desktop/pdf样本 as input. Create one runnable local Python script that scans "
-    "PDF files and writes one deterministic reviewable manifest under artifacts/. "
-    "Local-only. Do not overclaim OCR/extraction behavior."
-)
+ORIGIN_ID = "trello:69c24cd3c1a2359ddd7a1bf8"
+TITLE = "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)"
+DESCRIPTION = "Purpose:"
 LABELS = ["best_effort", "evidence_backed", "readonly", "reviewable", "trello"]
 
-MANIFEST_COLUMNS = [
-    "source_origin_id",
-    "input_dir",
-    "relative_path",
-    "file_name",
-    "file_size_bytes",
-    "modified_time_utc",
-    "sha256_first_1mb",
-    "pdf_header",
-    "is_probably_pdf",
-    "ocr_mode_requested",
-    "text_extraction_performed",
-    "ocr_performed",
-    "review_status",
-    "notes",
-]
+
+def xml_escape(value):
+    return saxutils.escape(str(value), {'"': '&quot;'})
 
 
-def expand_path(raw: str) -> Path:
-    return Path(os.path.expanduser(raw)).resolve()
-
-
-def ensure_parent_dir(path: Path) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-
-
-def sha256_first_1mb(path: Path) -> str:
-    hasher = hashlib.sha256()
-    with path.open("rb") as fh:
-        hasher.update(fh.read(1024 * 1024))
-    return hasher.hexdigest()
-
-
-def read_pdf_header(path: Path) -> str:
+def run_capture(cmd):
     try:
-        with path.open("rb") as fh:
-            data = fh.read(8)
-        if not data:
-            return ""
-        return data.decode("latin-1", errors="replace")
+        proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False)
+        return proc.returncode, proc.stdout, proc.stderr
     except Exception as exc:
-        return f"ERROR:{type(exc).__name__}"
+        return 1, "", f"exception: {exc}"
 
 
-def is_probably_pdf_from_header(header: str) -> bool:
-    return header.startswith("%PDF-")
+def detect_tools():
+    names = [
+        "pdftotext",
+        "pdfinfo",
+        "pdftoppm",
+        "tesseract",
+    ]
+    return {name: shutil.which(name) for name in names}
 
 
-def iso_mtime_utc(path: Path) -> str:
-    from datetime import datetime, timezone
-
-    ts = path.stat().st_mtime
-    return datetime.fromtimestamp(ts, tz=timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-
-
-def iter_pdfs(root: Path) -> Iterable[Path]:
+def list_pdfs(input_dir):
+    root = Path(input_dir)
     if not root.exists() or not root.is_dir():
         return []
-    return sorted(
-        [p for p in root.rglob("*") if p.is_file() and p.suffix.lower() == ".pdf"],
-        key=lambda p: str(p.relative_to(root)).replace("\\", "/"),
-    )
+    return sorted([p for p in root.iterdir() if p.is_file() and p.suffix.lower() == ".pdf"], key=lambda p: p.name.lower())
 
 
-def build_rows(input_dir: Path) -> List[Dict[str, str]]:
-    rows: List[Dict[str, str]] = []
-    for pdf_path in iter_pdfs(input_dir):
-        rel = str(pdf_path.relative_to(input_dir)).replace("\\", "/")
-        header = read_pdf_header(pdf_path)
+def get_pdfinfo(pdf_path, tools):
+    info = {"pages": "", "title": "", "author": "", "producer": "", "raw": ""}
+    if not tools.get("pdfinfo"):
+        return info
+    code, out, err = run_capture([tools["pdfinfo"], str(pdf_path)])
+    raw = (out or "") + ("\n" + err if err else "")
+    info["raw"] = raw.strip()
+    if code != 0:
+        return info
+    for line in out.splitlines():
+        if ":" not in line:
+            continue
+        k, v = line.split(":", 1)
+        key = k.strip().lower()
+        val = v.strip()
+        if key == "pages":
+            info["pages"] = val
+        elif key == "title":
+            info["title"] = val
+        elif key == "author":
+            info["author"] = val
+        elif key == "producer":
+            info["producer"] = val
+    return info
+
+
+def extract_with_pdftotext(pdf_path, tools):
+    if not tools.get("pdftotext"):
+        return False, "", "pdftotext not available"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_txt = Path(tmpdir) / "out.txt"
+        code, out, err = run_capture([tools["pdftotext"], "-layout", str(pdf_path), str(out_txt)])
+        text = ""
+        if out_txt.exists():
+            try:
+                text = out_txt.read_text(encoding="utf-8", errors="replace")
+            except Exception:
+                text = out_txt.read_text(errors="replace")
+        if code == 0 and text.strip():
+            return True, text, "pdftotext -layout"
+        return False, text, (err or out or "pdftotext produced no usable text").strip()
+
+
+def extract_with_ocr(pdf_path, tools):
+    if not tools.get("pdftoppm") or not tools.get("tesseract"):
+        return False, "", "OCR tools not fully available (need pdftoppm and tesseract)"
+    combined = []
+    details = []
+    with tempfile.TemporaryDirectory() as tmpdir:
+        prefix = str(Path(tmpdir) / "page")
+        code, out, err = run_capture([tools["pdftoppm"], "-r", "150", "-png", str(pdf_path), prefix])
+        if code != 0:
+            return False, "", (err or out or "pdftoppm failed").strip()
+        images = sorted(Path(tmpdir).glob("page-*.png"))
+        if not images:
+            return False, "", "pdftoppm created no images"
+        for img in images:
+            base = img.with_suffix("")
+            code, out, err = run_capture([tools["tesseract"], str(img), str(base), "txt"])
+            txt_path = Path(str(base) + ".txt")
+            page_text = ""
+            if txt_path.exists():
+                try:
+                    page_text = txt_path.read_text(encoding="utf-8", errors="replace")
+                except Exception:
+                    page_text = txt_path.read_text(errors="replace")
+            details.append(f"{img.name}: rc={code}")
+            if page_text.strip():
+                combined.append(f"===== {img.name} =====\n{page_text}")
+        final = "\n\n".join(combined).strip()
+        if final:
+            return True, final, "ocr via pdftoppm+tesseract"
+        return False, "", "; ".join(details) if details else "OCR yielded no text"
+
+
+def summarize_text(text, limit=2000):
+    cleaned = text.replace("\r\n", "\n").replace("\r", "\n").strip()
+    if len(cleaned) <= limit:
+        return cleaned
+    return cleaned[:limit] + "\n...[truncated]"
+
+
+def make_rows(pdfs, tools):
+    rows = []
+    now = datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+    for pdf in pdfs:
+        info = get_pdfinfo(pdf, tools)
+        method = "none"
+        status = "no_text"
+        text = ""
+        notes = []
+
+        ok, extracted, detail = extract_with_pdftotext(pdf, tools)
+        if ok:
+            method = "pdftotext"
+            status = "text_extracted"
+            text = extracted
+            notes.append(detail)
+        else:
+            notes.append(detail)
+            if OCR_MODE in ("auto", "on"):
+                ok2, extracted2, detail2 = extract_with_ocr(pdf, tools)
+                notes.append(detail2)
+                if ok2:
+                    method = "ocr"
+                    status = "ocr_text_extracted"
+                    text = extracted2
+                else:
+                    status = "review_needed"
+
         row = {
-            "source_origin_id": ORIGIN_ID,
-            "input_dir": str(input_dir),
-            "relative_path": rel,
-            "file_name": pdf_path.name,
-            "file_size_bytes": str(pdf_path.stat().st_size),
-            "modified_time_utc": iso_mtime_utc(pdf_path),
-            "sha256_first_1mb": sha256_first_1mb(pdf_path),
-            "pdf_header": header,
-            "is_probably_pdf": "true" if is_probably_pdf_from_header(header) else "false",
-            "ocr_mode_requested": OCR_MODE,
-            "text_extraction_performed": "false",
-            "ocr_performed": "false",
-            "review_status": "inventory_only",
-            "notes": "Deterministic manifest only; no OCR or text extraction attempted.",
+            "origin_id": ORIGIN_ID,
+            "title": TITLE,
+            "labels": ",".join(LABELS),
+            "generated_at_utc": now,
+            "input_dir": str(Path(INPUT_DIR)),
+            "pdf_file": pdf.name,
+            "pdf_path": str(pdf),
+            "pdf_size_bytes": str(pdf.stat().st_size),
+            "pdf_pages": info.get("pages", ""),
+            "pdf_title": info.get("title", ""),
+            "pdf_author": info.get("author", ""),
+            "pdf_producer": info.get("producer", ""),
+            "extraction_status": status,
+            "extraction_method": method,
+            "ocr_mode": OCR_MODE,
+            "tool_pdftotext": tools.get("pdftotext") or "",
+            "tool_pdfinfo": tools.get("pdfinfo") or "",
+            "tool_pdftoppm": tools.get("pdftoppm") or "",
+            "tool_tesseract": tools.get("tesseract") or "",
+            "notes": " | ".join(n for n in notes if n),
+            "text_preview": summarize_text(text, limit=4000),
         }
         rows.append(row)
     return rows
 
 
-def write_xlsx_with_openpyxl(output_path: Path, rows: List[Dict[str, str]]) -> Tuple[bool, str]:
-    try:
-        from openpyxl import Workbook  # type: ignore
-    except Exception as exc:
-        return False, f"openpyxl unavailable: {type(exc).__name__}: {exc}"
-
-    wb = Workbook()
-    ws = wb.active
-    ws.title = "pdf_manifest"
-    ws.append(MANIFEST_COLUMNS)
-    for row in rows:
-        ws.append([row.get(col, "") for col in MANIFEST_COLUMNS])
-
-    meta = wb.create_sheet("run_metadata")
-    metadata_rows = [
-        ("title", TITLE),
-        ("description", DESCRIPTION),
-        ("origin_id", ORIGIN_ID),
-        ("ocr_mode_requested", OCR_MODE),
-        ("dry_run", str(DRY_RUN).lower()),
-        ("input_dir", str(expand_path(INPUT_DIR_RAW))),
-        ("output_path", str(output_path)),
-        ("row_count", str(len(rows))),
-        ("writer", "openpyxl"),
-        ("limitations", "No OCR or text extraction performed by this script."),
+def write_spreadsheetml(output_path, rows):
+    headers = [
+        "origin_id",
+        "title",
+        "labels",
+        "generated_at_utc",
+        "input_dir",
+        "pdf_file",
+        "pdf_path",
+        "pdf_size_bytes",
+        "pdf_pages",
+        "pdf_title",
+        "pdf_author",
+        "pdf_producer",
+        "extraction_status",
+        "extraction_method",
+        "ocr_mode",
+        "tool_pdftotext",
+        "tool_pdfinfo",
+        "tool_pdftoppm",
+        "tool_tesseract",
+        "notes",
+        "text_preview",
     ]
-    for item in metadata_rows:
-        meta.append(list(item))
 
-    wb.save(output_path)
-    return True, "wrote xlsx via openpyxl"
+    lines = []
+    lines.append('<?xml version="1.0"?>')
+    lines.append('<?mso-application progid="Excel.Sheet"?>')
+    lines.append('<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"')
+    lines.append(' xmlns:o="urn:schemas-microsoft-com:office:office"')
+    lines.append(' xmlns:x="urn:schemas-microsoft-com:office:excel"')
+    lines.append(' xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet"')
+    lines.append(' xmlns:html="http://www.w3.org/TR/REC-html40">')
+    lines.append(' <DocumentProperties xmlns="urn:schemas-microsoft-com:office:office">')
+    lines.append(f'  <Author>{xml_escape("automation")}</Author>')
+    lines.append(f'  <Title>{xml_escape(TITLE)}</Title>')
+    lines.append(' </DocumentProperties>')
+    lines.append(' <Worksheet ss:Name="pdf_extract">')
+    lines.append('  <Table>')
+    lines.append('   <Row>')
+    for h in headers:
+        lines.append(f'    <Cell><Data ss:Type="String">{xml_escape(h)}</Data></Cell>')
+    lines.append('   </Row>')
+    for row in rows:
+        lines.append('   <Row>')
+        for h in headers:
+            value = row.get(h, "")
+            lines.append(f'    <Cell><Data ss:Type="String">{xml_escape(value)}</Data></Cell>')
+        lines.append('   </Row>')
+    lines.append('  </Table>')
+    lines.append(' </Worksheet>')
+    lines.append('</Workbook>')
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(output_path).write_text("\n".join(lines), encoding="utf-8")
 
 
-def write_csv_fallback(output_path: Path, rows: List[Dict[str, str]]) -> str:
-    with output_path.open("w", encoding="utf-8", newline="") as fh:
-        fh.write("# REVIEWABLE FALLBACK: CSV content stored at requested .xlsx path because openpyxl is unavailable.\n")
-        fh.write("# This is not a true XLSX binary workbook. Rename to .csv if needed for import.\n")
-        fh.write(f"# origin_id={ORIGIN_ID}\n")
-        fh.write(f"# ocr_mode_requested={OCR_MODE}\n")
-        fh.write("# text_extraction_performed=false\n")
-        fh.write("# ocr_performed=false\n")
-        writer = csv.DictWriter(fh, fieldnames=MANIFEST_COLUMNS)
-        writer.writeheader()
-        for row in rows:
-            writer.writerow(row)
-    return "wrote csv fallback at requested output path"
+def main():
+    print(f"[info] title: {TITLE}")
+    print(f"[info] origin_id: {ORIGIN_ID}")
+    print(f"[info] input_dir: {INPUT_DIR}")
+    print(f"[info] output_xlsx: {OUTPUT_XLSX}")
+    print(f"[info] dry_run: {DRY_RUN}")
 
+    tools = detect_tools()
+    print("[info] detected tools:")
+    for name, path in tools.items():
+        print(f"  - {name}: {path or 'not found'}")
 
-def main() -> int:
-    input_dir = expand_path(INPUT_DIR_RAW)
-    output_path = expand_path(OUTPUT_XLSX_RAW)
-    ensure_parent_dir(output_path)
-
-    rows = build_rows(input_dir)
-
-    run_summary = {
-        "title": TITLE,
-        "origin_id": ORIGIN_ID,
-        "input_dir": str(input_dir),
-        "output_path": str(output_path),
-        "ocr_mode_requested": OCR_MODE,
-        "dry_run": DRY_RUN,
-        "pdf_count": len(rows),
-        "limitations": [
-            "No OCR performed.",
-            "No text extraction performed.",
-            "Manifest reflects file inventory only.",
-        ],
-    }
-
-    print(json.dumps(run_summary, ensure_ascii=False, indent=2))
+    pdfs = list_pdfs(INPUT_DIR)
+    print(f"[info] found {len(pdfs)} pdf(s)")
+    for pdf in pdfs:
+        print(f"  - {pdf}")
 
     if DRY_RUN:
+        print("[info] dry_run enabled; no output written")
         return 0
 
-    wrote_xlsx, detail = write_xlsx_with_openpyxl(output_path, rows)
-    if not wrote_xlsx:
-        detail = write_csv_fallback(output_path, rows) + f"; xlsx_unavailable_reason={detail}"
-
-    print(detail)
+    rows = make_rows(pdfs, tools)
+    write_spreadsheetml(OUTPUT_XLSX, rows)
+    print(f"[info] wrote reviewable workbook data to {OUTPUT_XLSX}")
+    if not pdfs:
+        print("[warn] no PDFs found; output contains headers only")
+    unresolved = [r for r in rows if r.get("extraction_status") in ("review_needed", "no_text")]
+    if unresolved:
+        print(f"[warn] {len(unresolved)} file(s) need review or had no text extracted")
     return 0
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- record the governed approval and real execute of the fresh Trello preview
- capture the initial sandboxed Docker client failure and the elevated replay that completed with critic_verdict=needs_revision
- mark BL-20260324-017 done and add BL-20260324-018 for the exposed artifact-quality follow-up

## Included Runtime Evidence
- artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
- artifacts/reviews/pdf_to_excel_ocr_inbox_review.md
- TRELLO_LIVE_PREVIEW_EXECUTION_REPORT.md

## Verification
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh