### PR TITLE
BL-029: close governed validation and archive runtime evidence

### DIFF
--- a/POST_CONTRACT_ALIGNMENT_VALIDATION_REPORT.md
+++ b/POST_CONTRACT_ALIGNMENT_VALIDATION_REPORT.md
@@ -1,0 +1,142 @@
+# Post-Contract Alignment Validation Report
+
+## Objective
+
+Validate `BL-20260325-028` on one fresh same-origin governed candidate by
+running:
+
+- one live Trello read-only smoke
+- one explicit same-origin regeneration
+- one preview creation
+- one explicit approval
+- one real execute (`test_mode=off`)
+
+This phase objective is validation truth, not forcing a `pass` verdict.
+
+## Scope
+
+In scope:
+
+- one governed run against origin `trello:69c24cd3c1a2359ddd7a1bf8`
+- one regeneration token and one fresh preview candidate
+- runtime evidence capture for automation and critic outcomes
+- explicit recording of whether wrapper/delegate contract drift is cleared
+
+Out of scope:
+
+- source-code hardening inside this validation phase
+- git finalization and Trello Done writeback
+- additional live reruns beyond this one governed candidate
+
+## Pre-Run Checks
+
+- branch: `phase8w/validate-bl029-contract-alignment`
+- Trello env loaded from `/tmp/trello_env.sh`:
+  - `TRELLO_API_KEY` set
+  - `TRELLO_API_TOKEN` set
+  - `TRELLO_BOARD_ID` set
+- OpenAI runtime files present:
+  - `secrets/openai_api_key.txt`
+  - `secrets/openai_api_base.txt`
+  - `secrets/openai_model_name.txt`
+- Docker sidecars/workers reachable for governed execute
+
+## Run Summary
+
+Target origin:
+
+- `trello:69c24cd3c1a2359ddd7a1bf8`
+
+Regeneration token:
+
+- `regen-20260325-bl029-001`
+
+### 1) Live Trello read-only smoke
+
+- smoke succeeded and returned `read_count=1`
+- archive snapshot:
+  - `runtime_archives/bl029/tmp/bl029_smoke_result.json`
+
+### 2) Regenerated payload and preview ingest
+
+- generated inbox payload from live mapped preview using token
+  `regen-20260325-bl029-001`
+- ingest result sidecar:
+  - `processed/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl029-001.json.result.json`
+- ingest decision:
+  - `status = processed`
+  - `decision = preview_created_pending_approval`
+  - `preview_id = preview-trello-69c24cd3c1a2359ddd7a1bf8-ab85bf08e44d`
+
+### 3) Preview candidate
+
+Generated preview:
+
+- `preview-trello-69c24cd3c1a2359ddd7a1bf8-ab85bf08e44d`
+- preview file:
+  - `preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-ab85bf08e44d.json`
+
+### 4) Explicit approval
+
+- approval file:
+  - `approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-ab85bf08e44d.json`
+
+### 5) Real execute (`test_mode=off`)
+
+Final result sidecar:
+
+- `approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-ab85bf08e44d.result.json`
+- `status = rejected`
+- `decision_reason = critic_verdict=needs_revision`
+
+Worker outcomes:
+
+- automation:
+  - task `AUTO-20260325-855`
+  - `status = success`
+  - artifact: `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`
+- critic:
+  - task `CRITIC-20260325-276`
+  - `status = success`
+  - verdict: `needs_revision`
+  - artifact: `artifacts/reviews/pdf_to_excel_ocr_inbox_review.md`
+
+## Critical Finding
+
+This validation did **not** clear wrapper/delegate integration drift.
+
+The critic output and generated review identify a concrete CLI mismatch:
+
+- wrapper command appends `--report-json <tempfile>`
+  (`artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`)
+- reviewed delegate `artifacts/scripts/pdf_to_excel_ocr.py` does not define
+  `--report-json` in `parse_args()`
+
+Practical impact:
+
+- delegate can fail at argument parsing before normal conversion flow
+- wrapper cannot reliably consume the expected delegate evidence handoff
+- end-to-end path remains `needs_revision` despite source-side contract hints
+  from `BL-20260325-028`
+
+## Validation Conclusion
+
+`BL-20260325-029` is complete as a governed validation phase.
+
+It successfully answers the intended question: after `BL-20260325-028`, a fresh
+same-origin governed run still exposes an integration blocker. The blocker is
+now narrowed to a specific wrapper/delegate CLI contract mismatch on
+`--report-json`.
+
+Next required phase: implement and verify source-side/runtime contract alignment
+for wrapper/delegate report handoff before the next governed validation run.
+
+## Archive Preservation
+
+To preserve runtime evidence and avoid loss from tracked artifact overwrite, this
+phase archived outputs under:
+
+- `runtime_archives/bl029/artifacts/`
+- `runtime_archives/bl029/runtime/`
+- `runtime_archives/bl029/state/`
+- `runtime_archives/bl029/tmp/`

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -537,8 +537,8 @@ Allowed enum values:
 ### BL-20260325-029
 - title: Validate BL-20260325-028 contract alignment on a fresh same-origin governed candidate
 - type: mainline
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-028
@@ -546,7 +546,24 @@ Allowed enum values:
 - done_when: One governed validation creates a fresh same-origin preview candidate after BL-20260325-028, runs one explicit approval plus one real execute, and records whether automation/critic outcome now clears the previously observed wrapper/delegate contract drift findings
 - source: `RUNNER_CONTRACT_ALIGNMENT_REPORT.md` on 2026-03-25 concludes the next correct step is a fresh governed validation phase rather than assuming contract hardening success without runtime evidence
 - link: /Users/lingguozhong/openclaw-team/POST_CONTRACT_ALIGNMENT_VALIDATION_REPORT.md
-- issue: deferred:phase=next until BL-20260325-028 lands on main
+- issue: https://github.com/Oscarling/openclaw-team/issues/51
+- evidence: `POST_CONTRACT_ALIGNMENT_VALIDATION_REPORT.md` records one fresh same-origin governed run (`regen-20260325-bl029-001`) to preview `preview-trello-69c24cd3c1a2359ddd7a1bf8-ab85bf08e44d` with explicit approval and one real execute; automation (`AUTO-20260325-855`) and critic (`CRITIC-20260325-276`) both completed, and the run isolated a concrete blocker where the generated wrapper unconditionally passes `--report-json` but the reviewed delegate does not support that CLI argument, so integration remains `critic_verdict=needs_revision`
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-030
+- title: Fix wrapper/delegate report-handoff CLI mismatch exposed by BL-20260325-029
+- type: blocker
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-029
+- start_when: `BL-20260325-029` has completed validation and narrowed the remaining `needs_revision` root cause to wrapper/delegate CLI contract drift around `--report-json` handoff
+- done_when: Wrapper/delegate integration no longer passes unsupported CLI arguments, evidence handoff remains reviewable and deterministic (stdout JSON and/or sidecar path contract clearly aligned), focused tests cover the agreed contract, and one phase report records the implementation outcome
+- source: `POST_CONTRACT_ALIGNMENT_VALIDATION_REPORT.md` on 2026-03-25 confirms the post-BL-20260325-028 governed run still fails review because wrapper and delegate report-handoff CLI contracts are incompatible
+- link: /Users/lingguozhong/openclaw-team/RUNNER_DELEGATE_CLI_ALIGNMENT_FIX_REPORT.md
+- issue: deferred:phase=next until BL-20260325-029 lands on main
 - evidence: -
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -1003,6 +1003,68 @@ Verification snapshot on 2026-03-24:
   - verdict: `needs_revision`
   - artifact: `artifacts/reviews/pdf_to_excel_ocr_inbox_review.md`
 
+### 37. Post-Contract Alignment Governed Validation After BL-028
+
+User objective:
+
+- continue from `BL-20260325-028` with a fresh same-origin governed validation
+- verify whether strengthened source-side contract guidance actually clears the
+  wrapper/delegate integration drift
+- preserve runtime evidence and keep backlog-first closure discipline
+
+Main work areas:
+
+- activated and executed `BL-20260325-029` against origin
+  `trello:69c24cd3c1a2359ddd7a1bf8`
+- generated one explicit regeneration token:
+  - `regen-20260325-bl029-001`
+- ingested one fresh payload and created preview candidate:
+  - `preview-trello-69c24cd3c1a2359ddd7a1bf8-ab85bf08e44d`
+- wrote one explicit approval file and ran one governed real execute in
+  `test_mode=off`
+- captured automation and critic runtime artifacts for this candidate
+- archived runtime outputs under `runtime_archives/bl029/` before restoring
+  tracked `artifacts/` baselines
+- wrote validation report and promoted the next implementation phase as
+  `BL-20260325-030`
+
+Primary output:
+
+- [POST_CONTRACT_ALIGNMENT_VALIDATION_REPORT.md](/Users/lingguozhong/openclaw-team/POST_CONTRACT_ALIGNMENT_VALIDATION_REPORT.md)
+
+Key result:
+
+- `BL-20260325-029` completed its validation objective with governed evidence
+- automation and critic both completed on the fresh candidate:
+  - automation task: `AUTO-20260325-855` (`success`)
+  - critic task: `CRITIC-20260325-276` (`success`, verdict
+    `needs_revision`)
+- residual blocker is now explicit and narrow:
+  - generated wrapper unconditionally passes `--report-json`
+  - reviewed delegate `artifacts/scripts/pdf_to_excel_ocr.py` does not accept
+    `--report-json`
+- this is a real integration defect (CLI contract mismatch), not a replay or
+  governance-path failure
+- backlog was updated to:
+  - mark `BL-20260325-029` done with report evidence
+  - add `BL-20260325-030` as the next blocker for contract alignment fix
+
+Verification snapshot on 2026-03-25:
+
+- governed ingest sidecar:
+  - `processed/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl029-001.json.result.json`
+  - `status = processed`
+  - `decision = preview_created_pending_approval`
+- approval sidecar:
+  - `approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-ab85bf08e44d.result.json`
+  - `status = rejected`
+  - `decision_reason = critic_verdict=needs_revision`
+- runtime archive preserved under:
+  - `runtime_archives/bl029/artifacts/`
+  - `runtime_archives/bl029/runtime/`
+  - `runtime_archives/bl029/state/`
+  - `runtime_archives/bl029/tmp/`
+
 ### 31. Post-Timeout Governed Validation On Fresh Same-Origin Candidate
 
 User objective:

