### PR TITLE
feat: add governed preview regeneration path

### DIFF
--- a/BASELINE_FREEZE_NOTE.md
+++ b/BASELINE_FREEZE_NOTE.md
@@ -39,20 +39,23 @@
 
 当前冻结规则（方案 A）：
 - 同一 `origin_id` 只允许一次 preview；后续同卡内容变更，不自动重新生成 preview。
+- 默认仍按现有 `origin`-based dedupe 冻结；未显式声明 regeneration 时，命中 `origin:<origin_id>` 即去重。
+- 当前新增的受控例外：外部输入若显式携带 `regeneration_token`，可按 `origin_regeneration:<origin_id>:<token>` 在同一 `origin_id` 下重新生成一个新的 preview；该 token 必须进入 preview / sidecar 证据链。
 
 适用范围：
 - 仅适用于当前 phase 的 `manager-side Trello read-only -> preview` 链路。
 
 当前不支持：
 - 同一张 Trello 卡片在内容更新后自动重进 preview。
+- 未显式提供 `regeneration_token` 的同源重进 preview。
 
 冻结原因：
 - 保持最小改动。
 - 与现有 `origin`-based dedupe 机制一致（即命中 `origin:<origin_id>` 即去重）。
+- 在需要同源重生成时，仍然要求显式、可审计、非自动的重新入链。
 
 未来可选升级（本阶段不做）：
 - 按内容 `hash/version` 允许同卡变更后再入链。
-- 引入显式标记（rerun/replay token）后再入链。
 
 明确不在本次冻结范围：
 - execute / Git / Trello writeback。

--- a/PREVIEW_REGENERATION_PATH_REPORT.md
+++ b/PREVIEW_REGENERATION_PATH_REPORT.md
@@ -1,0 +1,111 @@
+# PREVIEW_REGENERATION_PATH_REPORT
+
+## Objective
+
+Add one explicit, governed way to regenerate a preview for the same `origin_id`
+without weakening the default Trello read-only preview freeze.
+
+This phase exists because:
+
+- `BL-20260324-018` hardened the source-side preview contract
+- `BL-20260324-019` needs a fresh preview candidate to validate that hardening
+- the current freeze intentionally blocks a simple same-origin re-preview
+- the user explicitly chose a regeneration-path phase over a fresh-card path
+
+## Scope
+
+In scope:
+
+- local inbox payload validation
+- same-origin dedupe semantics at ingest time
+- preview and ingest sidecar audit visibility
+- regression coverage for the new governed behavior
+
+Out of scope:
+
+- changing `skills/execute_approved_previews.py`
+- reinterpreting `--allow-replay` as regeneration
+- automatic content-change re-entry for the same Trello card
+- Git finalization or Trello writeback
+
+## Implemented Design
+
+The minimal-safe path is an explicit `regeneration_token`.
+
+Rules now implemented:
+
+- default behavior is unchanged:
+  same-origin preview creation still dedupes on `origin:<origin_id>`
+- regeneration is opt-in only:
+  a caller must provide `regeneration_token`
+- regeneration requires an explicit `origin_id`
+- if `regeneration_token` is repeated across top-level payload, `metadata`, or
+  `source`, the values must match
+- a regeneration request uses dedupe key
+  `origin_regeneration:<origin_id>:<token>` instead of `origin:<origin_id>`
+- the token is copied into preview evidence and ingest sidecars so the new
+  preview is audit-visible rather than a silent dedupe bypass
+
+This keeps replay protection and the default freeze intact while allowing one
+controlled new preview per explicit token.
+
+## Files Changed
+
+- `PROJECT_BACKLOG.md`
+- `BASELINE_FREEZE_NOTE.md`
+- `adapters/local_inbox_adapter.py`
+- `skills/ingest_tasks.py`
+- `tests/test_local_inbox_adapter.py`
+- `tests/test_trello_readonly_ingress.py`
+
+## Verification
+
+Phase-local smoke + regressions on 2026-03-24:
+
+```bash
+python3 -m unittest -v \
+  tests.test_trello_readonly_ingress.TrelloReadonlyIngressTests.test_process_one_allows_controlled_regeneration_and_blocks_token_reuse \
+  tests.test_trello_readonly_ingress.TrelloReadonlyIngressTests.test_process_one_blocks_same_origin_duplicate_without_regeneration_token \
+  tests.test_local_inbox_adapter.LocalInboxAdapterTests.test_normalize_local_inbox_payload_uses_explicit_regeneration_token_for_dedupe \
+  tests.test_local_inbox_adapter.LocalInboxAdapterTests.test_validate_external_payload_rejects_regeneration_without_explicit_origin
+```
+
+Result:
+
+- `4/4` passed
+- smoke proved the same origin can create a new preview when an explicit token is
+  present and that reusing the same token is still blocked
+- regressions proved the default same-origin freeze still blocks duplicate
+  preview creation and that regeneration cannot be requested without an explicit
+  `origin_id`
+
+Broader focused suites on 2026-03-24:
+
+```bash
+python3 -m unittest tests.test_local_inbox_adapter
+python3 -m unittest tests.test_trello_readonly_ingress
+```
+
+Result:
+
+- `tests.test_local_inbox_adapter`: `4/4` passed
+- `tests.test_trello_readonly_ingress`: `10/10` passed
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed while `BL-20260324-020` was mirrored
+  to issue `#31`, and passed again after closeout with no remaining `phase=now`
+  actionable items requiring mirroring
+- `bash scripts/premerge_check.sh` passed with `Warnings: 0` and `Failures: 0`
+
+## Gstack Checkpoint Note
+
+`plan-eng-review` was not separately run for this phase.
+
+Reason:
+
+- the change is deliberately constrained to the ingest contract
+- `BASELINE_FREEZE_NOTE.md` already narrowed the allowed direction to an explicit
+  rerun/replay token style re-entry
+- no executor, approval, or finalization architecture was changed
+
+The next phase, `BL-20260324-019`, remains the governed validation phase for the
+new regenerated preview candidate.

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -371,12 +371,29 @@ Allowed enum values:
 - phase: next
 - priority: p1
 - owner: Oscarling
