### PR TITLE
Harden preview artifact contract

### DIFF
--- a/PREVIEW_ARTIFACT_CONTRACT_HARDENING_REPORT.md
+++ b/PREVIEW_ARTIFACT_CONTRACT_HARDENING_REPORT.md
@@ -1,0 +1,150 @@
+# Preview Artifact Contract Hardening Report
+
+## Scope
+
+This report covers the source-side contract hardening that follows
+[TRELLO_LIVE_PREVIEW_EXECUTION_REPORT.md](/Users/lingguozhong/openclaw-team/TRELLO_LIVE_PREVIEW_EXECUTION_REPORT.md).
+
+Goal:
+
+- reduce the chance that the next generated inbox runner repeats the same
+  `needs_revision` findings
+- harden the adapter-side task contract rather than patching one runtime artifact
+  by hand
+- keep this phase limited to contract code and tests
+
+Out of scope:
+
+- another live preview creation run
+- another approval / execute run
+- git finalization
+- Trello Done / writeback
+
+## Findings Addressed
+
+The prior governed execute surfaced four artifact-quality concerns:
+
+- output path ended with `.xlsx`, but the generated script wrote non-XLSX text
+  content
+- input path was hardcoded instead of staying parameter-driven
+- automation description context collapsed to `Purpose:`
+- review lacked stronger contract guidance about runtime-summary expectations
+
+## Implemented Changes
+
+Files changed:
+
+- [adapters/local_inbox_adapter.py](/Users/lingguozhong/openclaw-team/adapters/local_inbox_adapter.py)
+- [tests/test_local_inbox_adapter.py](/Users/lingguozhong/openclaw-team/tests/test_local_inbox_adapter.py)
+
+### 1. Better automation description condensation
+
+Changed `_condense_automation_description(...)` so it now:
+
+- strips zero-width / non-breaking whitespace artifacts
+- keeps multiple meaningful lines before the `Execution contract:` suffix
+- joins those lines into one compact traceable summary
+- avoids collapsing long structured descriptions down to a heading fragment such
+  as `Purpose:`
+
+### 2. Stronger automation reuse contract
+
+The PDF-to-Excel automation task now includes explicit source hints:
+
+- `preferred_base_script = artifacts/scripts/pdf_to_excel_ocr.py`
+- `reference_docs` pointing to:
+  - `artifacts/docs/pdf_to_excel_ocr_usage.md`
+  - `artifacts/reviews/pdf_to_excel_ocr_review.md`
+
+Interpretation:
+
+- future automation is now steered toward wrapping or adapting the existing
+  repository script that already has true XLSX semantics evidence, instead of
+  improvising a brand-new implementation from scratch
+
+### 3. Stronger fidelity and portability rules
+
+Added explicit `contract_hints`, constraints, and acceptance criteria covering:
+
+- true `.xlsx` fidelity:
+  do not write XML / CSV / plaintext to a `.xlsx` path
+- path portability:
+  do not hardcode the input directory when `input_dir` is already provided in
+  params
+- traceability:
+  preserve meaningful description context instead of collapsing it to a heading
+  fragment
+- runtime summary expectation:
+  generated script should emit a structured summary for later reviewability
+
+### 4. Contract profile versioning
+
+Updated automation metadata profile from:
+
+- `narrow_script_artifact`
+
+to:
+
+- `narrow_script_artifact_with_repo_reuse_and_format_fidelity`
+
+This makes the hardened contract visible in repo truth rather than leaving it as
+an unversioned prompt nuance.
+
+## Gstack Checkpoint Decision
+
+Explicit skip rationale:
+
+- no extra gstack skill was used beyond standard pre-merge review discipline
+- this phase is a narrow adapter contract hardening plus tests, not a new
+  architecture or live-system investigation
+
+## Local Verification
+
+Commands run:
+
+```bash
+python3 -m unittest -v tests/test_local_inbox_adapter.py
+python3 -m unittest -v tests/test_trello_readonly_ingress.py
+python3 scripts/backlog_lint.py
+python3 scripts/backlog_sync.py
+bash scripts/premerge_check.sh
+```
+
+Observed result:
+
+- local inbox adapter tests passed `2/2`
+- Trello read-only ingress tests passed `8/8`
+- backlog lint passed
+- backlog sync passed with no remaining `phase=now` actionable items requiring
+  mirrored issues
+- `premerge_check.sh` passed with `Warnings: 0` and `Failures: 0`
+
+## Remaining Gap
+
+This phase hardens the source contract only. It does not retroactively change the
+already-executed preview from the prior phase.
+
+Why:
+
+- existing preview internal tasks are already frozen in
+  [preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de.json](/Users/lingguozhong/openclaw-team/preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-354139fc92de.json)
+- the current dedupe freeze still prevents simply creating a new preview from the
+  same Trello origin without an explicit rerun path
+
+So the next validation step must be a new governed phase:
+
+- either obtain a fresh live card / preview candidate
+- or define an explicit regeneration path for validating the hardened contract
+
+## Conclusion
+
+`BL-20260324-018` is complete as a source-side hardening phase:
+
+- meaningful description context is preserved better
+- future automation is steered toward the existing repo script
+- output-format fidelity and path-portability rules are now explicit contract
+  requirements
+- repository tests lock these expectations in
+
+The next step is not another silent retry. The next step is a separate governed
+validation phase that exercises the hardened contract on a fresh preview candidate.

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -350,16 +350,33 @@ Allowed enum values:
 ### BL-20260324-018
 - title: Address the artifact-quality findings exposed by the governed fresh-preview execution
 - type: debt
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260324-017
 - start_when: The governed execution report has confirmed the control chain works, but the Critic still returned `needs_revision` for artifact-quality reasons
 - done_when: The repo either fixes or intentionally accepts the fresh-review findings around output format fidelity, path portability, traceability, and runtime evidence expectations before another approval/execute attempt
 - source: `TRELLO_LIVE_PREVIEW_EXECUTION_REPORT.md` on 2026-03-24 captured Critic findings about fake `.xlsx` output semantics, hardcoded input path, truncated description context, and missing runtime output evidence