--- a/runtime_archives/bl029/runtime/AUTO-20260325-855.json
+++ b/runtime_archives/bl029/runtime/AUTO-20260325-855.json
@@ -1,0 +1,183 @@
+{
+  "task_id": "AUTO-20260325-855",
+  "worker": "automation",
+  "status": "success",
+  "created_at": "2026-03-25T01:52:32.905465Z",
+  "updated_at": "2026-03-25T01:53:39.012791Z",
+  "retries": 0,
+  "max_retries": 0,
+  "attempts": [
+    {
+      "attempt": 1,
+      "status": "success",
+      "retryable": false,
+      "error": null,
+      "runtime_log": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-855/runtime.attempt-1.log",
+      "exit_code": 0,
+      "timed_out": false,
+      "wait_error": null,
+      "output_path": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-855/output.json",
+      "started_at": "2026-03-25T01:52:32.907421Z",
+      "finished_at": "2026-03-25T01:53:38.983401Z"
+    }
+  ],
+  "task_dir": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-855",
+  "payload": {
+    "task_id": "AUTO-20260325-855",
+    "worker": "automation",
+    "task_type": "generate_script",
+    "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+    "inputs": {
+      "params": {
+        "input_dir": "~/Desktop/pdf样本",
+        "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+        "ocr": "auto",
+        "dry_run": false,
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "description": "Purpose: | Controlled Trello live preview smoke for openclaw-team. | Expected behavior: | - read-only Trello ingest | - preview creation smoke only | - no business execution claim | - no Trello writeback expected in this step | Traceability: | - backlog: BL-20260324-014 | - blocker context: BL-20260324-015 | - created_by: Oscarling | - created_at: 2026-03-24 Asia/Shanghai | Note: | This card is only for governed smoke verification and should remain open until the smoke is finished.",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "preferred_wrapper_script": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "preferred_base_script": "artifacts/scripts/pdf_to_excel_ocr.py",
+        "reference_docs": [
+          "artifacts/docs/pdf_to_excel_ocr_usage.md",
+          "artifacts/reviews/pdf_to_excel_ocr_review.md"
+        ],
+        "contract_hints": {
+          "output_format_fidelity": "If output_xlsx ends with .xlsx, produce a real XLSX workbook container or fail honestly before writing mismatched text/XML/CSV content to a .xlsx path.",
+          "path_portability": "Use the provided input_dir parameter as runtime input. Do not hardcode a user-home or absolute input path when params already declare the path.",
+          "traceability": "Preserve meaningful description context from the external input; do not collapse it to a heading fragment such as Purpose:.",
+          "reuse_preference": "Prefer reusing artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py as the wrapper baseline and artifacts/scripts/pdf_to_excel_ocr.py as the reviewed delegate when compatible, so workbook semantics and contract behavior stay aligned with repository evidence.",
+          "outcome_status_model": "Use the reviewable status model success/partial/failed. Dry-run requests or zero-PDF discovery should resolve to partial rather than claiming success without an output artifact.",
+          "delegate_resolution": "If preferred_base_script is relative, resolve it from the repository or script location instead of Path.cwd() so behavior stays portable across shells and CI.",
+          "reviewed_delegate_contract": "For readonly reviewable preview flows, delegate only to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py or fail honestly instead of broadening behavior through an arbitrary helper.",
+          "delegate_success_evidence": "Do not treat zero exit code plus output-file existence as sufficient wrapper success evidence on their own. Prefer a structured delegate report that confirms a real success outcome with at least one processed input and no failed-file counterexamples before the wrapper claims success.",
+          "delegate_timeout": "Bound delegate subprocess execution with an explicit timeout and report timeout as an honest failed/partial outcome instead of allowing smoke automation to hang indefinitely.",
+          "runtime_summary": "The generated script should emit a structured summary of what it produced so later review can inspect behavior without guessing.",
+          "delegate_report_schema": "Treat delegate JSON report fields status/total_files/status_counter/dry_run as the canonical evidence contract. Do not require undeclared processed_files/succeeded_files/failed_files counters.",
+          "delegate_report_handoff": "When the delegate prints a JSON report to stdout, parse that JSON directly instead of relying only on sidecar-report file path discovery.",
+          "dry_run_semantics": "If wrapper dry-run short-circuits before delegate execution, keep execution.delegated=false and report partial honestly. If wrapper does delegate under dry-run, pass through --dry-run explicitly."
+        }
+      }
+    },
+    "expected_outputs": [
+      {
+        "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "type": "script"
+      }
+    ],
+    "constraints": [
+      "Follow the local inbox normalized request",
+      "Do not claim unsupported runtime dependencies",
+      "Keep output deterministic and executable",
+      "Produce only the expected script artifact",
+      "Prefer honest, reviewable intermediate behavior over unsupported OCR claims",
+      "If the requested output path ends with .xlsx, do not write non-XLSX text/XML/CSV content to that path.",
+      "Do not hardcode an input directory when the task params already provide input_dir.",
+      "Preserve meaningful traceability from the incoming description instead of collapsing it to a heading fragment.",
+      "Prefer wrapping or adapting artifacts/scripts/pdf_to_excel_ocr.py when that existing repo script already matches the requested behavior.",
+      "When artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py already exists, prefer updating that reviewed wrapper baseline instead of rewriting a new control flow from scratch.",
+      "If dry_run is true or no PDFs are discovered, report a reviewable partial outcome instead of claiming success without an XLSX artifact.",
+      "Resolve relative delegate script paths from the repository or script location, not from Path.cwd().",
+      "For readonly reviewable preview flows, only delegate to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py unless failing honestly.",
+      "Do not claim wrapper success from exit code plus output existence alone when the reviewed delegate report does not provide strong enough success evidence.",
+      "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
+      "When delegate emits JSON to stdout, parse that report directly instead of depending only on sidecar report-file discovery.",
+      "If wrapper supports dry-run short-circuit semantics, keep execution.delegated=false and preserve partial status honestly.",
+      "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely."
+    ],
+    "priority": "medium",
+    "source": {
+      "kind": "local_inbox",
+      "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+      "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl029-001.json",
+      "received_at": "2026-03-25T01:51:34.187455Z",
+      "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "provider": "trello",
+      "mode": "readonly",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "regeneration_token": "regen-20260325-bl029-001"
+    },
+    "acceptance_criteria": [
+      "Produce the expected script artifact at expected_outputs[0].path",
+      "Script behavior remains runnable, deterministic, and reviewable",
+      "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
+      "Artifact behavior remains parameter-driven for input_dir and output_xlsx rather than hardcoding unrelated local defaults.",
+      "Dry-run or zero-input behavior is represented as a reviewable partial outcome instead of artifact-production success.",
+      "Relative preferred_base_script resolution remains portable and does not depend on Path.cwd().",
+      "Wrapper success requires stronger delegate evidence than zero exit code plus a non-empty output file alone.",
+      "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
+      "Delegate report handoff can consume JSON printed to stdout without relying exclusively on report sidecar file discovery.",
+      "Dry-run semantics remain explicit: short-circuit stays partial with no delegated execution, or delegated dry-run is passed through honestly.",
+      "Delegate execution is bounded by an explicit timeout and reports timeout honestly."
+    ],
+    "metadata": {
+      "integration_phase": "8B",
+      "pipeline": "inbox->adapter->manager->automation->critic",
+      "request_type": "pdf_to_excel_ocr",
+      "payload_hash": "ab85bf08e44d3e7f05c017310441410e4bf8db6291535cdb3c113e713fccc59e",
+      "regeneration_token": "regen-20260325-bl029-001",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "external_metadata": {
+        "source_system": "trello",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "card_short_id": 7,
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "date_last_activity": "2026-03-24T08:35:56.234Z",
+        "readonly_mapped_at": "2026-03-25T01:51:22.186443Z",
+        "contract_profile": "best_effort_evidence_backed",
+        "ocr_claim_policy": "do_not_claim_success_without_evidence",
+        "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+        "regeneration_token": "regen-20260325-bl029-001"
+      },
+      "automation_contract_profile": "narrow_script_artifact_with_repo_reuse_and_reviewable_runner_contract"
+    }
+  },
+  "result": {
+    "task_id": "AUTO-20260325-855",
+    "worker": "automation",
+    "status": "success",
+    "summary": "Generated exactly one runnable helper wrapper script artifact that reuses the reviewed pdf_to_excel_ocr.py delegate, preserves parameter-driven input/output behavior, uses explicit timeout control, parses delegate JSON from stdout or sidecar report, and applies reviewable success/partial/failed evidence rules.",
+    "artifacts": [
+      {
+        "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "type": "script"
+      }
+    ],
+    "timestamp": "2026-03-25T01:53:38.846608Z",
+    "duration_ms": 65711,
+    "notes": [
+      "The artifact is provided as file contents for the expected path only.",
+      "The wrapper is designed to preserve true XLSX semantics by delegating workbook creation to the reviewed base script and failing honestly when evidence is insufficient.",
+      "Dry-run and zero-PDF discovery resolve to partial outcomes."
+    ],
+    "metadata": {
+      "task_id": "AUTO-20260325-855",
+      "worker": "automation",
+      "objective": "generate_script",
+      "generated_files": 1
+    }
+  }
+}

