### PR TITLE
Harden automation LLM timeout handling

### DIFF
--- a/AUTOMATION_TIMEOUT_HARDENING_REPORT.md
+++ b/AUTOMATION_TIMEOUT_HARDENING_REPORT.md
@@ -1,0 +1,83 @@
+# Automation Timeout Hardening Report
+
+## Objective
+
+Close `BL-20260324-026` by hardening the automation worker's LLM timeout path so
+future governed live validation is no longer blocked by the previous hard-coded
+60-second read timeout behavior.
+
+This phase is a timeout-mitigation phase, not a new governed live validation.
+
+## Root Cause Summary
+
+`BL-20260324-025` showed a consistent pattern:
+
+- the automation worker started normally
+- the configured endpoint was
+  `https://fast.vpsairobot.com/v1/chat/completions`
+- each LLM call failed at roughly 60-second intervals with
+  `The read operation timed out`
+- the task then closed as `failed` before generating any script artifact
+
+Code inspection confirmed the runtime cause:
+
+- `dispatcher/worker_runtime.py` used a hard-coded
+  `LLM_TIMEOUT = 60`
+- the worker gave no easy runtime override for timeout / retry tuning
+- startup logs did not include the effective timeout / retry configuration,
+  which made real timeout debugging slower than it needed to be
+
+## Changes
+
+### 1. Worker runtime timeout policy
+
+`dispatcher/worker_runtime.py` now:
+
+- raises the default LLM read timeout from `60` to `120` seconds
+- resolves timeout and retry counts through runtime helpers instead of fixed
+  constants
+- supports environment overrides:
+  - `ARGUS_LLM_TIMEOUT_SECONDS`
+  - `ARGUS_LLM_MAX_RETRIES`
+- logs the effective timeout and attempt count when the worker starts
+
+This keeps the default path more tolerant for slower real completions while
+still allowing future targeted tuning without another code edit.
+
+### 2. Environment propagation
+
+`skills/delegate_task.py` now forwards:
+
+- `ARGUS_LLM_TIMEOUT_SECONDS`
+- `ARGUS_LLM_MAX_RETRIES`
+
+from the host environment into the worker container when these are set.
+
+That means future live validation can deliberately tune the runtime policy from
+the outer execute command if the default mitigation still needs adjustment.
+
+### 3. Regression coverage
+
+Expanded `tests/test_argus_hardening.py` to cover:
+
+- the relaxed default LLM timeout
+- env-driven timeout / retry overrides for `call_llm(...)`
+
+## Verification
+
+Passed on 2026-03-24:
+
+- `python3 -m unittest -v tests/test_argus_hardening.py`
+- `python3 -m unittest -v tests/test_execute_approved_previews.py`
+
+This phase still requires the normal local gate run before review and merge.
+
+## Conclusion
+
+`BL-20260324-026` can be treated as complete as a timeout hardening phase once
+the full local gates pass and the evidence is merged.
+
+The next correct step is a fresh governed validation phase on a new same-origin
+preview candidate so the project can verify whether the new default timeout
+policy is enough to let automation reach artifact generation and review under
+real execution.

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -486,16 +486,33 @@ Allowed enum values:
 ### BL-20260324-026
 - title: Stabilize automation LLM read timeouts blocking post-hardening live validation
 - type: blocker
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260324-025
 - start_when: `BL-20260324-025` has proved that the fresh preview candidate carries the BL-20260324-024 hardening, but the automation worker still fails real execute because the configured LLM endpoint times out before producing any script artifact
 - done_when: The repo either mitigates the automation LLM read-timeout failure path or explicitly changes runtime/provider policy enough to let the next governed live validation reach artifact generation and review
 - source: `POST_PROPAGATION_HARDENING_VALIDATION_REPORT.md` on 2026-03-24 records three consecutive automation LLM read timeouts at `https://fast.vpsairobot.com/v1/chat/completions`, which now block further governed validation
-- link: /Users/lingguozhong/openclaw-team/POST_PROPAGATION_HARDENING_VALIDATION_REPORT.md
-- issue: deferred:phase=next until BL-20260324-025 lands on main
+- link: /Users/lingguozhong/openclaw-team/AUTOMATION_TIMEOUT_HARDENING_REPORT.md
+- issue: https://github.com/Oscarling/openclaw-team/issues/45
+- evidence: `AUTOMATION_TIMEOUT_HARDENING_REPORT.md` records the runtime fix that raises the default worker LLM read timeout to 120 seconds, exposes timeout/retry overrides through `ARGUS_LLM_TIMEOUT_SECONDS` and `ARGUS_LLM_MAX_RETRIES`, forwards those settings through `skills/delegate_task.py`, and passes focused regression coverage in `tests/test_argus_hardening.py`
+- last_reviewed_at: 2026-03-24
+- opened_at: 2026-03-24
+
+### BL-20260324-027
+- title: Validate BL-20260324-026 timeout mitigation on a fresh same-origin preview candidate
+- type: mainline
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260324-026
+- start_when: `BL-20260324-026` is merged so the relaxed default timeout policy can be exercised through the normal governed preview pipeline under real execution
+- done_when: One governed validation creates a fresh same-origin preview candidate after the timeout hardening, runs one explicit approval plus one real execute, and records whether automation now reaches artifact generation and critic review under the new timeout policy
+- source: `AUTOMATION_TIMEOUT_HARDENING_REPORT.md` on 2026-03-24 concludes the next correct step is a fresh governed validation rather than a same-preview replay
+- link: /Users/lingguozhong/openclaw-team/AUTOMATION_TIMEOUT_HARDENING_REPORT.md
+- issue: deferred:phase=next until BL-20260324-026 lands on main
 - evidence: -
 - last_reviewed_at: 2026-03-24
 - opened_at: 2026-03-24

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -1139,6 +1139,58 @@ Verification snapshot on 2026-03-24:
 - no critic workspace was created because automation never produced a reviewable
   artifact
 
+### 36. Automation Timeout Hardening After BL-20260324-025
+
+User objective:
+
+- continue after `BL-20260324-025` exposed an automation runtime blocker
+- fix the timeout policy at the worker/runtime layer instead of replaying the
+  same validation branch blindly
+- keep the next live verification as a separate governed phase
+
+Main work areas:
+
+- promoted `BL-20260324-026` into the active phase and mirrored it to GitHub
+  issue #45
+- traced the repeated live automation failure back to
+  `dispatcher/worker_runtime.py`, where the LLM read timeout was hard-coded to
+  `60` seconds
+- confirmed from the runtime log that the worker hit three consecutive timeout
+  failures at roughly 60-second intervals against
+  `https://fast.vpsairobot.com/v1/chat/completions`
+- hardened the worker runtime so it now:
+  - uses a more relaxed default LLM timeout of `120` seconds
+  - resolves timeout and retry counts through environment-aware helpers
+  - logs the effective timeout / attempt policy on worker startup
+- updated `skills/delegate_task.py` so host-side timeout / retry overrides can
+  flow into the worker container through:
+  - `ARGUS_LLM_TIMEOUT_SECONDS`
+  - `ARGUS_LLM_MAX_RETRIES`
+- added focused regression coverage for:
+  - relaxed default timeout
+  - env-driven timeout / retry overrides
+- recorded the next fresh governed validation as `BL-20260324-027`
+
+Primary output:
+
+- [AUTOMATION_TIMEOUT_HARDENING_REPORT.md](/Users/lingguozhong/openclaw-team/AUTOMATION_TIMEOUT_HARDENING_REPORT.md)
+
+Key result:
+
+- `BL-20260324-026` is complete as a timeout hardening phase
+- the runtime now has a more defensible default policy for slower real LLM
+  responses and an explicit override path for future tuning
+- the next correct step is a fresh governed validation phase under the new
+  timeout policy, not another same-preview replay
+
+Verification snapshot on 2026-03-24:
+
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed while `BL-20260324-026` was mirrored
+  to issue `#45`
+- `python3 -m unittest -v tests/test_argus_hardening.py` passed `6/6`
+- `python3 -m unittest -v tests/test_execute_approved_previews.py` passed `3/3`
+
 ### 31. Close Residual Inbox Runner Contract Gaps Before Reuse
 
 User objective:

--- a/dispatcher/worker_runtime.py
+++ b/dispatcher/worker_runtime.py
@@ -63,11 +63,24 @@ def require_setting(label, secret_names, env_names):
     raise RuntimeError(f"Missing {label}. Checked: {joined}")
 
 
+def read_int_env(name, default, *, minimum=1):
+    raw = os.environ.get(name)
+    if raw is None or not str(raw).strip():
+        return default
+    try:
+        value = int(str(raw).strip())
+    except ValueError as exc:
+        raise RuntimeError(f"{name} must be an integer when set") from exc
+    if value < minimum:
+        raise RuntimeError(f"{name} must be >= {minimum}")
+    return value
+
+
 # ==========================================
 # Runtime guards
 # ==========================================
-LLM_TIMEOUT = 60
-LLM_MAX_RETRIES = 3
+DEFAULT_LLM_TIMEOUT_SECONDS = 120
+DEFAULT_LLM_MAX_RETRIES = 3
 MAX_ARTIFACT_SIZE = 2 * 1024 * 1024  # 2MB
 NO_PROXY_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
 HTTP_USER_AGENT = "Mozilla/5.0"
@@ -113,6 +126,22 @@ def get_llm_settings():
         "chat_url": normalize_chat_endpoint(api_base),
         "model_name": model_name,
     }
+
+
+def llm_timeout_seconds():
+    return read_int_env(
+        "ARGUS_LLM_TIMEOUT_SECONDS",
+        DEFAULT_LLM_TIMEOUT_SECONDS,
+        minimum=1,
+    )
+
+
+def llm_max_retries():
+    return read_int_env(
+        "ARGUS_LLM_MAX_RETRIES",
+        DEFAULT_LLM_MAX_RETRIES,
+        minimum=1,
+    )
 
 
 # ==========================================
@@ -284,6 +313,8 @@ def load_test_mode_payload(task, worker):
 # LLM Call with retry
 # ==========================================
 def call_llm(system_prompt, user_prompt, worker, llm_settings):
+    timeout_seconds = llm_timeout_seconds()
+    max_attempts = llm_max_retries()
     payload = {
         "model": llm_settings["model_name"],
         "messages": [
@@ -297,7 +328,7 @@ def call_llm(system_prompt, user_prompt, worker, llm_settings):
         "Authorization": f"Bearer {llm_settings['api_key']}",
         "User-Agent": HTTP_USER_AGENT,
     }
-    for attempt in range(LLM_MAX_RETRIES):
+    for attempt in range(max_attempts):
         try:
             req = urllib.request.Request(
                 llm_settings["chat_url"],
@@ -305,7 +336,7 @@ def call_llm(system_prompt, user_prompt, worker, llm_settings):
                 headers=headers,
                 method="POST",
             )
-            with NO_PROXY_OPENER.open(req, timeout=LLM_TIMEOUT) as resp:
+            with NO_PROXY_OPENER.open(req, timeout=timeout_seconds) as resp:
                 raw = resp.read().decode("utf-8")
                 result = json.loads(raw)
             choices = result.get("choices", [])
@@ -315,7 +346,7 @@ def call_llm(system_prompt, user_prompt, worker, llm_settings):
             return content
         except Exception as e:
             log(worker, "WARN", f"LLM call failed attempt {attempt + 1}: {e}")
-            if attempt == LLM_MAX_RETRIES - 1:
+            if attempt == max_attempts - 1:
                 raise
             time.sleep(2 ** attempt)
     return ""
@@ -709,7 +740,13 @@ def run_worker(task_dir=None, worker_override=None, base_dir=None, llm_override=
                 parsed = llm_override(task=task, worker=worker)
             else:
                 llm_settings = get_llm_settings()
-                log(worker, "INFO", f"Worker started using endpoint {llm_settings['chat_url']}")
+                log(
+                    worker,
+                    "INFO",
+                    "Worker started using endpoint "
+                    f"{llm_settings['chat_url']} "
+                    f"(timeout={llm_timeout_seconds()}s, attempts={llm_max_retries()})",
+                )
                 soul = load_soul(worker)
                 user_prompt = build_user_prompt(task)
                 llm_output = call_llm(soul, user_prompt, worker, llm_settings)

--- a/skills/delegate_task.py
+++ b/skills/delegate_task.py
@@ -283,6 +283,8 @@ def build_worker_env(worker):
         "LLM_MODEL",
         "MODEL",
     )
+    env["ARGUS_LLM_TIMEOUT_SECONDS"] = first_env("ARGUS_LLM_TIMEOUT_SECONDS")
+    env["ARGUS_LLM_MAX_RETRIES"] = first_env("ARGUS_LLM_MAX_RETRIES")
     return {key: value for key, value in env.items() if value is not None}
 
 

--- a/tests/test_argus_hardening.py
+++ b/tests/test_argus_hardening.py
@@ -10,6 +10,7 @@ import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from typing import Any
+from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
@@ -383,6 +384,104 @@ class ArgusHardeningTests(unittest.TestCase):
         self.assertTrue((self.tmpdir / "artifacts" / "reviews" / "local_test_mode_review.md").exists())
         runtime_log = (self.tmpdir / "workspaces" / "critic" / "CRITIC-20260324-001" / "runtime.log").read_text()
         self.assertIn("local-test-mode", runtime_log)
+
+    def test_call_llm_uses_relaxed_default_timeout(self) -> None:
+        calls: list[int] = []
+
+        class FakeResponse:
+            def __enter__(self) -> "FakeResponse":
+                return self
+
+            def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+                return False
+
+            def read(self) -> bytes:
+                payload = {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": json.dumps({"status": "success", "summary": "ok"})
+                            }
+                        }
+                    ]
+                }
+                return json.dumps(payload).encode("utf-8")
+
+        class RecordingOpener:
+            def open(self, req: Any, timeout: int | None = None) -> FakeResponse:  # noqa: ARG002
+                calls.append(timeout or 0)
+                return FakeResponse()
+
+        with mock.patch.object(worker_runtime, "NO_PROXY_OPENER", RecordingOpener()):
+            with mock.patch.dict(os.environ, {}, clear=False):
+                content = worker_runtime.call_llm(
+                    "system",
+                    "user",
+                    "automation",
+                    {
+                        "api_key": "key",
+                        "api_base": "https://example.invalid/v1",
+                        "chat_url": "https://example.invalid/v1/chat/completions",
+                        "model_name": "demo-model",
+                    },
+                )
+
+        self.assertEqual(calls, [120])
+        self.assertEqual(json.loads(content)["status"], "success")
+
+    def test_call_llm_honors_env_timeout_and_retry_overrides(self) -> None:
+        calls: list[int] = []
+        attempts = {"count": 0}
+
+        class FakeResponse:
+            def __enter__(self) -> "FakeResponse":
+                return self
+
+            def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+                return False
+
+            def read(self) -> bytes:
+                payload = {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": json.dumps({"status": "success", "summary": "ok"})
+                            }
+                        }
+                    ]
+                }
+                return json.dumps(payload).encode("utf-8")
+
+        class FlakyOpener:
+            def open(self, req: Any, timeout: int | None = None) -> FakeResponse:  # noqa: ARG002
+                calls.append(timeout or 0)
+                attempts["count"] += 1
+                if attempts["count"] == 1:
+                    raise TimeoutError("The read operation timed out")
+                return FakeResponse()
+
+        with mock.patch.object(worker_runtime, "NO_PROXY_OPENER", FlakyOpener()):
+            with mock.patch.object(worker_runtime.time, "sleep", return_value=None):
+                with mock.patch.dict(
+                    os.environ,
+                    {"ARGUS_LLM_TIMEOUT_SECONDS": "7", "ARGUS_LLM_MAX_RETRIES": "2"},
+                    clear=False,
+                ):
+                    content = worker_runtime.call_llm(
+                        "system",
+                        "user",
+                        "automation",
+                        {
+                            "api_key": "key",
+                            "api_base": "https://example.invalid/v1",
+                            "chat_url": "https://example.invalid/v1/chat/completions",
+                            "model_name": "demo-model",
+                        },
+                    )
+
+        self.assertEqual(calls, [7, 7])
+        self.assertEqual(attempts["count"], 2)
+        self.assertEqual(json.loads(content)["status"], "success")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Goal