-- link: /Users/lingguozhong/openclaw-team/TRELLO_LIVE_PREVIEW_EXECUTION_REPORT.md
-- issue: deferred:phase=next until the user chooses to address the review findings
+- link: /Users/lingguozhong/openclaw-team/PREVIEW_ARTIFACT_CONTRACT_HARDENING_REPORT.md
+- issue: https://github.com/Oscarling/openclaw-team/issues/29
+- evidence: `PREVIEW_ARTIFACT_CONTRACT_HARDENING_REPORT.md` records the adapter-side hardening that preserves richer description context, steers automation toward `artifacts/scripts/pdf_to_excel_ocr.py`, and encodes explicit `.xlsx` fidelity plus no-hardcoded-input-path rules with regression tests
+- last_reviewed_at: 2026-03-24
+- opened_at: 2026-03-24
+
+### BL-20260324-019
+- title: Validate the hardened preview artifact contract on a fresh preview candidate
+- type: mainline
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260324-018
+- start_when: The source-side contract hardening is merged and a fresh preview candidate or explicit regeneration path is available
+- done_when: A governed validation phase proves whether the hardened contract clears the prior review findings on a fresh preview candidate, without guessing around dedupe-frozen runtime state
+- source: `PREVIEW_ARTIFACT_CONTRACT_HARDENING_REPORT.md` on 2026-03-24 noted that the already-executed preview cannot inherit the new adapter contract and the current dedupe freeze blocks a simple same-origin re-preview
+- link: /Users/lingguozhong/openclaw-team/PREVIEW_ARTIFACT_CONTRACT_HARDENING_REPORT.md
+- issue: deferred:phase=next until a fresh preview candidate or explicit regeneration path is chosen
 - evidence: -
 - last_reviewed_at: 2026-03-24
 - opened_at: 2026-03-24

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -1010,3 +1010,46 @@ Verification snapshot on 2026-03-24:
 - `python3 scripts/backlog_sync.py` passed with no remaining `phase=now`
   actionable items requiring mirrored issues
 - `bash scripts/premerge_check.sh` passed with `Warnings: 0` and `Failures: 0`
+
+### 28. Source-Side Hardening For Future Preview Artifacts
+
+User objective:
+
+- continue after the governed execute exposed `needs_revision` findings
+- address the root contract causes instead of patching one runtime artifact by
+  hand
+- avoid immediately rerunning a live preview before the source contract is
+  hardened
+
+Main work areas:
+
+- promoted `BL-20260324-018` into the active phase and mirrored it to GitHub issue #29
+- identified `_condense_automation_description(...)` as the root cause for the
+  collapsed `Purpose:` description
+- tightened the local inbox adapter contract so PDF-to-Excel automation now:
+  - preserves richer description context
+  - prefers the existing repo script `artifacts/scripts/pdf_to_excel_ocr.py`
+  - encodes true `.xlsx` fidelity and no-hardcoded-input-path rules
+  - asks for structured runtime summary output
+- added dedicated regression coverage for the hardened adapter contract
+- recorded the follow-up validation need as `BL-20260324-019`
+
+Primary output:
+
+- [PREVIEW_ARTIFACT_CONTRACT_HARDENING_REPORT.md](/Users/lingguozhong/openclaw-team/PREVIEW_ARTIFACT_CONTRACT_HARDENING_REPORT.md)
+
+Key result:
+
+- the source-side contract is stronger before any future preview generation
+- this phase does not mutate the already-executed preview in place
+- the next meaningful step is a new governed validation phase on a fresh preview
+  candidate, not another blind replay on the same origin
+
+Verification snapshot on 2026-03-24:
+
+- `python3 -m unittest -v tests/test_local_inbox_adapter.py` passed `2/2`
+- `python3 -m unittest -v tests/test_trello_readonly_ingress.py` passed `8/8`
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed with no remaining `phase=now`
+  actionable items requiring mirrored issues
+- `bash scripts/premerge_check.sh` passed with `Warnings: 0` and `Failures: 0`