-- depends_on: BL-20260324-018
-- start_when: The source-side contract hardening is merged and a fresh preview candidate or explicit regeneration path is available
+- depends_on: BL-20260324-018, BL-20260324-020
+- start_when: The explicit same-origin regeneration path is merged and can produce a fresh governed preview candidate under the hardened source-side contract
 - done_when: A governed validation phase proves whether the hardened contract clears the prior review findings on a fresh preview candidate, without guessing around dedupe-frozen runtime state
 - source: `PREVIEW_ARTIFACT_CONTRACT_HARDENING_REPORT.md` on 2026-03-24 noted that the already-executed preview cannot inherit the new adapter contract and the current dedupe freeze blocks a simple same-origin re-preview
 - link: /Users/lingguozhong/openclaw-team/PREVIEW_ARTIFACT_CONTRACT_HARDENING_REPORT.md
-- issue: deferred:phase=next until a fresh preview candidate or explicit regeneration path is chosen
+- issue: deferred:phase=next until BL-20260324-020 lands and a regenerated preview candidate exists
 - evidence: -
+- last_reviewed_at: 2026-03-24
+- opened_at: 2026-03-24
+
+### BL-20260324-020
+- title: Add an explicit controlled regeneration path for same-origin preview creation
+- type: blocker
+- status: done
+- phase: now
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260324-018
+- start_when: The hardened source-side contract is merged and the next governed step is to regenerate a preview for the same Trello origin instead of relying on a fresh-card path
+- done_when: The ingest path preserves the default origin-based freeze, but a caller can intentionally provide an explicit regeneration token that creates one new auditable preview for the same origin under controlled conditions
+- source: User request on 2026-03-24 to make an explicit `regeneration path` phase first, plus the future-upgrade clause in `BASELINE_FREEZE_NOTE.md` allowing `rerun/replay token` based re-entry
+- link: /Users/lingguozhong/openclaw-team/PREVIEW_REGENERATION_PATH_REPORT.md
+- issue: https://github.com/Oscarling/openclaw-team/issues/31
+- evidence: `PREVIEW_REGENERATION_PATH_REPORT.md` records the explicit `regeneration_token` path that preserves default `origin` freeze, adds governed `origin_regeneration:<origin_id>:<token>` dedupe for same-origin re-preview, updates `BASELINE_FREEZE_NOTE.md`, and passes phase-local smoke/regressions plus `backlog_lint`, `backlog_sync`, and `premerge_check`
 - last_reviewed_at: 2026-03-24
 - opened_at: 2026-03-24

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -1053,3 +1053,62 @@ Verification snapshot on 2026-03-24:
 - `python3 scripts/backlog_sync.py` passed with no remaining `phase=now`
   actionable items requiring mirrored issues
 - `bash scripts/premerge_check.sh` passed with `Warnings: 0` and `Failures: 0`
+
+### 29. Explicit Same-Origin Preview Regeneration Path
+
+User objective:
+
+- make the next phase an explicit `regeneration path`
+- allow the same `origin_id` to regenerate a new preview only under controlled
+  conditions
+- avoid weakening the default dedupe freeze or confusing regeneration with
+  execute replay
+
+Main work areas:
+
+- promoted `BL-20260324-020` into the active phase and mirrored it to GitHub
+  issue #31
+- moved `BL-20260324-019` into a clear follow-up dependency on the regeneration
+  path instead of leaving the decision implicit
+- extended local inbox validation to accept an explicit `regeneration_token`
+  only when:
+  - the token is non-empty, well-formed, and consistent across repeated fields
+  - an explicit `origin_id` is provided
+- preserved the default same-origin freeze by keeping `origin:<origin_id>`
+  dedupe for normal inputs
+- introduced a separate governed dedupe key
+  `origin_regeneration:<origin_id>:<token>` for explicit regeneration requests
+- recorded the token in preview evidence and ingest result sidecars so same-origin
+  regeneration is audit-visible
+- updated the freeze note so current repo rules distinguish:
+  - automatic same-origin re-entry: still not supported
+  - explicit governed regeneration: now supported
+
+Primary output:
+
+- [PREVIEW_REGENERATION_PATH_REPORT.md](/Users/lingguozhong/openclaw-team/PREVIEW_REGENERATION_PATH_REPORT.md)
+
+Key result:
+
+- the repo now has a minimal, explicit regeneration path for same-origin preview
+  creation
+- default `origin`-based dedupe remains intact for ordinary inputs
+- regeneration is no longer an undocumented workaround; it is a governed,
+  auditable ingest mode
+- `BL-20260324-019` is now the next validation phase, not a vague branch of
+  options
+
+Verification snapshot on 2026-03-24:
+
+- phase-local smoke + regressions passed `4/4`:
+  - same-origin regeneration with explicit token creates a new preview
+  - reusing the same token is blocked
+  - same-origin duplicate without token is still blocked
+  - regeneration without explicit `origin_id` is rejected
+- `python3 -m unittest tests.test_local_inbox_adapter` passed `4/4`
+- `python3 -m unittest tests.test_trello_readonly_ingress` passed `10/10`
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed while `BL-20260324-020` was mirrored
+  to issue `#31`, and passed again after closeout with no remaining `phase=now`
+  actionable items requiring mirroring
+- `bash scripts/premerge_check.sh` passed with `Warnings: 0` and `Failures: 0`

--- a/adapters/local_inbox_adapter.py
+++ b/adapters/local_inbox_adapter.py
@@ -14,6 +14,7 @@ class StandardizedInboxTask:
     origin_id: str
     payload_hash: str
     dedupe_keys: list[str]
+    regeneration_token: str | None
     source: dict[str, Any]
     title: str
     description: str
@@ -86,6 +87,42 @@ def _validate_labels(value: Any) -> list[str]:
     return labels
 
 
+def _extract_regeneration_token(
+    raw_payload: dict[str, Any],
+    *,
+    metadata: dict[str, Any],
+    source_input: dict[str, Any],
+) -> str | None:
+    raw_values = [
+        raw_payload.get("regeneration_token"),
+        metadata.get("regeneration_token"),
+        source_input.get("regeneration_token"),
+    ]
+    candidates: list[str] = []
+    for raw in raw_values:
+        if raw is None:
+            continue
+        if not isinstance(raw, str) or not raw.strip():
+            raise RuntimeError("regeneration_token must be a non-empty string when provided")
+        candidates.append(raw.strip())
+
+    if not candidates:
+        return None
+
+    distinct = set(candidates)
+    if len(distinct) != 1:
+        raise RuntimeError(
+            "regeneration_token must be consistent across top-level, metadata, and source when repeated"
+        )
+
+    token = candidates[0].lower()
+    if not re.fullmatch(r"[a-z0-9][a-z0-9._:-]{2,63}", token):
+        raise RuntimeError(
+            "regeneration_token must match ^[a-z0-9][a-z0-9._:-]{2,63}$"
+        )
+    return token
+
+
 def validate_external_payload(raw_payload: dict[str, Any], inbox_filename: str) -> dict[str, Any]:
     if not isinstance(raw_payload, dict):
         raise RuntimeError("Inbox payload must be a JSON object")
@@ -103,12 +140,14 @@ def validate_external_payload(raw_payload: dict[str, Any], inbox_filename: str) 
         metadata = {}
     if not isinstance(metadata, dict):
         raise RuntimeError("metadata must be an object when provided")
+    metadata = dict(metadata)
 
     source_input = raw_payload.get("source", {})
     if source_input is None:
         source_input = {}
     if not isinstance(source_input, dict):
         raise RuntimeError("source must be an object when provided")
+    source_input = dict(source_input)
 
     provided_origin_id = raw_payload.get("origin_id") or source_input.get("origin_id")
     if provided_origin_id is not None and not str(provided_origin_id).strip():
@@ -116,6 +155,14 @@ def validate_external_payload(raw_payload: dict[str, Any], inbox_filename: str) 
     origin_id = str(provided_origin_id).strip() if provided_origin_id else ""
     if not origin_id:
         origin_id = Path(inbox_filename).stem
+
+    regeneration_token = _extract_regeneration_token(
+        raw_payload,
+        metadata=metadata,
+        source_input=source_input,
+    )
+    if regeneration_token and not provided_origin_id:
+        raise RuntimeError("regeneration_token requires an explicit origin_id")
 
     request_type = str(raw_payload.get("request_type", "pdf_to_excel_ocr")).strip().lower()
     if request_type != "pdf_to_excel_ocr":
@@ -128,7 +175,14 @@ def validate_external_payload(raw_payload: dict[str, Any], inbox_filename: str) 
     payload_hash = _payload_hash(raw_payload)
     dedupe_keys = [f"hash:{payload_hash}"]
     if provided_origin_id:
-        dedupe_keys.insert(0, f"origin:{origin_id}")
+        if regeneration_token:
+            dedupe_keys.insert(0, f"origin_regeneration:{origin_id}:{regeneration_token}")
+        else:
+            dedupe_keys.insert(0, f"origin:{origin_id}")
+
+    if regeneration_token:
+        metadata["regeneration_token"] = regeneration_token
+        source_input["regeneration_token"] = regeneration_token
 
     return {
         "title": title.strip(),
@@ -137,6 +191,7 @@ def validate_external_payload(raw_payload: dict[str, Any], inbox_filename: str) 
         "metadata": metadata,
         "source_input": source_input,
         "origin_id": origin_id,
+        "regeneration_token": regeneration_token,
         "request_type": request_type,
         "inputs": inputs,
         "payload_hash": payload_hash,
@@ -173,6 +228,7 @@ def normalize_local_inbox_payload(
     inputs = validated["inputs"]
     payload_hash = validated["payload_hash"]
     dedupe_keys = validated["dedupe_keys"]
+    regeneration_token = validated["regeneration_token"]
     title = validated["title"]
     description = validated["description"]
     labels = validated["labels"]
@@ -199,6 +255,8 @@ def normalize_local_inbox_payload(
         "labels": labels,
     }
     source.update({k: v for k, v in source_input.items() if k not in {"kind"}})
+    if regeneration_token:
+        source["regeneration_token"] = regeneration_token
     priority = _normalize_priority(raw_payload.get("priority"))
 
     auto_task = {
@@ -282,6 +340,7 @@ def normalize_local_inbox_payload(
             "pipeline": "inbox->adapter->manager->automation->critic",
             "request_type": request_type,
             "payload_hash": payload_hash,
+            "regeneration_token": regeneration_token,
             "labels": labels,
             "external_metadata": metadata,
             "automation_contract_profile": "narrow_script_artifact_with_repo_reuse_and_format_fidelity",
@@ -326,6 +385,7 @@ def normalize_local_inbox_payload(
             "pipeline": "inbox->adapter->manager->automation->critic",
             "request_type": request_type,
             "payload_hash": payload_hash,
+            "regeneration_token": regeneration_token,
             "labels": labels,
             "external_metadata": metadata,
         },
@@ -335,6 +395,7 @@ def normalize_local_inbox_payload(
         origin_id=origin_id,
         payload_hash=payload_hash,
         dedupe_keys=dedupe_keys,
+        regeneration_token=regeneration_token,
         source=source,
         title=title,
         description=description,

--- a/skills/ingest_tasks.py
+++ b/skills/ingest_tasks.py
@@ -267,16 +267,20 @@ def build_preview_payload(
     if bool(inputs.get("dry_run", False)):
         warnings.append("This request asks for dry-run mode.")
 
+    source_payload = {
+        "kind": standardized.source.get("kind"),
+        "origin_id": standardized.origin_id,
+        "received_at": standardized.source.get("received_at") or utc_now(),
+        "inbox_file": inbox_filename,
+    }
+    if standardized.regeneration_token:
+        source_payload["regeneration_token"] = standardized.regeneration_token
+
     return {
         "preview_id": preview_id,
         "created_at": utc_now(),
         "approved": False,
-        "source": {
-            "kind": standardized.source.get("kind"),
-            "origin_id": standardized.origin_id,
-            "received_at": standardized.source.get("received_at") or utc_now(),
-            "inbox_file": inbox_filename,
-        },
+        "source": source_payload,
         "external_input": {
             "title": standardized.title,
             "description": standardized.description,
@@ -371,22 +375,22 @@ def process_one(processing_file: Path, seen_dedupe_keys: set[str]) -> dict[str, 
             for key in standardized.dedupe_keys:
                 seen_dedupe_keys.add(key)
 
-        sidecar = write_result_sidecar(
-            moved,
-            {
-                "ingested_at": utc_now(),
-                "status": "processed",
-                "decision": "preview_created_pending_approval",
-                "decision_reason": "preview_created; waiting_for_explicit_approval",
-                "origin_id": None if standardized is None else standardized.origin_id,
-                "payload_hash": None if standardized is None else standardized.payload_hash,
-                "dedupe_keys": [] if standardized is None else standardized.dedupe_keys,
-                "title": None if standardized is None else standardized.title,
-                "labels": [] if standardized is None else standardized.labels,
-                "preview_id": preview_payload["preview_id"],
-                "preview_file": str(preview_path),
-            },
-        )
+        sidecar_payload = {
+            "ingested_at": utc_now(),
+            "status": "processed",
+            "decision": "preview_created_pending_approval",
+            "decision_reason": "preview_created; waiting_for_explicit_approval",
+            "origin_id": None if standardized is None else standardized.origin_id,
+            "payload_hash": None if standardized is None else standardized.payload_hash,
+            "dedupe_keys": [] if standardized is None else standardized.dedupe_keys,
+            "title": None if standardized is None else standardized.title,
+            "labels": [] if standardized is None else standardized.labels,
+            "preview_id": preview_payload["preview_id"],
+            "preview_file": str(preview_path),
+        }
+        if standardized and standardized.regeneration_token:
+            sidecar_payload["regeneration_token"] = standardized.regeneration_token
+        sidecar = write_result_sidecar(moved, sidecar_payload)
         return {
             "status": "processed",
             "decision": "preview_created_pending_approval",
@@ -402,21 +406,21 @@ def process_one(processing_file: Path, seen_dedupe_keys: set[str]) -> dict[str, 
         reason_text = str(exc)
         if "duplicate inbox input detected" in reason_text:
             decision = "duplicate_skipped"
-        sidecar = write_result_sidecar(
-            moved,
-            {
-                "ingested_at": utc_now(),
-                "status": "rejected",
-                "decision": decision,
-                "decision_reason": reason_text,
-                "error": reason_text,
-                "origin_id": None if standardized is None else standardized.origin_id,
-                "payload_hash": None if standardized is None else standardized.payload_hash,
-                "dedupe_keys": [] if standardized is None else standardized.dedupe_keys,
-                "title": None if standardized is None else standardized.title,
-                "preview_file": None if preview_path is None else str(preview_path),
-            },
-        )
+        sidecar_payload = {
+            "ingested_at": utc_now(),
+            "status": "rejected",
+            "decision": decision,
+            "decision_reason": reason_text,
+            "error": reason_text,
+            "origin_id": None if standardized is None else standardized.origin_id,
+            "payload_hash": None if standardized is None else standardized.payload_hash,
+            "dedupe_keys": [] if standardized is None else standardized.dedupe_keys,
+            "title": None if standardized is None else standardized.title,
+            "preview_file": None if preview_path is None else str(preview_path),
+        }
+        if standardized and standardized.regeneration_token:
+            sidecar_payload["regeneration_token"] = standardized.regeneration_token
+        sidecar = write_result_sidecar(moved, sidecar_payload)
         if standardized:
             for key in standardized.dedupe_keys:
                 seen_dedupe_keys.add(key)

--- a/tests/test_local_inbox_adapter.py
+++ b/tests/test_local_inbox_adapter.py
@@ -9,6 +9,35 @@ from argus_contracts import validate_task
 
 
 class LocalInboxAdapterTests(unittest.TestCase):
+    def _sample_payload(self, *, origin_id: str | None, regeneration_token: str | None = None) -> dict:
+        payload = {
+            "title": "Fresh Trello preview execution follow-up",
+            "description": (
+                "Purpose:\n\n"
+                "Controlled Trello live preview smoke for openclaw-team.\n\n"
+                "Expected behavior:\n"
+                "- read-only Trello ingest\n"
+                "- preview creation smoke only\n\n"
+                "Traceability:\n"
+                "- backlog: BL-20260324-020\n\n"
+                "Execution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt."
+            ),
+            "labels": ["trello", "readonly", "reviewable"],
+            "request_type": "pdf_to_excel_ocr",
+            "input": {
+                "input_dir": "/tmp/pdf-samples",
+                "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+                "ocr": "auto",
+                "dry_run": False,
+            },
+            "metadata": {"source_system": "trello"},
+        }
+        if origin_id is not None:
+            payload["origin_id"] = origin_id
+        if regeneration_token is not None:
+            payload["regeneration_token"] = regeneration_token
+        return payload
+
     def test_condense_automation_description_preserves_meaningful_context(self) -> None:
         description = """
 Purpose:
@@ -33,28 +62,7 @@ Execution contract: treat this as a best-effort, evidence-backed PDF extraction/
         self.assertNotIn("Execution contract:", condensed)
 
     def test_normalize_local_inbox_payload_adds_contract_hints_for_pdf_to_excel(self) -> None:
-        raw_payload = {
-            "origin_id": "trello:test-card-123",
-            "title": "Fresh Trello preview execution follow-up",
-            "description": (
-                "Purpose:\n\n"
-                "Controlled Trello live preview smoke for openclaw-team.\n\n"
-                "Expected behavior:\n"
-                "- read-only Trello ingest\n"
-                "- preview creation smoke only\n\n"
-                "Traceability:\n"
-                "- backlog: BL-20260324-018\n\n"
-                "Execution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt."
-            ),
-            "labels": ["trello", "readonly", "reviewable"],
-            "request_type": "pdf_to_excel_ocr",
-            "input": {
-                "input_dir": "~/Desktop/pdf样本",
-                "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
-                "ocr": "auto",
-                "dry_run": False,
-            },
-        }
+        raw_payload = self._sample_payload(origin_id="trello:test-card-123")
 
         with tempfile.TemporaryDirectory(prefix="local-inbox-adapter-") as tmp:
             base_dir = Path(tmp)
@@ -96,6 +104,46 @@ Execution contract: treat this as a best-effort, evidence-backed PDF extraction/
             "narrow_script_artifact_with_repo_reuse_and_format_fidelity",
         )
         self.assertEqual(validate_task(auto_task), [])
+
+    def test_normalize_local_inbox_payload_uses_explicit_regeneration_token_for_dedupe(self) -> None:
+        raw_payload = self._sample_payload(
+            origin_id="trello:test-card-123",
+            regeneration_token="regen-20260324-a",
+        )
+
+        with tempfile.TemporaryDirectory(prefix="local-inbox-adapter-") as tmp:
+            base_dir = Path(tmp)
+            task = local_inbox_adapter.normalize_local_inbox_payload(
+                raw_payload,
+                inbox_filename="trello-readonly-test-card.json",
+                base_dir=base_dir,
+            )
+
+        self.assertEqual(task.regeneration_token, "regen-20260324-a")
+        self.assertEqual(
+            task.dedupe_keys[0],
+            "origin_regeneration:trello:test-card-123:regen-20260324-a",
+        )
+        self.assertNotIn("origin:trello:test-card-123", task.dedupe_keys)
+        self.assertEqual(task.source["regeneration_token"], "regen-20260324-a")
+        self.assertEqual(task.metadata["regeneration_token"], "regen-20260324-a")
+        self.assertEqual(
+            task.automation_task["metadata"]["regeneration_token"],
+            "regen-20260324-a",
+        )
+        self.assertEqual(
+            task.critic_task["metadata"]["regeneration_token"],
+            "regen-20260324-a",
+        )
+
+    def test_validate_external_payload_rejects_regeneration_without_explicit_origin(self) -> None:
+        raw_payload = self._sample_payload(origin_id=None, regeneration_token="regen-20260324-a")
+
+        with self.assertRaisesRegex(RuntimeError, "regeneration_token requires an explicit origin_id"):
+            local_inbox_adapter.validate_external_payload(
+                raw_payload,
+                inbox_filename="trello-readonly-test-card.json",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_trello_readonly_ingress.py
+++ b/tests/test_trello_readonly_ingress.py
@@ -44,6 +44,76 @@ class TrelloReadonlyIngressTests(unittest.TestCase):
             else:
                 os.environ[name] = value
 
+    def _sample_local_inbox_payload(
+        self,
+        *,
+        origin_id: str = "trello:card-regen-123",
+        title: str = "Controlled same-origin regeneration sample",
+        description_suffix: str = "baseline",
+        regeneration_token: str | None = None,
+    ) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "origin_id": origin_id,
+            "title": title,
+            "description": (
+                "Purpose:\n\n"
+                "Controlled regeneration-path verification for openclaw-team.\n\n"
+                "Expected behavior:\n"
+                "- preview only\n"
+                "- no execute\n"
+                f"- scenario: {description_suffix}\n\n"
+                "Traceability:\n"
+                "- backlog: BL-20260324-020\n\n"
+                "Execution contract: keep this as a governed preview-ingest test."
+            ),
+            "labels": ["trello", "readonly", "reviewable"],
+            "request_type": "pdf_to_excel_ocr",
+            "input": {
+                "input_dir": "/tmp/pdf-samples",
+                "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+                "ocr": "auto",
+                "dry_run": False,
+            },
+            "metadata": {"source_system": "trello"},
+        }
+        if regeneration_token is not None:
+            payload["regeneration_token"] = regeneration_token
+        return payload
+
+    def _activate_temp_ingest_repo(self) -> tuple[Path, tuple[Path, Path, Path, Path, Path, Path]]:
+        repo_root = Path(tempfile.mkdtemp(prefix="trello-readonly-ingest-regen-"))
+        original_paths = (
+            ingest_tasks.REPO_ROOT,
+            ingest_tasks.INBOX_DIR,
+            ingest_tasks.PROCESSING_DIR,
+            ingest_tasks.PROCESSED_DIR,
+            ingest_tasks.REJECTED_DIR,
+            ingest_tasks.PREVIEW_DIR,
+        )
+        ingest_tasks.REPO_ROOT = repo_root
+        ingest_tasks.INBOX_DIR = repo_root / "inbox"
+        ingest_tasks.PROCESSING_DIR = repo_root / "processing"
+        ingest_tasks.PROCESSED_DIR = repo_root / "processed"
+        ingest_tasks.REJECTED_DIR = repo_root / "rejected"
+        ingest_tasks.PREVIEW_DIR = repo_root / "preview"
+        ingest_tasks.ensure_dirs()
+        return repo_root, original_paths
+
+    def _restore_ingest_repo(self, original_paths: tuple[Path, Path, Path, Path, Path, Path]) -> None:
+        (
+            ingest_tasks.REPO_ROOT,
+            ingest_tasks.INBOX_DIR,
+            ingest_tasks.PROCESSING_DIR,
+            ingest_tasks.PROCESSED_DIR,
+            ingest_tasks.REJECTED_DIR,
+            ingest_tasks.PREVIEW_DIR,
+        ) = original_paths
+
+    def _write_processing_payload(self, repo_root: Path, filename: str, payload: dict[str, object]) -> Path:
+        path = repo_root / "processing" / filename
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        return path
+
     def test_smoke_read_reports_missing_credentials_before_http(self) -> None:
         result = trello_readonly_prep.smoke_read_trello(
             list_id="list-123",
@@ -226,6 +296,102 @@ class TrelloReadonlyIngressTests(unittest.TestCase):
                 limit=1,
                 requests_get=fake_get,
             )
+
+    def test_process_one_blocks_same_origin_duplicate_without_regeneration_token(self) -> None:
+        repo_root, original_paths = self._activate_temp_ingest_repo()
+        seen_dedupe_keys: set[str] = set()
+
+        try:
+            first = ingest_tasks.process_one(
+                self._write_processing_payload(
+                    repo_root,
+                    "baseline.json",
+                    self._sample_local_inbox_payload(description_suffix="first-preview"),
+                ),
+                seen_dedupe_keys,
+            )
+            second = ingest_tasks.process_one(
+                self._write_processing_payload(
+                    repo_root,
+                    "updated.json",
+                    self._sample_local_inbox_payload(description_suffix="updated-content-same-origin"),
+                ),
+                seen_dedupe_keys,
+            )
+        finally:
+            self._restore_ingest_repo(original_paths)
+
+        self.assertEqual(first["status"], "processed")
+        self.assertEqual(second["status"], "rejected")
+        self.assertEqual(second["decision"], "duplicate_skipped")
+        self.assertIn("origin:trello:card-regen-123", second["decision_reason"])
+
+    def test_process_one_allows_controlled_regeneration_and_blocks_token_reuse(self) -> None:
+        repo_root, original_paths = self._activate_temp_ingest_repo()
+        seen_dedupe_keys: set[str] = set()
+        regeneration_token = "regen-20260324-a"
+
+        try:
+            first = ingest_tasks.process_one(
+                self._write_processing_payload(
+                    repo_root,
+                    "baseline.json",
+                    self._sample_local_inbox_payload(description_suffix="first-preview"),
+                ),
+                seen_dedupe_keys,
+            )
+            regenerated = ingest_tasks.process_one(
+                self._write_processing_payload(
+                    repo_root,
+                    "regenerated.json",
+                    self._sample_local_inbox_payload(
+                        description_suffix="explicit-regeneration",
+                        regeneration_token=regeneration_token,
+                    ),
+                ),
+                seen_dedupe_keys,
+            )
+            replayed_token = ingest_tasks.process_one(
+                self._write_processing_payload(
+                    repo_root,
+                    "replayed-token.json",
+                    self._sample_local_inbox_payload(
+                        description_suffix="same-token-should-block",
+                        regeneration_token=regeneration_token,
+                    ),
+                ),
+                seen_dedupe_keys,
+            )
+        finally:
+            self._restore_ingest_repo(original_paths)
+
+        self.assertEqual(first["status"], "processed")
+        self.assertEqual(regenerated["status"], "processed")
+        self.assertNotEqual(first["preview_id"], regenerated["preview_id"])
+        self.assertEqual(replayed_token["status"], "rejected")
+        self.assertEqual(replayed_token["decision"], "duplicate_skipped")
+        self.assertIn(
+            "origin_regeneration:trello:card-regen-123:regen-20260324-a",
+            replayed_token["decision_reason"],
+        )
+
+        regenerated_preview = json.loads(
+            Path(regenerated["preview_file"]).read_text(encoding="utf-8")
+        )
+        regenerated_sidecar = json.loads(
+            Path(regenerated["result_sidecar"]).read_text(encoding="utf-8")
+        )
+
+        self.assertEqual(regenerated_preview["source"]["regeneration_token"], regeneration_token)
+        self.assertEqual(
+            regenerated_preview["external_input"]["metadata"]["regeneration_token"],
+            regeneration_token,
+        )
+        self.assertEqual(
+            regenerated_preview["dedupe_keys"][0],
+            "origin_regeneration:trello:card-regen-123:regen-20260324-a",
+        )
+        self.assertEqual(regenerated_sidecar["regeneration_token"], regeneration_token)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add an explicit regeneration_token path for same-origin preview regeneration
- preserve the default origin-based freeze when no token is provided
- record the regeneration token in preview evidence, sidecars, backlog, and current-state docs

## Why
- BL-20260324-018 hardened the source-side contract
- BL-20260324-019 needs a fresh preview candidate to validate that hardening
- the current freeze intentionally blocks simple same-origin re-preview
- this branch adds the explicit, governed path the user chose instead of a fresh-card path

## Verification
- python3 -m unittest -v tests.test_trello_readonly_ingress.TrelloReadonlyIngressTests.test_process_one_allows_controlled_regeneration_and_blocks_token_reuse tests.test_trello_readonly_ingress.TrelloReadonlyIngressTests.test_process_one_blocks_same_origin_duplicate_without_regeneration_token tests.test_local_inbox_adapter.LocalInboxAdapterTests.test_normalize_local_inbox_payload_uses_explicit_regeneration_token_for_dedupe tests.test_local_inbox_adapter.LocalInboxAdapterTests.test_validate_external_payload_rejects_regeneration_without_explicit_origin
- python3 -m unittest tests.test_local_inbox_adapter
- python3 -m unittest tests.test_trello_readonly_ingress
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh

## Risk
- changes are intentionally limited to local inbox validation and preview ingest semantics
- default preview dedupe remains unchanged unless an explicit regeneration_token is provided

## Rollback
- revert commit dbba08c to remove the explicit regeneration path and restore the prior freeze-only behavior

Closes #31