--- a/runtime_archives/bl029/runtime/CRITIC-20260325-276.json
+++ b/runtime_archives/bl029/runtime/CRITIC-20260325-276.json
@@ -1,0 +1,200 @@
+{
+  "task_id": "CRITIC-20260325-276",
+  "worker": "critic",
+  "status": "success",
+  "created_at": "2026-03-25T01:53:39.018928Z",
+  "updated_at": "2026-03-25T01:54:13.535283Z",
+  "retries": 0,
+  "max_retries": 0,
+  "attempts": [
+    {
+      "attempt": 1,
+      "status": "success",
+      "retryable": false,
+      "error": null,
+      "runtime_log": "/Users/lingguozhong/openclaw-team/workspaces/critic/CRITIC-20260325-276/runtime.attempt-1.log",
+      "exit_code": 0,
+      "timed_out": false,
+      "wait_error": null,
+      "output_path": "/Users/lingguozhong/openclaw-team/workspaces/critic/CRITIC-20260325-276/output.json",
+      "started_at": "2026-03-25T01:53:39.022453Z",
+      "finished_at": "2026-03-25T01:54:13.515026Z"
+    }
+  ],
+  "task_dir": "/Users/lingguozhong/openclaw-team/workspaces/critic/CRITIC-20260325-276",
+  "payload": {
+    "task_id": "CRITIC-20260325-276",
+    "worker": "critic",
+    "task_type": "review_artifact",
+    "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+    "inputs": {
+      "artifacts": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        },
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+          "type": "script"
+        }
+      ],
+      "params": {
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "review_scope": {
+          "primary_artifact": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "paired_artifacts": [
+            "artifacts/scripts/pdf_to_excel_ocr.py"
+          ],
+          "goal": "Audit the wrapper and the reviewed delegate together so the review evidence can speak to the end-to-end readonly smoke path."
+        },
+        "artifact_snapshots": [
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "available": true,
+            "content": "#!/usr/bin/env python3\nfrom __future__ import annotations\n\nimport argparse\nimport json\nimport os\nimport subprocess\nimport sys\nimport tempfile\nfrom dataclasses import dataclass\nfrom pathlib import Path\nfrom typing import Any\n\n\nDEFAULT_TIMEOUT_SECONDS = 900\n\n\n@dataclass\nclass RequestContext:\n    input_dir: Path\n    output_xlsx: Path\n    ocr: str\n    dry_run: bool\n    origin_id: str\n    title: str\n    description: str\n    labels: list[str]\n    delegate_path: Path\n    timeout_seconds: int\n\n\ndef _expand_path(raw: str) -> Path:\n    return Path(os.path.expandvars(os.path.expanduser(raw))).resolve()\n\n\ndef _repo_root_from_script() -> Path:\n    return Path(__file__).resolve().parents[2]\n\n\ndef _resolve_delegate(preferred_base_script: str | None) -> Path:\n    repo_root = _repo_root_from_script()\n    script_dir = Path(__file__).resolve().parent\n\n    candidates: list[Path] = []\n    if preferred_base_script:\n        p = Path(preferred_base_script)\n        if p.is_absolute():\n            candidates.append(p)\n        else:\n            candidates.append((repo_root / p).resolve())\n            candidates.append((script_dir / p).resolve())\n    candidates.append((repo_root / \"artifacts/scripts/pdf_to_excel_ocr.py\").resolve())\n\n    seen: set[Path] = set()\n    for candidate in candidates:\n        if candidate in seen:\n            continue\n        seen.add(candidate)\n        if candidate.exists() and candidate.is_file():\n            return candidate\n    raise FileNotFoundError(\n        \"Unable to locate reviewed delegate script artifacts/scripts/pdf_to_excel_ocr.py\"\n    )\n\n\ndef _discover_pdfs(input_dir: Path) -> list[Path]:\n    if not input_dir.exists() or not input_dir.is_dir():\n        return []\n    return sorted(\n        [p for p in input_dir.rglob(\"*\") if p.is_file() and p.suffix.lower() == \".pdf\"]\n    )\n\n\ndef _is_probably_json(text: str) -> bool:\n    stripped = text.strip()\n    return stripped.startswith(\"{\") and stripped.endswith(\"}\")\n\n\ndef _parse_first_json_object(stdout_text: str) -> dict[str, Any] | None:\n    text = stdout_text.strip()\n    if not text:\n        return None\n    if _is_probably_json(text):\n        try:\n            data = json.loads(text)\n            if isinstance(data, dict):\n                return data\n        except json.JSONDecodeError:\n            pass\n\n    decoder = json.JSONDecoder()\n    for idx, ch in enumerate(stdout_text):\n        if ch != \"{\":\n            continue\n        try:\n            obj, end = decoder.raw_decode(stdout_text[idx:])\n        except json.JSONDecodeError:\n            continue\n        if isinstance(obj, dict):\n            return obj\n    return None\n\n\ndef _load_report_from_sidecar(path: Path) -> dict[str, Any] | None:\n    if not path.exists() or not path.is_file():\n        return None\n    try:\n        data = json.loads(path.read_text(encoding=\"utf-8\"))\n    except Exception:\n        return None\n    return data if isinstance(data, dict) else None\n\n\ndef _normalize_counter(value: Any) -> dict[str, int]:\n    if not isinstance(value, dict):\n        return {}\n    normalized: dict[str, int] = {}\n    for k, v in value.items():\n        if isinstance(v, bool):\n            normalized[str(k)] = int(v)\n        elif isinstance(v, int):\n            normalized[str(k)] = v\n        else:\n            try:\n                normalized[str(k)] = int(v)\n            except Exception:\n                continue\n    return normalized\n\n\ndef _build_summary(\n    status: str,\n    ctx: RequestContext,\n    pdf_count: int,\n    delegated: bool,\n    output_exists: bool,\n    delegate_report: dict[str, Any] | None,\n    delegate_returncode: int | None,\n    stdout_tail: str,\n    stderr_tail: str,\n    notes: list[str],\n) -> dict[str, Any]:\n    return {\n        \"status\": status,\n        \"request\": {\n            \"origin_id\": ctx.origin_id,\n            \"title\": ctx.title,\n            \"description\": ctx.description,\n            \"labels\": ctx.labels,\n            \"input_dir\": str(ctx.input_dir),\n            \"output_xlsx\": str(ctx.output_xlsx),\n            \"ocr\": ctx.ocr,\n            \"dry_run\": ctx.dry_run,\n        },\n        \"execution\": {\n            \"delegated\": delegated,\n            \"delegate_path\": str(ctx.delegate_path),\n            \"timeout_seconds\": ctx.timeout_seconds,\n            \"delegate_returncode\": delegate_returncode,\n            \"pdf_discovered\": pdf_count,\n            \"output_exists\": output_exists,\n        },\n        \"delegate_report\": delegate_report,\n        \"stdout_tail\": stdout_tail,\n        \"stderr_tail\": stderr_tail,\n        \"notes\": notes,\n    }\n\n\ndef _success_from_delegate(report: dict[str, Any] | None, output_xlsx: Path) -> tuple[bool, list[str]]:\n    reasons: list[str] = []\n    if not isinstance(report, dict):\n        reasons.append(\"delegate report missing\")\n        return False, reasons\n\n    status = report.get(\"status\")\n    total_files = report.get(\"total_files\")\n    dry_run = report.get(\"dry_run\")\n    counter = _normalize_counter(report.get(\"status_counter\"))\n\n    if status != \"success\":\n        reasons.append(f\"delegate status is {status!r}, not 'success'\")\n    if isinstance(total_files, bool) or not isinstance(total_files, int) or total_files < 1:\n        reasons.append(\"delegate total_files does not confirm at least one input\")\n    if bool(dry_run):\n        reasons.append(\"delegate reports dry_run=true\")\n    if counter.get(\"failed\", 0) > 0:\n        reasons.append(\"delegate reports failed files\")\n    processed_evidence = counter.get(\"success\", 0) + counter.get(\"partial\", 0)\n    if processed_evidence < 1 and isinstance(total_files, int) and total_files > 0:\n        reasons.append(\"delegate status_counter lacks positive processed evidence\")\n    if not output_xlsx.exists() or not output_xlsx.is_file():\n        reasons.append(\"expected XLSX output artifact does not exist\")\n    elif output_xlsx.suffix.lower() == \".xlsx\" and output_xlsx.stat().st_size <= 0:\n        reasons.append(\"expected XLSX output artifact is empty\")\n\n    return (len(reasons) == 0, reasons)\n\n\ndef _parse_args() -> argparse.Namespace:\n    parser = argparse.ArgumentParser(\n        description=\"Readonly reviewable wrapper for reviewed PDF-to-Excel delegate.\"\n    )\n    parser.add_argument(\"--input-dir\", required=True)\n    parser.add_argument(\"--output-xlsx\", required=True)\n    parser.add_argument(\"--ocr\", default=\"auto\")\n    parser.add_argument(\"--dry-run\", action=\"store_true\")\n    parser.add_argument(\"--origin-id\", default=\"\")\n    parser.add_argument(\"--title\", default=\"\")\n    parser.add_argument(\"--description\", default=\"\")\n    parser.add_argument(\"--labels\", nargs=\"*\", default=[])\n    parser.add_argument(\"--preferred-base-script\", default=\"artifacts/scripts/pdf_to_excel_ocr.py\")\n    parser.add_argument(\"--timeout-seconds\", type=int, default=DEFAULT_TIMEOUT_SECONDS)\n    return parser.parse_args()\n\n\ndef main() -> int:\n    args = _parse_args()\n    try:\n        delegate_path = _resolve_delegate(args.preferred_base_script)\n    except Exception as exc:\n        summary = {\n            \"status\": \"failed\",\n            \"request\": {\n                \"origin_id\": args.origin_id,\n                \"title\": args.title,\n                \"description\": args.description,\n                \"labels\": args.labels,\n                \"input_dir\": str(_expand_path(args.input_dir)),\n                \"output_xlsx\": str(_expand_path(args.output_xlsx)),\n                \"ocr\": args.ocr,\n                \"dry_run\": args.dry_run,\n            },\n            \"execution\": {\n                \"delegated\": False,\n                \"delegate_path\": None,\n                \"timeout_seconds\": args.timeout_seconds,\n                \"delegate_returncode\": None,\n                \"pdf_discovered\": 0,\n                \"output_exists\": False,\n            },\n            \"delegate_report\": None,\n            \"stdout_tail\": \"\",\n            \"stderr_tail\": \"\",\n            \"notes\": [f\"delegate resolution failed: {exc}\"],\n        }\n        print(json.dumps(summary, ensure_ascii=False, indent=2))\n        return 2\n\n    ctx = RequestContext(\n        input_dir=_expand_path(args.input_dir),\n        output_xlsx=_expand_path(args.output_xlsx),\n        ocr=args.ocr,\n        dry_run=bool(args.dry_run),\n        origin_id=args.origin_id,\n        title=args.title,\n        description=args.description,\n        labels=list(args.labels),\n        delegate_path=delegate_path,\n        timeout_seconds=max(1, int(args.timeout_seconds)),\n    )\n\n    pdfs = _discover_pdfs(ctx.input_dir)\n\n    if ctx.dry_run:\n        summary = _build_summary(\n            status=\"partial\",\n            ctx=ctx,\n            pdf_count=len(pdfs),\n            delegated=False,\n            output_exists=ctx.output_xlsx.exists(),\n            delegate_report=None,\n            delegate_returncode=None,\n            stdout_tail=\"\",\n            stderr_tail=\"\",\n            notes=[\n                \"dry-run requested; wrapper short-circuited before delegate execution\",\n                \"no XLSX artifact claimed\",\n            ],\n        )\n        print(json.dumps(summary, ensure_ascii=False, indent=2))\n        return 0\n\n    if not pdfs:\n        summary = _build_summary(\n            status=\"partial\",\n            ctx=ctx,\n            pdf_count=0,\n            delegated=False,\n            output_exists=ctx.output_xlsx.exists(),\n            delegate_report=None,\n            delegate_returncode=None,\n            stdout_tail=\"\",\n            stderr_tail=\"\",\n            notes=[\n                \"no PDF files discovered under input_dir\",\n                \"no XLSX artifact claimed\",\n            ],\n        )\n        print(json.dumps(summary, ensure_ascii=False, indent=2))\n        return 0\n\n    ctx.output_xlsx.parent.mkdir(parents=True, exist_ok=True)\n\n    with tempfile.NamedTemporaryFile(prefix=\"pdf_to_excel_delegate_report_\", suffix=\".json\", delete=False) as tf:\n        report_path = Path(tf.name)\n\n    cmd = [\n        sys.executable,\n        str(ctx.delegate_path),\n        \"--input-dir\",\n        str(ctx.input_dir),\n        \"--output-xlsx\",\n        str(ctx.output_xlsx),\n        \"--ocr\",\n        ctx.ocr,\n    ]\n\n    # Best-effort compatibility with reviewed delegate implementations that support sidecar reporting.\n    cmd.extend([\"--report-json\", str(report_path)])\n\n    completed: subprocess.CompletedProcess[str] | None = None\n    stdout_text = \"\"\n    stderr_text = \"\"\n    delegate_report: dict[str, Any] | None = None\n\n    try:\n        completed = subprocess.run(\n            cmd,\n            capture_output=True,\n            text=True,\n            timeout=ctx.timeout_seconds,\n            check=False,\n        )\n        stdout_text = completed.stdout or \"\"\n        stderr_text = completed.stderr or \"\"\n        delegate_report = _parse_first_json_object(stdout_text)\n        if delegate_report is None:\n            delegate_report = _load_report_from_sidecar(report_path)\n    except subprocess.TimeoutExpired as exc:\n        stdout_text = (exc.stdout or \"\") if isinstance(exc.stdout, str) else \"\"\n        stderr_text = (exc.stderr or \"\") if isinstance(exc.stderr, str) else \"\"\n        summary = _build_summary(\n            status=\"failed\",\n            ctx=ctx,\n            pdf_count=len(pdfs),\n            delegated=True,\n            output_exists=ctx.output_xlsx.exists(),\n            delegate_report=None,\n            delegate_returncode=None,\n            stdout_tail=stdout_text[-4000:],\n            stderr_tail=stderr_text[-4000:],\n            notes=[f\"delegate execution timed out after {ctx.timeout_seconds} seconds\"],\n        )\n        print(json.dumps(summary, ensure_ascii=False, indent=2))\n        return 124\n    finally:\n        try:\n            report_path.unlink(missing_ok=True)\n        except Exception:\n            pass\n\n    ok, reasons = _success_from_delegate(delegate_report, ctx.output_xlsx)\n\n    if ok:\n        summary = _build_summary(\n            status=\"success\",\n            ctx=ctx,\n            pdf_count=len(pdfs),\n            delegated=True,\n            output_exists=ctx.output_xlsx.exists(),\n            delegate_report=delegate_report,\n           ",
+            "truncated": true
+          },
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+            "available": true,
+            "content": "#!/usr/bin/env python3\n\"\"\"\nBatch PDF -> Excel extractor with optional OCR fallback.\n\nDesign goals:\n- Batch processing with per-file isolation (single file failure must not stop the batch)\n- OCR mode: auto | on | off\n- Chinese-friendly OCR defaults (chi_sim+eng)\n- Dry-run support for pilot validation when dependencies are unavailable\n\"\"\"\n\nfrom __future__ import annotations\n\nimport argparse\nimport json\nimport shutil\nimport sys\nfrom dataclasses import asdict, dataclass\nfrom pathlib import Path\nfrom typing import Any\n\n\ntry:\n    from pypdf import PdfReader  # type: ignore\nexcept Exception:\n    PdfReader = None\n\ntry:\n    import pandas as pd  # type: ignore\nexcept Exception:\n    pd = None\n\ntry:\n    import pytesseract  # type: ignore\nexcept Exception:\n    pytesseract = None\n\ntry:\n    from pdf2image import convert_from_path  # type: ignore\nexcept Exception:\n    convert_from_path = None\n\n\n@dataclass\nclass FileResult:\n    file_name: str\n    file_path: str\n    status: str\n    extract_method: str\n    page_count: int\n    text_chars: int\n    text_preview: str\n    warnings: str\n    error: str\n\n\ndef parse_args() -> argparse.Namespace:\n    parser = argparse.ArgumentParser(description=\"Batch PDF to Excel extractor with OCR fallback.\")\n    parser.add_argument(\"--input-dir\", required=True, help=\"Directory containing PDF files.\")\n    parser.add_argument(\"--output-xlsx\", required=True, help=\"Output Excel path.\")\n    parser.add_argument(\n        \"--ocr\",\n        choices=(\"auto\", \"on\", \"off\"),\n        default=\"auto\",\n        help=\"OCR mode. auto=use OCR when plain text extraction is weak.\",\n    )\n    parser.add_argument(\n        \"--dry-run\",\n        action=\"store_true\",\n        help=\"Do not write Excel file. Print execution summary only.\",\n    )\n    parser.add_argument(\n        \"--ocr-lang\",\n        default=\"chi_sim+eng\",\n        help=\"OCR language pack for pytesseract, default supports Chinese + English.\",\n    )\n    parser.add_argument(\n        \"--auto-ocr-min-chars\",\n        type=int,\n        default=50,\n        help=\"In auto mode, run OCR when extracted text chars < this threshold.\",\n    )\n    return parser.parse_args()\n\n\ndef discover_pdfs(input_dir: Path) -> list[Path]:\n    if not input_dir.exists():\n        raise FileNotFoundError(f\"Input directory does not exist: {input_dir}\")\n    if not input_dir.is_dir():\n        raise NotADirectoryError(f\"Input path is not a directory: {input_dir}\")\n    files = sorted([p for p in input_dir.rglob(\"*\") if p.is_file() and p.suffix.lower() == \".pdf\"])\n    return files\n\n\ndef detect_ocr_runtime_status() -> tuple[str, list[str]]:\n    missing: list[str] = []\n    present: list[str] = []\n\n    if pytesseract is None:\n        missing.append(\"python module pytesseract\")\n    else:\n        present.append(\"python module pytesseract\")\n    if convert_from_path is None:\n        missing.append(\"python module pdf2image\")\n    else:\n        present.append(\"python module pdf2image\")\n    if shutil.which(\"tesseract\") is None:\n        missing.append(\"binary tesseract\")\n    else:\n        present.append(\"binary tesseract\")\n    if shutil.which(\"pdftoppm\") is None:\n        missing.append(\"binary pdftoppm (poppler)\")\n    else:\n        present.append(\"binary pdftoppm (poppler)\")\n\n    if not missing:\n        return \"available\", []\n    if present:\n        return \"partial\", missing\n    return \"blocked\", missing\n\n\ndef extract_text_pypdf(pdf_path: Path) -> tuple[str, int]:\n    if PdfReader is None:\n        raise RuntimeError(\"pypdf not installed\")\n    reader = PdfReader(str(pdf_path))\n    page_texts: list[str] = []\n    for page in reader.pages:\n        text = page.extract_text() or \"\"\n        page_texts.append(text)\n    return \"\\n\".join(page_texts), len(reader.pages)\n\n\ndef extract_text_ocr(pdf_path: Path, ocr_lang: str) -> str:\n    if pytesseract is None:\n        raise RuntimeError(\"pytesseract not installed\")\n    if convert_from_path is None:\n        raise RuntimeError(\"pdf2image not installed\")\n    if shutil.which(\"tesseract\") is None:\n        raise RuntimeError(\"tesseract binary not found\")\n    if shutil.which(\"pdftoppm\") is None:\n        raise RuntimeError(\"pdftoppm binary not found (install poppler)\")\n\n    images = convert_from_path(str(pdf_path), dpi=220)\n    chunks: list[str] = []\n    for image in images:\n        chunks.append(pytesseract.image_to_string(image, lang=ocr_lang))\n    return \"\\n\".join(chunks)\n\n\ndef compact_preview(text: str, limit: int = 160) -> str:\n    single_line = \" \".join(text.split())\n    if len(single_line) <= limit:\n        return single_line\n    return single_line[: limit - 3] + \"...\"\n\n\ndef process_one_pdf(\n    pdf_path: Path,\n    ocr_mode: str,\n    ocr_lang: str,\n    auto_ocr_min_chars: int,\n) -> FileResult:\n    warnings: list[str] = []\n    errors: list[str] = []\n    method = \"none\"\n    text = \"\"\n    page_count = 0\n\n    try:\n        text, page_count = extract_text_pypdf(pdf_path)\n        method = \"text\"\n    except Exception as e:\n        warnings.append(f\"text extraction unavailable: {e}\")\n\n    needs_ocr = False\n    if ocr_mode == \"on\":\n        needs_ocr = True\n    elif ocr_mode == \"auto\" and len(text.strip()) < auto_ocr_min_chars:\n        needs_ocr = True\n\n    if needs_ocr:\n        try:\n            ocr_text = extract_text_ocr(pdf_path, ocr_lang).strip()\n            if ocr_text:\n                if text.strip():\n                    text = f\"{text.strip()}\\n\\n[OCR Fallback]\\n{ocr_text}\"\n                    method = \"text+ocr\"\n                else:\n                    text = ocr_text\n                    method = \"ocr\"\n            else:\n                warnings.append(\"OCR returned empty text\")\n        except Exception as e:\n            errors.append(f\"OCR failed: {e}\")\n\n    if not text.strip():\n        if errors:\n            status = \"failed\"\n        else:\n            status = \"partial\"\n            warnings.append(\"No extractable text captured\")\n    else:\n        status = \"success\"\n\n    return FileResult(\n        file_name=pdf_path.name,\n        file_path=str(pdf_path),\n        status=status,\n        extract_method=method,\n        page_count=page_count,\n        text_chars=len(text),\n        text_preview=compact_preview(text),\n        warnings=\" | \".join(warnings),\n        error=\" | \".join(errors),\n    )\n\n\ndef write_excel(results: list[FileResult], output_xlsx: Path) -> None:\n    if pd is None:\n        raise RuntimeError(\"pandas is required to write Excel output\")\n    output_xlsx.parent.mkdir(parents=True, exist_ok=True)\n\n    rows = [asdict(r) for r in results]\n    detail_df = pd.DataFrame(rows)\n\n    summary_rows: list[dict[str, Any]] = []\n    by_status = detail_df.groupby(\"status\").size().to_dict()\n    by_method = detail_df.groupby(\"extract_method\").size().to_dict()\n    for key, value in sorted(by_status.items()):\n        summary_rows.append({\"metric\": \"status_count\", \"name\": key, \"value\": int(value)})\n    for key, value in sorted(by_method.items()):\n        summary_rows.append({\"metric\": \"method_count\", \"name\": key, \"value\": int(value)})\n    summary_rows.append({\"metric\": \"total_files\", \"name\": \"all\", \"value\": int(len(results))})\n    summary_df = pd.DataFrame(summary_rows)\n\n    with pd.ExcelWriter(output_xlsx) as writer:\n        summary_df.to_excel(writer, sheet_name=\"summary\", index=False)\n        detail_df.to_excel(writer, sheet_name=\"files\", index=False)\n\n\ndef main() -> int:\n    args = parse_args()\n    input_dir = Path(args.input_dir).expanduser().resolve()\n    output_xlsx = Path(args.output_xlsx).expanduser().resolve()\n\n    try:\n        pdf_files = discover_pdfs(input_dir)\n    except Exception as e:\n        print(json.dumps({\"status\": \"failed\", \"error\": str(e)}, ensure_ascii=False, indent=2))\n        return 2\n\n    if not pdf_files:\n        print(\n            json.dumps(\n                {\n                    \"status\": \"failed\",\n                    \"error\": f\"No PDF files found under {input_dir}\",\n                },\n                ensure_ascii=False,\n                indent=2,\n            )\n        )\n        return 2\n\n    ocr_runtime, missing = detect_ocr_runtime_status()\n    results: list[FileResult] = []\n    for pdf in pdf_files:\n        try:\n            results.append(\n                process_one_pdf(\n                    pdf,\n                    ocr_mode=args.ocr,\n                    ocr_lang=args.ocr_lang,\n                    auto_ocr_min_chars=args.auto_ocr_min_chars,\n                )\n            )\n        except Exception as e:\n            results.append(\n                FileResult(\n                    file_name=pdf.name,\n                    file_path=str(pdf),\n                    status=\"failed\",\n                    extract_method=\"none\",\n                    page_count=0,\n                    text_chars=0,\n                    text_preview=\"\",\n                    warnings=\"\",\n                    error=f\"Unhandled processing exception: {e}\",\n                )\n            )\n\n    status_counter: dict[str, int] = {}\n    for item in results:\n        status_counter[item.status] = status_counter.get(item.status, 0) + 1\n\n    report = {\n        \"status\": \"success\" if status_counter.get(\"failed\", 0) == 0 else \"partial\",\n        \"input_dir\": str(input_dir),\n        \"output_xlsx\": str(output_xlsx),\n        \"ocr_mode\": args.ocr,\n        \"ocr_runtime_status\": ocr_runtime,\n        \"ocr_missing_dependencies\": missing,\n        \"total_files\": len(results),\n        \"status_counter\": status_counter,\n        \"dry_run\": bool(args.dry_run),\n    }\n\n    if args.dry_run:\n        print(json.dumps(report, ensure_ascii=False, indent=2))\n        return 0\n\n    try:\n        write_excel(results, output_xlsx)\n        print(json.dumps(report, ensure_ascii=False, indent=2))\n        return 0\n    except Exception as e:\n        report[\"status\"] = \"failed\"\n        report[\"error\"] = str(e)\n        print(json.dumps(report, ensure_ascii=False, indent=2))\n        return 3\n\n\nif __name__ == \"__main__\":\n    raise SystemExit(main())\n",
+            "truncated": false
+          }
+        ],
+        "review_contract": {
+          "required_status": [
+            "success",
+            "partial",
+            "failed"
+          ],
+          "required_verdict_values": [
+            "fail",
+            "needs_revision",
+            "pass"
+          ],
+          "required_metadata_key": "verdict",
+          "must_write_review_artifact_to": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "artifact_policy": "Always include either `file_contents` for the review artifact path or `artifacts` referencing that exact path.",
+          "fallback_policy": "If evidence is insufficient, return `status=partial`, include explicit `errors`, still generate review artifact content, and set verdict=needs_revision."
+        },
+        "review_template": {
+          "title": "Review: <artifact name>",
+          "sections": [
+            "Scope",
+            "Findings",
+            "Verdict",
+            "Rationale"
+          ],
+          "verdict_required": true
+        }
+      }
+    },
+    "expected_outputs": [
+      {
+        "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+        "type": "review"
+      }
+    ],
+    "constraints": [
+      "Review must be grounded in produced automation artifact",
+      "When both wrapper and reviewed delegate snapshots are supplied, evaluate them as one end-to-end readonly pair instead of ignoring the delegate evidence.",
+      "Do not invent missing artifact content",
+      "Return a clear verdict: pass, fail, or needs_revision",
+      "Include metadata.verdict in output",
+      "Generate review artifact markdown for expected_outputs[0].path",
+      "Use artifact_snapshots when provided; avoid claiming access problems if snapshot content exists.",
+      "When both the generated wrapper and reviewed delegate snapshots are provided, review them together rather than silently narrowing scope to one file.",
+      "Return metadata.verdict with one of: pass, fail, needs_revision.",
+      "Always generate review artifact content for expected_outputs[0].path.",
+      "If evidence is insufficient, use partial + errors + verdict=needs_revision, but still output review artifact."
+    ],
+    "priority": "medium",
+    "source": {
+      "kind": "local_inbox",
+      "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+      "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl029-001.json",
+      "received_at": "2026-03-25T01:51:34.187455Z",
+      "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "provider": "trello",
+      "mode": "readonly",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "regeneration_token": "regen-20260325-bl029-001"
+    },
+    "acceptance_criteria": [
+      "Produce a review artifact with explicit verdict (pass/fail/needs_revision)"
+    ],
+    "metadata": {
+      "integration_phase": "8B",
+      "pipeline": "inbox->adapter->manager->automation->critic",
+      "request_type": "pdf_to_excel_ocr",
+      "payload_hash": "ab85bf08e44d3e7f05c017310441410e4bf8db6291535cdb3c113e713fccc59e",
+      "regeneration_token": "regen-20260325-bl029-001",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "external_metadata": {
+        "source_system": "trello",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "card_short_id": 7,
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "date_last_activity": "2026-03-24T08:35:56.234Z",
+        "readonly_mapped_at": "2026-03-25T01:51:22.186443Z",
+        "contract_profile": "best_effort_evidence_backed",
+        "ocr_claim_policy": "do_not_claim_success_without_evidence",
+        "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+        "regeneration_token": "regen-20260325-bl029-001"
+      }
+    }
+  },
+  "result": {
+    "task_id": "CRITIC-20260325-276",
+    "worker": "critic",
+    "status": "success",
+    "summary": "Reviewed the inbox runner and paired delegate together as an end-to-end readonly smoke path. The pair is generally aligned with the best-effort/evidence-backed contract, but the wrapper assumes delegate support for --report-json that the reviewed delegate does not implement, creating a real integration defect that can cause wrapper-reported failure even when the delegate otherwise works. Verdict: needs_revision.",
+    "artifacts": [
+      {
+        "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+        "type": "review"
+      }
+    ],
+    "timestamp": "2026-03-25T01:54:13.394469Z",
+    "duration_ms": 34158,
+    "notes": [
+      "Review grounded in provided artifact snapshots for both scripts.",
+      "Scope evaluated as wrapper + delegate pair, not as isolated files.",
+      "Review artifact content is included in file_contents."
+    ],
+    "metadata": {
+      "task_id": "CRITIC-20260325-276",
+      "worker": "critic",
+      "verdict": "needs_revision",
+      "reviewed_artifacts": [
+        "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "artifacts/scripts/pdf_to_excel_ocr.py"
+      ]
+    }
+  }
+}

--- a/runtime_archives/bl029/runtime/automation-output.json
+++ b/runtime_archives/bl029/runtime/automation-output.json
@@ -1,0 +1,25 @@
+{
+  "task_id": "AUTO-20260325-855",
+  "worker": "automation",
+  "status": "success",
+  "summary": "Generated exactly one runnable helper wrapper script artifact that reuses the reviewed pdf_to_excel_ocr.py delegate, preserves parameter-driven input/output behavior, uses explicit timeout control, parses delegate JSON from stdout or sidecar report, and applies reviewable success/partial/failed evidence rules.",
+  "artifacts": [
+    {
+      "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+      "type": "script"
+    }
+  ],
+  "timestamp": "2026-03-25T01:53:38.846608Z",
+  "duration_ms": 65711,
+  "notes": [
+    "The artifact is provided as file contents for the expected path only.",
+    "The wrapper is designed to preserve true XLSX semantics by delegating workbook creation to the reviewed base script and failing honestly when evidence is insufficient.",
+    "Dry-run and zero-PDF discovery resolve to partial outcomes."
+  ],
+  "metadata": {
+    "task_id": "AUTO-20260325-855",
+    "worker": "automation",
+    "objective": "generate_script",
+    "generated_files": 1
+  }
+}

--- a/runtime_archives/bl029/runtime/automation-runtime.attempt-1.log
+++ b/runtime_archives/bl029/runtime/automation-runtime.attempt-1.log
@@ -1,0 +1,19 @@
+task_id: AUTO-20260325-855
+worker: automation
+attempt: 1
+container_name: argus-automation-auto-20260325-855
+worker_image: argus-worker:latest
+started_at: 2026-03-25T01:52:32.907421Z
+finished_at: 2026-03-25T01:53:38.983401Z
+exit_code: 0
+timed_out: False
+wait_error: 
+
+=== stdout ===
+[2026-03-25T01:52:33.135911Z] [automation] [INFO] Worker started using endpoint https://fast.vpsairobot.com/v1/chat/completions (timeout=120s, attempts=3)
+[2026-03-25T01:53:38.845638Z] [automation] [INFO] Artifact written: artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
+[2026-03-25T01:53:38.847155Z] [automation] [INFO] Task completed AUTO-20260325-855 with status success
+[2026-03-25T01:53:38.848424Z] [automation] [INFO] Worker exiting from /app/workspaces/automation/AUTO-20260325-855
+
+=== stderr ===
+

--- a/runtime_archives/bl029/runtime/critic-output.json
+++ b/runtime_archives/bl029/runtime/critic-output.json
@@ -1,0 +1,28 @@
+{
+  "task_id": "CRITIC-20260325-276",
+  "worker": "critic",
+  "status": "success",
+  "summary": "Reviewed the inbox runner and paired delegate together as an end-to-end readonly smoke path. The pair is generally aligned with the best-effort/evidence-backed contract, but the wrapper assumes delegate support for --report-json that the reviewed delegate does not implement, creating a real integration defect that can cause wrapper-reported failure even when the delegate otherwise works. Verdict: needs_revision.",
+  "artifacts": [
+    {
+      "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+      "type": "review"
+    }
+  ],
+  "timestamp": "2026-03-25T01:54:13.394469Z",
+  "duration_ms": 34158,
+  "notes": [
+    "Review grounded in provided artifact snapshots for both scripts.",
+    "Scope evaluated as wrapper + delegate pair, not as isolated files.",
+    "Review artifact content is included in file_contents."
+  ],
+  "metadata": {
+    "task_id": "CRITIC-20260325-276",
+    "worker": "critic",
+    "verdict": "needs_revision",
+    "reviewed_artifacts": [
+      "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+      "artifacts/scripts/pdf_to_excel_ocr.py"
+    ]
+  }
+}

--- a/runtime_archives/bl029/runtime/critic-runtime.attempt-1.log
+++ b/runtime_archives/bl029/runtime/critic-runtime.attempt-1.log
@@ -1,0 +1,19 @@
+task_id: CRITIC-20260325-276
+worker: critic
+attempt: 1
+container_name: argus-critic-critic-20260325-276
+worker_image: argus-worker:latest
+started_at: 2026-03-25T01:53:39.022453Z
+finished_at: 2026-03-25T01:54:13.515026Z
+exit_code: 0
+timed_out: False
+wait_error: 
+
+=== stdout ===
+[2026-03-25T01:53:39.236396Z] [critic] [INFO] Worker started using endpoint https://fast.vpsairobot.com/v1/chat/completions (timeout=120s, attempts=3)
+[2026-03-25T01:54:13.393998Z] [critic] [INFO] Artifact written: artifacts/reviews/pdf_to_excel_ocr_inbox_review.md
+[2026-03-25T01:54:13.394935Z] [critic] [INFO] Task completed CRITIC-20260325-276 with status success
+[2026-03-25T01:54:13.395680Z] [critic] [INFO] Worker exiting from /app/workspaces/critic/CRITIC-20260325-276
+
+=== stderr ===
+

--- a/runtime_archives/bl029/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-ab85bf08e44d.json
+++ b/runtime_archives/bl029/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-ab85bf08e44d.json
@@ -1,0 +1,386 @@
+{
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-ab85bf08e44d",
+  "created_at": "2026-03-25T01:51:34.187894Z",
+  "approved": true,
+  "source": {
+    "kind": "local_inbox",
+    "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+    "received_at": "2026-03-25T01:51:34.187455Z",
+    "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl029-001.json",
+    "regeneration_token": "regen-20260325-bl029-001"
+  },
+  "external_input": {
+    "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+    "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+    "labels": [
+      "best_effort",
+      "evidence_backed",
+      "readonly",
+      "reviewable",
+      "trello"
+    ],
+    "metadata": {
+      "source_system": "trello",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "card_short_id": 7,
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "date_last_activity": "2026-03-24T08:35:56.234Z",
+      "readonly_mapped_at": "2026-03-25T01:51:22.186443Z",
+      "contract_profile": "best_effort_evidence_backed",
+      "ocr_claim_policy": "do_not_claim_success_without_evidence",
+      "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+      "regeneration_token": "regen-20260325-bl029-001"
+    },
+    "request_type": "pdf_to_excel_ocr",
+    "input": {
+      "input_dir": "~/Desktop/pdf样本",
+      "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+      "ocr": "auto",
+      "dry_run": false
+    }
+  },
+  "task_summary": {
+    "automation": {
+      "task_id": "AUTO-20260325-855",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+      "expected_outputs": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ]
+    },
+    "critic": {
+      "task_id": "CRITIC-20260325-276",
+      "worker": "critic",
+      "task_type": "review_artifact",
+      "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+      "expected_outputs": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ]
+    }
+  },
+  "internal_tasks": {
+    "automation": {
+      "task_id": "AUTO-20260325-855",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+      "inputs": {
+        "params": {
+          "input_dir": "~/Desktop/pdf样本",
+          "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+          "ocr": "auto",
+          "dry_run": false,
+          "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+          "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+          "description": "Purpose: | Controlled Trello live preview smoke for openclaw-team. | Expected behavior: | - read-only Trello ingest | - preview creation smoke only | - no business execution claim | - no Trello writeback expected in this step | Traceability: | - backlog: BL-20260324-014 | - blocker context: BL-20260324-015 | - created_by: Oscarling | - created_at: 2026-03-24 Asia/Shanghai | Note: | This card is only for governed smoke verification and should remain open until the smoke is finished.",
+          "labels": [
+            "best_effort",
+            "evidence_backed",
+            "readonly",
+            "reviewable",
+            "trello"
+          ],
+          "preferred_wrapper_script": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "preferred_base_script": "artifacts/scripts/pdf_to_excel_ocr.py",
+          "reference_docs": [
+            "artifacts/docs/pdf_to_excel_ocr_usage.md",
+            "artifacts/reviews/pdf_to_excel_ocr_review.md"
+          ],
+          "contract_hints": {
+            "output_format_fidelity": "If output_xlsx ends with .xlsx, produce a real XLSX workbook container or fail honestly before writing mismatched text/XML/CSV content to a .xlsx path.",
+            "path_portability": "Use the provided input_dir parameter as runtime input. Do not hardcode a user-home or absolute input path when params already declare the path.",
+            "traceability": "Preserve meaningful description context from the external input; do not collapse it to a heading fragment such as Purpose:.",
+            "reuse_preference": "Prefer reusing artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py as the wrapper baseline and artifacts/scripts/pdf_to_excel_ocr.py as the reviewed delegate when compatible, so workbook semantics and contract behavior stay aligned with repository evidence.",
+            "outcome_status_model": "Use the reviewable status model success/partial/failed. Dry-run requests or zero-PDF discovery should resolve to partial rather than claiming success without an output artifact.",
+            "delegate_resolution": "If preferred_base_script is relative, resolve it from the repository or script location instead of Path.cwd() so behavior stays portable across shells and CI.",
+            "reviewed_delegate_contract": "For readonly reviewable preview flows, delegate only to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py or fail honestly instead of broadening behavior through an arbitrary helper.",
+            "delegate_success_evidence": "Do not treat zero exit code plus output-file existence as sufficient wrapper success evidence on their own. Prefer a structured delegate report that confirms a real success outcome with at least one processed input and no failed-file counterexamples before the wrapper claims success.",
+            "delegate_timeout": "Bound delegate subprocess execution with an explicit timeout and report timeout as an honest failed/partial outcome instead of allowing smoke automation to hang indefinitely.",
+            "runtime_summary": "The generated script should emit a structured summary of what it produced so later review can inspect behavior without guessing.",
+            "delegate_report_schema": "Treat delegate JSON report fields status/total_files/status_counter/dry_run as the canonical evidence contract. Do not require undeclared processed_files/succeeded_files/failed_files counters.",
+            "delegate_report_handoff": "When the delegate prints a JSON report to stdout, parse that JSON directly instead of relying only on sidecar-report file path discovery.",
+            "dry_run_semantics": "If wrapper dry-run short-circuits before delegate execution, keep execution.delegated=false and report partial honestly. If wrapper does delegate under dry-run, pass through --dry-run explicitly."
+          }
+        }
+      },
+      "expected_outputs": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ],
+      "constraints": [
+        "Follow the local inbox normalized request",
+        "Do not claim unsupported runtime dependencies",
+        "Keep output deterministic and executable",
+        "Produce only the expected script artifact",
+        "Prefer honest, reviewable intermediate behavior over unsupported OCR claims",
+        "If the requested output path ends with .xlsx, do not write non-XLSX text/XML/CSV content to that path.",
+        "Do not hardcode an input directory when the task params already provide input_dir.",
+        "Preserve meaningful traceability from the incoming description instead of collapsing it to a heading fragment.",
+        "Prefer wrapping or adapting artifacts/scripts/pdf_to_excel_ocr.py when that existing repo script already matches the requested behavior.",
+        "When artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py already exists, prefer updating that reviewed wrapper baseline instead of rewriting a new control flow from scratch.",
+        "If dry_run is true or no PDFs are discovered, report a reviewable partial outcome instead of claiming success without an XLSX artifact.",
+        "Resolve relative delegate script paths from the repository or script location, not from Path.cwd().",
+        "For readonly reviewable preview flows, only delegate to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py unless failing honestly.",
+        "Do not claim wrapper success from exit code plus output existence alone when the reviewed delegate report does not provide strong enough success evidence.",
+        "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
+        "When delegate emits JSON to stdout, parse that report directly instead of depending only on sidecar report-file discovery.",
+        "If wrapper supports dry-run short-circuit semantics, keep execution.delegated=false and preserve partial status honestly.",
+        "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely."
+      ],
+      "priority": "medium",
+      "source": {
+        "kind": "local_inbox",
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl029-001.json",
+        "received_at": "2026-03-25T01:51:34.187455Z",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "regeneration_token": "regen-20260325-bl029-001"
+      },
+      "acceptance_criteria": [
+        "Produce the expected script artifact at expected_outputs[0].path",
+        "Script behavior remains runnable, deterministic, and reviewable",
+        "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
+        "Artifact behavior remains parameter-driven for input_dir and output_xlsx rather than hardcoding unrelated local defaults.",
+        "Dry-run or zero-input behavior is represented as a reviewable partial outcome instead of artifact-production success.",
+        "Relative preferred_base_script resolution remains portable and does not depend on Path.cwd().",
+        "Wrapper success requires stronger delegate evidence than zero exit code plus a non-empty output file alone.",
+        "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
+        "Delegate report handoff can consume JSON printed to stdout without relying exclusively on report sidecar file discovery.",
+        "Dry-run semantics remain explicit: short-circuit stays partial with no delegated execution, or delegated dry-run is passed through honestly.",
+        "Delegate execution is bounded by an explicit timeout and reports timeout honestly."
+      ],
+      "metadata": {
+        "integration_phase": "8B",
+        "pipeline": "inbox->adapter->manager->automation->critic",
+        "request_type": "pdf_to_excel_ocr",
+        "payload_hash": "ab85bf08e44d3e7f05c017310441410e4bf8db6291535cdb3c113e713fccc59e",
+        "regeneration_token": "regen-20260325-bl029-001",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "external_metadata": {
+          "source_system": "trello",
+          "card_id": "69c24cd3c1a2359ddd7a1bf8",
+          "card_short_id": 7,
+          "board_id": "69be462743bfa0038ca10f7a",
+          "list_id": "69be462743bfa0038ca10f8f",
+          "date_last_activity": "2026-03-24T08:35:56.234Z",
+          "readonly_mapped_at": "2026-03-25T01:51:22.186443Z",
+          "contract_profile": "best_effort_evidence_backed",
+          "ocr_claim_policy": "do_not_claim_success_without_evidence",
+          "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+          "regeneration_token": "regen-20260325-bl029-001"
+        },
+        "automation_contract_profile": "narrow_script_artifact_with_repo_reuse_and_reviewable_runner_contract"
+      }
+    },
+    "critic": {
+      "task_id": "CRITIC-20260325-276",
+      "worker": "critic",
+      "task_type": "review_artifact",
+      "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+      "inputs": {
+        "artifacts": [
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "type": "script"
+          },
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+            "type": "script"
+          }
+        ],
+        "params": {
+          "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+          "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+          "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+          "labels": [
+            "best_effort",
+            "evidence_backed",
+            "readonly",
+            "reviewable",
+            "trello"
+          ],
+          "review_scope": {
+            "primary_artifact": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "paired_artifacts": [
+              "artifacts/scripts/pdf_to_excel_ocr.py"
+            ],
+            "goal": "Audit the wrapper and the reviewed delegate together so the review evidence can speak to the end-to-end readonly smoke path."
+          }
+        }
+      },
+      "expected_outputs": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ],
+      "constraints": [
+        "Review must be grounded in produced automation artifact",
+        "When both wrapper and reviewed delegate snapshots are supplied, evaluate them as one end-to-end readonly pair instead of ignoring the delegate evidence.",
+        "Do not invent missing artifact content",
+        "Return a clear verdict: pass, fail, or needs_revision",
+        "Include metadata.verdict in output",
+        "Generate review artifact markdown for expected_outputs[0].path"
+      ],
+      "priority": "medium",
+      "source": {
+        "kind": "local_inbox",
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl029-001.json",
+        "received_at": "2026-03-25T01:51:34.187455Z",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "regeneration_token": "regen-20260325-bl029-001"
+      },
+      "acceptance_criteria": [
+        "Produce a review artifact with explicit verdict (pass/fail/needs_revision)"
+      ],
+      "metadata": {
+        "integration_phase": "8B",
+        "pipeline": "inbox->adapter->manager->automation->critic",
+        "request_type": "pdf_to_excel_ocr",
+        "payload_hash": "ab85bf08e44d3e7f05c017310441410e4bf8db6291535cdb3c113e713fccc59e",
+        "regeneration_token": "regen-20260325-bl029-001",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "external_metadata": {
+          "source_system": "trello",
+          "card_id": "69c24cd3c1a2359ddd7a1bf8",
+          "card_short_id": 7,
+          "board_id": "69be462743bfa0038ca10f7a",
+          "list_id": "69be462743bfa0038ca10f8f",
+          "date_last_activity": "2026-03-24T08:35:56.234Z",
+          "readonly_mapped_at": "2026-03-25T01:51:22.186443Z",
+          "contract_profile": "best_effort_evidence_backed",
+          "ocr_claim_policy": "do_not_claim_success_without_evidence",
+          "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+          "regeneration_token": "regen-20260325-bl029-001"
+        }
+      }
+    }
+  },
+  "expected_artifacts": [
+    "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+    "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py"
+  ],
+  "dedupe_keys": [
+    "origin_regeneration:trello:69c24cd3c1a2359ddd7a1bf8:regen-20260325-bl029-001",
+    "hash:ab85bf08e44d3e7f05c017310441410e4bf8db6291535cdb3c113e713fccc59e"
+  ],
+  "risk_warnings": [],
+  "execution": {
+    "status": "rejected",
+    "executed": true,
+    "attempts": 1,
+    "executed_at": "2026-03-25T01:54:13.535846Z",
+    "decision_reason": "critic_verdict=needs_revision"
+  },
+  "approval": {
+    "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-ab85bf08e44d.json",
+    "approved_by": "Oscarling",
+    "approved_at": "2026-03-25T01:52:18.458674Z",
+    "note": "BL-20260325-029 governed validation execute only; no Git finalization; no Trello Done."
+  },
+  "last_execution": {
+    "decision": "rejected",
+    "decision_reason": "critic_verdict=needs_revision",
+    "automation_result": {
+      "task_id": "AUTO-20260325-855",
+      "worker": "automation",
+      "status": "success",
+      "summary": "Generated exactly one runnable helper wrapper script artifact that reuses the reviewed pdf_to_excel_ocr.py delegate, preserves parameter-driven input/output behavior, uses explicit timeout control, parses delegate JSON from stdout or sidecar report, and applies reviewable success/partial/failed evidence rules.",
+      "artifacts": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ],
+      "timestamp": "2026-03-25T01:53:38.846608Z",
+      "duration_ms": 65711,
+      "notes": [
+        "The artifact is provided as file contents for the expected path only.",
+        "The wrapper is designed to preserve true XLSX semantics by delegating workbook creation to the reviewed base script and failing honestly when evidence is insufficient.",
+        "Dry-run and zero-PDF discovery resolve to partial outcomes."
+      ],
+      "metadata": {
+        "task_id": "AUTO-20260325-855",
+        "worker": "automation",
+        "objective": "generate_script",
+        "generated_files": 1
+      }
+    },
+    "critic_result": {
+      "task_id": "CRITIC-20260325-276",
+      "worker": "critic",
+      "status": "success",
+      "summary": "Reviewed the inbox runner and paired delegate together as an end-to-end readonly smoke path. The pair is generally aligned with the best-effort/evidence-backed contract, but the wrapper assumes delegate support for --report-json that the reviewed delegate does not implement, creating a real integration defect that can cause wrapper-reported failure even when the delegate otherwise works. Verdict: needs_revision.",
+      "artifacts": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ],
+      "timestamp": "2026-03-25T01:54:13.394469Z",
+      "duration_ms": 34158,
+      "notes": [
+        "Review grounded in provided artifact snapshots for both scripts.",
+        "Scope evaluated as wrapper + delegate pair, not as isolated files.",
+        "Review artifact content is included in file_contents."
+      ],
+      "metadata": {
+        "task_id": "CRITIC-20260325-276",
+        "worker": "critic",
+        "verdict": "needs_revision",
+        "reviewed_artifacts": [
+          "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "artifacts/scripts/pdf_to_excel_ocr.py"
+        ]
+      }
+    },
+    "critic_verdict": "needs_revision"
+  }
+}

--- a/runtime_archives/bl029/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-ab85bf08e44d.result.json
+++ b/runtime_archives/bl029/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-ab85bf08e44d.result.json
@@ -1,0 +1,9 @@
+{
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-ab85bf08e44d",
+  "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-ab85bf08e44d.json",
+  "executed_at": "2026-03-25T01:54:13.536291Z",
+  "status": "rejected",
+  "decision_reason": "critic_verdict=needs_revision",
+  "critic_verdict": "needs_revision",
+  "test_mode": "off"
+}

--- a/runtime_archives/bl029/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl029-001.json
+++ b/runtime_archives/bl029/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl029-001.json
@@ -1,0 +1,39 @@
+{
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "metadata": {
+    "source_system": "trello",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "card_short_id": 7,
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "date_last_activity": "2026-03-24T08:35:56.234Z",
+    "readonly_mapped_at": "2026-03-25T01:51:22.186443Z",
+    "contract_profile": "best_effort_evidence_backed",
+    "ocr_claim_policy": "do_not_claim_success_without_evidence",
+    "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable"
+  },
+  "source": {
+    "provider": "trello",
+    "mode": "readonly",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "regeneration_token": "regen-20260325-bl029-001"
+  },
+  "request_type": "pdf_to_excel_ocr",
+  "input": {
+    "input_dir": "~/Desktop/pdf样本",
+    "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+    "ocr": "auto",
+    "dry_run": false
+  }
+}

--- a/runtime_archives/bl029/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl029-001.json.result.json
+++ b/runtime_archives/bl029/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl029-001.json.result.json
@@ -1,0 +1,23 @@
+{
+  "ingested_at": "2026-03-25T01:51:34.188256Z",
+  "status": "processed",
+  "decision": "preview_created_pending_approval",
+  "decision_reason": "preview_created; waiting_for_explicit_approval",
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "payload_hash": "ab85bf08e44d3e7f05c017310441410e4bf8db6291535cdb3c113e713fccc59e",
+  "dedupe_keys": [
+    "origin_regeneration:trello:69c24cd3c1a2359ddd7a1bf8:regen-20260325-bl029-001",
+    "hash:ab85bf08e44d3e7f05c017310441410e4bf8db6291535cdb3c113e713fccc59e"
+  ],
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-ab85bf08e44d",
+  "preview_file": "/Users/lingguozhong/openclaw-team/preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-ab85bf08e44d.json",
+  "regeneration_token": "regen-20260325-bl029-001"
+}

--- a/runtime_archives/bl029/tmp/bl029_live_mapped_preview.json
+++ b/runtime_archives/bl029/tmp/bl029_live_mapped_preview.json
@@ -1,0 +1,39 @@
+{
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "metadata": {
+    "source_system": "trello",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "card_short_id": 7,
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "date_last_activity": "2026-03-24T08:35:56.234Z",
+    "readonly_mapped_at": "2026-03-25T01:51:22.186443Z",
+    "contract_profile": "best_effort_evidence_backed",
+    "ocr_claim_policy": "do_not_claim_success_without_evidence",
+    "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable"
+  },
+  "source": {
+    "provider": "trello",
+    "mode": "readonly",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "regeneration_token": "regen-20260325-bl029-001"
+  },
+  "request_type": "pdf_to_excel_ocr",
+  "input": {
+    "input_dir": "~/Desktop/pdf样本",
+    "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+    "ocr": "auto",
+    "dry_run": false
+  }
+}

--- a/runtime_archives/bl029/tmp/bl029_smoke_result.json
+++ b/runtime_archives/bl029/tmp/bl029_smoke_result.json
@@ -1,0 +1,64 @@
+{
+  "status": "pass",
+  "read_count": 1,
+  "scope": {
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": null
+  },
+  "scope_kind": "board",
+  "mapped_preview": {
+    "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+    "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+    "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+    "labels": [
+      "best_effort",
+      "evidence_backed",
+      "readonly",
+      "reviewable",
+      "trello"
+    ],
+    "metadata": {
+      "source_system": "trello",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "card_short_id": 7,
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "date_last_activity": "2026-03-24T08:35:56.234Z",
+      "readonly_mapped_at": "2026-03-25T01:51:22.186443Z",
+      "contract_profile": "best_effort_evidence_backed",
+      "ocr_claim_policy": "do_not_claim_success_without_evidence",
+      "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable"
+    },
+    "source": {
+      "provider": "trello",
+      "mode": "readonly",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "regeneration_token": "regen-20260325-bl029-001"
+    },
+    "request_type": "pdf_to_excel_ocr",
+    "input": {
+      "input_dir": "~/Desktop/pdf样本",
+      "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+      "ocr": "auto",
+      "dry_run": false
+    }
+  },
+  "auth_env": {
+    "selected_names": {
+      "key": "TRELLO_API_KEY",
+      "token": "TRELLO_API_TOKEN"
+    },
+    "priority": "TRELLO_API_* first, fallback to TRELLO_*",
+    "presence": {
+      "TRELLO_API_KEY": "set",
+      "TRELLO_KEY": "set",
+      "TRELLO_API_TOKEN": "set",
+      "TRELLO_TOKEN": "set",
+      "TRELLO_BOARD_ID": "set",
+      "TRELLO_LIST_ID": "missing"
+    }
+  },
+  "note": "Read-only GET only. No write operations performed."
+}


### PR DESCRIPTION
## Summary
- add POST_CONTRACT_ALIGNMENT_VALIDATION_REPORT.md to close BL-20260325-029 with governed run evidence
- archive BL-029 runtime artifacts logs and state under runtime_archives/bl029
- restore tracked generated artifacts to baseline and update backlog/work log
- add follow-up blocker BL-20260325-030 for wrapper/delegate --report-json CLI mismatch

## Validation
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh
- git diff --check

Closes #51