Close BL-20260324-026 / #45 by hardening the automation worker timeout path that blocked BL-20260324-025 before artifact generation.

## Scope

- raise the default worker LLM read timeout to a more tolerant value
- make timeout / retry settings configurable through runtime env
- forward timeout / retry overrides into the worker container
- add focused regression coverage for the timeout policy
- update backlog, work log, and evidence report for BL-20260324-026
- record BL-20260324-027 as the next fresh governed validation phase

## Non-Goals

- running the next real governed validation in this PR
- changing provider endpoints or credentials
- Git finalization
- Trello writeback / Done

## Tests

- [x] `python3 scripts/backlog_lint.py`
- [x] `python3 scripts/backlog_sync.py`
- [x] `python3 -m unittest -v tests/test_argus_hardening.py`
- [x] `python3 -m unittest -v tests/test_execute_approved_previews.py`
- [x] `bash scripts/premerge_check.sh`
- [x] `git diff --check`

## Runtime / Integration Impact

- [x] No real Git / Trello integration affected
- [ ] Real integration affected and `docs/PRE_RUN_CHECKLIST.md` was completed
- [ ] `GIT_PUSH_REMOTE` / `GIT_PUSH_BRANCH` implications reviewed

## Backlog Sweep

Backlog IDs touched in this PR:

- BL-20260324-026
- BL-20260324-027

- [x] `PROJECT_BACKLOG.md` was reviewed during this PR
- [x] Relevant backlog items had `status` / `phase` / `last_reviewed_at` updated
- [x] Any new sideline / blocker / debt / future item discovered during implementation was recorded before requesting review
- [x] GitHub issue mirror was updated for every phase=now actionable backlog item, or a valid non-now defer reason is stated below

Issue mirror defer reason:

- BL-20260324-027 is intentionally `phase=next`, so issue mirroring is deferred until BL-20260324-026 lands and the next governed validation phase is activated

## Documents Updated

- [x] `PROJECT_BACKLOG.md`
- [x] `PROJECT_CHAT_AND_WORK_LOG.md`
- [x] evidence report updated or explicitly unchanged
- [x] stale snapshot docs reviewed
- [ ] no document changes required, with reason stated below

Reason:

- `AUTOMATION_TIMEOUT_HARDENING_REPORT.md` was added as the BL-20260324-026 evidence report

## Risks

This PR improves the timeout policy and override path, but it does not itself prove that the next live automation run will succeed under the provider's real latency profile. BL-20260324-027 remains the next fresh governed validation phase.

## Rollback / Retry

Rollback via a normal revert PR of commit `35ba5f2` if this timeout-hardening phase should not remain on `main`. Real retry should happen in BL-20260324-027 on a fresh same-origin preview candidate rather than replaying the old blocked validation branch.

## Merge Checklist

- [x] Branch policy respected
- [x] Backlog sweep completed
- [x] No unclassified runtime residue remains
- [x] Review completed
- [x] Ready to merge