--- a/adapters/local_inbox_adapter.py
+++ b/adapters/local_inbox_adapter.py
@@ -40,8 +40,16 @@ def _condense_automation_description(description: str, max_chars: int = 180) -> 
         return "Best-effort local extraction/conversion request."
 
     primary = text.split("\n\nExecution contract:", 1)[0]
-    primary = re.split(r"\n\s*\n", primary, maxsplit=1)[0]
-    primary = re.sub(r"\s+", " ", primary).strip()
+    primary = re.sub(r"[\u00a0\u200b\u200c\u200d\ufeff]", " ", primary)
+
+    segments: list[str] = []
+    for raw_line in primary.splitlines():
+        line = re.sub(r"\s+", " ", raw_line).strip()
+        if not line:
+            continue
+        segments.append(line)
+
+    primary = " | ".join(segments).strip()
 
     if not primary:
         primary = re.sub(r"\s+", " ", text).strip()
@@ -200,7 +208,10 @@ def normalize_local_inbox_payload(
         "objective": (
             f"{title}. "
             "Generate exactly one runnable local helper script artifact for a best-effort "
-            "PDF extraction/conversion attempt using the provided parameters."
+            "PDF extraction/conversion attempt using the provided parameters. "
+            "Prefer reusing the repository's existing PDF-to-Excel implementation "
+            "when it already satisfies the request instead of re-implementing the "
+            "pipeline from scratch."
         ),
         "inputs": {
             "params": {
@@ -212,6 +223,36 @@ def normalize_local_inbox_payload(
                 "title": title,
                 "description": automation_description,
                 "labels": labels,
+                "preferred_base_script": "artifacts/scripts/pdf_to_excel_ocr.py",
+                "reference_docs": [
+                    "artifacts/docs/pdf_to_excel_ocr_usage.md",
+                    "artifacts/reviews/pdf_to_excel_ocr_review.md",
+                ],
+                "contract_hints": {
+                    "output_format_fidelity": (
+                        "If output_xlsx ends with .xlsx, produce a real XLSX workbook "
+                        "container or fail honestly before writing mismatched text/XML/CSV "
+                        "content to a .xlsx path."
+                    ),
+                    "path_portability": (
+                        "Use the provided input_dir parameter as runtime input. Do not "
+                        "hardcode a user-home or absolute input path when params already "
+                        "declare the path."
+                    ),
+                    "traceability": (
+                        "Preserve meaningful description context from the external input; "
+                        "do not collapse it to a heading fragment such as Purpose:."
+                    ),
+                    "reuse_preference": (
+                        "Prefer a thin wrapper around artifacts/scripts/pdf_to_excel_ocr.py "
+                        "when compatible so workbook semantics and OCR behavior stay aligned "
+                        "with existing repo evidence."
+                    ),
+                    "runtime_summary": (
+                        "The generated script should emit a structured summary of what it "
+                        "produced so later review can inspect behavior without guessing."
+                    ),
+                },
             }
         },
         "expected_outputs": [
@@ -223,12 +264,18 @@ def normalize_local_inbox_payload(
             "Keep output deterministic and executable",
             "Produce only the expected script artifact",
             "Prefer honest, reviewable intermediate behavior over unsupported OCR claims",
+            "If the requested output path ends with .xlsx, do not write non-XLSX text/XML/CSV content to that path.",
+            "Do not hardcode an input directory when the task params already provide input_dir.",
+            "Preserve meaningful traceability from the incoming description instead of collapsing it to a heading fragment.",
+            "Prefer wrapping or adapting artifacts/scripts/pdf_to_excel_ocr.py when that existing repo script already matches the requested behavior.",
         ],
         "priority": priority,
         "source": source,
         "acceptance_criteria": [
             "Produce the expected script artifact at expected_outputs[0].path",
             "Script behavior remains runnable, deterministic, and reviewable",
+            "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
+            "Artifact behavior remains parameter-driven for input_dir and output_xlsx rather than hardcoding unrelated local defaults.",
         ],
         "metadata": {
             "integration_phase": "8B",
@@ -237,7 +284,7 @@ def normalize_local_inbox_payload(
             "payload_hash": payload_hash,
             "labels": labels,
             "external_metadata": metadata,
-            "automation_contract_profile": "narrow_script_artifact",
+            "automation_contract_profile": "narrow_script_artifact_with_repo_reuse_and_format_fidelity",
         },
     }
 

--- a/tests/test_local_inbox_adapter.py
+++ b/tests/test_local_inbox_adapter.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from adapters import local_inbox_adapter
+from argus_contracts import validate_task
+
+
+class LocalInboxAdapterTests(unittest.TestCase):
+    def test_condense_automation_description_preserves_meaningful_context(self) -> None:
+        description = """
+Purpose:
+
+  Controlled Trello live preview smoke for openclaw-team.
+
+Expected behavior:
+- read-only Trello ingest
+- preview creation smoke only
+
+Traceability:
+- backlog: BL-20260324-014
+
+Execution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt.
+""".strip()
+
+        condensed = local_inbox_adapter._condense_automation_description(description)
+
+        self.assertNotEqual(condensed, "Purpose:")
+        self.assertIn("Controlled Trello live preview smoke", condensed)
+        self.assertIn("Expected behavior:", condensed)
+        self.assertNotIn("Execution contract:", condensed)
+
+    def test_normalize_local_inbox_payload_adds_contract_hints_for_pdf_to_excel(self) -> None:
+        raw_payload = {
+            "origin_id": "trello:test-card-123",
+            "title": "Fresh Trello preview execution follow-up",
+            "description": (
+                "Purpose:\n\n"
+                "Controlled Trello live preview smoke for openclaw-team.\n\n"
+                "Expected behavior:\n"
+                "- read-only Trello ingest\n"
+                "- preview creation smoke only\n\n"
+                "Traceability:\n"
+                "- backlog: BL-20260324-018\n\n"
+                "Execution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt."
+            ),
+            "labels": ["trello", "readonly", "reviewable"],
+            "request_type": "pdf_to_excel_ocr",
+            "input": {
+                "input_dir": "~/Desktop/pdf样本",
+                "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+                "ocr": "auto",
+                "dry_run": False,
+            },
+        }
+
+        with tempfile.TemporaryDirectory(prefix="local-inbox-adapter-") as tmp:
+            base_dir = Path(tmp)
+            task = local_inbox_adapter.normalize_local_inbox_payload(
+                raw_payload,
+                inbox_filename="trello-readonly-test-card.json",
+                base_dir=base_dir,
+            )
+
+        auto_task = task.automation_task
+        params = auto_task["inputs"]["params"]
+        contract_hints = params["contract_hints"]
+
+        self.assertEqual(params["preferred_base_script"], "artifacts/scripts/pdf_to_excel_ocr.py")
+        self.assertEqual(
+            params["reference_docs"],
+            [
+                "artifacts/docs/pdf_to_excel_ocr_usage.md",
+                "artifacts/reviews/pdf_to_excel_ocr_review.md",
+            ],
+        )
+        self.assertIn("Controlled Trello live preview smoke", params["description"])
+        self.assertIn("Expected behavior:", params["description"])
+        self.assertIn("real XLSX workbook container", contract_hints["output_format_fidelity"])
+        self.assertIn("Do not hardcode", contract_hints["path_portability"])
+        self.assertIn("artifacts/scripts/pdf_to_excel_ocr.py", contract_hints["reuse_preference"])
+        self.assertTrue(
+            any(
+                "Preserve meaningful traceability from the incoming description" in item
+                for item in auto_task["constraints"]
+            )
+        )
+        self.assertIn(
+            "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
+            auto_task["acceptance_criteria"],
+        )
+        self.assertEqual(
+            auto_task["metadata"]["automation_contract_profile"],
+            "narrow_script_artifact_with_repo_reuse_and_format_fidelity",
+        )
+        self.assertEqual(validate_task(auto_task), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- harden the local inbox automation contract after the fresh preview execute surfaced quality findings
- preserve richer description context and add explicit reuse, .xlsx fidelity, and path-portability requirements
- add dedicated regression tests and record the next validation phase as BL-20260324-019

## Verification
- python3 -m unittest -v tests/test_local_inbox_adapter.py
- python3 -m unittest -v tests/test_trello_readonly_ingress.py
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh