### PR TITLE
BL-030: align delegate report-json CLI handoff

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -554,8 +554,8 @@ Allowed enum values:
 ### BL-20260325-030
 - title: Fix wrapper/delegate report-handoff CLI mismatch exposed by BL-20260325-029
 - type: blocker
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-029
@@ -563,7 +563,24 @@ Allowed enum values:
 - done_when: Wrapper/delegate integration no longer passes unsupported CLI arguments, evidence handoff remains reviewable and deterministic (stdout JSON and/or sidecar path contract clearly aligned), focused tests cover the agreed contract, and one phase report records the implementation outcome
 - source: `POST_CONTRACT_ALIGNMENT_VALIDATION_REPORT.md` on 2026-03-25 confirms the post-BL-20260325-028 governed run still fails review because wrapper and delegate report-handoff CLI contracts are incompatible
 - link: /Users/lingguozhong/openclaw-team/RUNNER_DELEGATE_CLI_ALIGNMENT_FIX_REPORT.md
-- issue: deferred:phase=next until BL-20260325-029 lands on main
+- issue: https://github.com/Oscarling/openclaw-team/issues/53
+- evidence: `RUNNER_DELEGATE_CLI_ALIGNMENT_FIX_REPORT.md` records the delegate-side compatibility fix that adds optional `--report-json` support to `artifacts/scripts/pdf_to_excel_ocr.py`, unifies report emission via `emit_report(...)` across success/failure paths, adds focused regressions in `tests/test_pdf_to_excel_ocr_delegate.py`, and updates usage documentation so wrapper/delegate report handoff no longer relies on an undeclared CLI argument
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-031
+- title: Validate BL-20260325-030 CLI alignment on a fresh same-origin governed candidate
+- type: mainline
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-030
+- start_when: `BL-20260325-030` is merged so a fresh same-origin governed run can verify whether the delegate-side CLI alignment removes the remaining wrapper/delegate report-handoff rejection pattern under real execute
+- done_when: One governed validation creates a fresh same-origin preview candidate after BL-20260325-030, runs one explicit approval plus one real execute, and records whether automation/critic outcome now clears the `--report-json` compatibility blocker isolated in BL-20260325-029
+- source: `RUNNER_DELEGATE_CLI_ALIGNMENT_FIX_REPORT.md` on 2026-03-25 concludes the next required step is governed runtime validation rather than assuming source-side fix success without live evidence
+- link: /Users/lingguozhong/openclaw-team/POST_CLI_ALIGNMENT_VALIDATION_REPORT.md
+- issue: deferred:phase=next until BL-20260325-030 lands on main
 - evidence: -
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -1065,6 +1065,47 @@ Verification snapshot on 2026-03-25:
   - `runtime_archives/bl029/state/`
   - `runtime_archives/bl029/tmp/`
 
+### 38. Delegate CLI Alignment Fix For Report-Handoff Compatibility
+
+User objective:
+
+- continue immediately after `BL-20260325-029` without losing SDLC cadence
+- fix the confirmed wrapper/delegate CLI mismatch around `--report-json`
+- keep the fix minimal, test-backed, and explicitly documented
+
+Main work areas:
+
+- activated `BL-20260325-030` and mirrored it to GitHub issue `#53`
+- updated reviewed delegate script `artifacts/scripts/pdf_to_excel_ocr.py` to:
+  - accept optional `--report-json`
+  - preserve stdout JSON output
+  - write the same JSON report to sidecar path when provided
+  - emit reports consistently for discovery failure, empty input, dry-run,
+    normal success, and write failure paths
+- added focused regression coverage:
+  - `tests/test_pdf_to_excel_ocr_delegate.py`
+  - verifies sidecar report creation and stdout/sidecar parity for dry-run and
+    write-failure flows
+- updated usage documentation:
+  - `artifacts/docs/pdf_to_excel_ocr_usage.md`
+- recorded the next governed validation phase as `BL-20260325-031`
+
+Primary output:
+
+- [RUNNER_DELEGATE_CLI_ALIGNMENT_FIX_REPORT.md](/Users/lingguozhong/openclaw-team/RUNNER_DELEGATE_CLI_ALIGNMENT_FIX_REPORT.md)
+
+Key result:
+
+- the reviewed delegate no longer rejects wrappers that pass `--report-json`
+- report handoff is now explicit and deterministic at the delegate boundary
+- this phase is a source-side fix phase; live governed runtime validation is
+  intentionally deferred to `BL-20260325-031`
+
+Verification snapshot on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_delegate.py` passed
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py` passed
+
 ### 31. Post-Timeout Governed Validation On Fresh Same-Origin Candidate
 
 User objective:

--- a/RUNNER_DELEGATE_CLI_ALIGNMENT_FIX_REPORT.md
+++ b/RUNNER_DELEGATE_CLI_ALIGNMENT_FIX_REPORT.md
@@ -1,0 +1,82 @@
+# Runner Delegate CLI Alignment Fix Report
+
+## Objective
+
+Complete `BL-20260325-030` by removing the wrapper/delegate CLI contract drift
+identified in `BL-20260325-029`, where generated wrappers could pass
+`--report-json` while the reviewed delegate did not accept that argument.
+
+## Scope
+
+In scope:
+
+- harden reviewed delegate CLI compatibility for report handoff
+- ensure report emission remains deterministic and reviewable
+- add focused regression coverage for `--report-json` behavior
+
+Out of scope:
+
+- fresh governed live Trello validation run
+- changes to preview/approval governance policy
+- git finalization / Trello Done writeback
+
+## Changes
+
+### 1) Added optional `--report-json` to reviewed delegate
+
+Updated `artifacts/scripts/pdf_to_excel_ocr.py`:
+
+- parse new optional argument:
+  - `--report-json <path>`
+- keep stdout JSON behavior unchanged
+- write the same JSON payload to sidecar path when provided
+
+This makes the reviewed delegate CLI-compatible with wrappers that include
+`--report-json`.
+
+### 2) Unified report emission across all delegate exit paths
+
+Introduced `emit_report(...)` in `artifacts/scripts/pdf_to_excel_ocr.py` and
+used it for:
+
+- discovery failure path
+- empty-input failure path
+- dry-run success path
+- normal success path
+- write failure path
+
+Result: sidecar report output is deterministic wherever a JSON report is
+already emitted to stdout.
+
+### 3) Added focused regression tests
+
+Added `tests/test_pdf_to_excel_ocr_delegate.py`:
+
+- `test_report_json_is_written_for_dry_run`
+- `test_report_json_is_written_on_write_failure`
+
+These verify stdout and sidecar parity and confirm compatibility behavior under
+both success-like and failure-like paths.
+
+### 4) Updated usage documentation
+
+Updated `artifacts/docs/pdf_to_excel_ocr_usage.md` to document:
+
+- `--report-json` argument and semantics
+
+## Verification
+
+Passed on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_delegate.py`
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py`
+
+## Conclusion
+
+`BL-20260325-030` can be treated as complete as a source-side contract fix
+phase.
+
+The reviewed delegate now accepts `--report-json`, removing the specific CLI
+mismatch found in `BL-20260325-029`. The next correct step is a fresh governed
+validation run on a same-origin regenerated candidate to confirm the runtime
+outcome end-to-end under the aligned contract.

--- a/artifacts/docs/pdf_to_excel_ocr_usage.md
+++ b/artifacts/docs/pdf_to_excel_ocr_usage.md
@@ -32,6 +32,7 @@ python3 artifacts/scripts/pdf_to_excel_ocr.py \
   - `on`: force OCR path.
   - `off`: do not invoke OCR.
 - `--dry-run`: no Excel file write, prints summary only.
+- `--report-json`: optional sidecar JSON output path. Writes the same report emitted to stdout.
 
 ## OCR Dependency Prerequisites
 - Python packages:

--- a/artifacts/scripts/pdf_to_excel_ocr.py
+++ b/artifacts/scripts/pdf_to_excel_ocr.py
@@ -80,6 +80,11 @@ def parse_args() -> argparse.Namespace:
         default=50,
         help="In auto mode, run OCR when extracted text chars < this threshold.",
     )
+    parser.add_argument(
+        "--report-json",
+        default="",
+        help="Optional sidecar path for writing the same JSON report emitted to stdout.",
+    )
     return parser.parse_args()
 
 
@@ -239,6 +244,16 @@ def write_excel(results: list[FileResult], output_xlsx: Path) -> None:
         detail_df.to_excel(writer, sheet_name="files", index=False)
 
 
+def emit_report(report: dict[str, Any], report_json: str) -> None:
+    rendered = json.dumps(report, ensure_ascii=False, indent=2)
+    print(rendered)
+    if not report_json:
+        return
+    out_path = Path(report_json).expanduser().resolve()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(rendered + "\n", encoding="utf-8")
+
+
 def main() -> int:
     args = parse_args()
     input_dir = Path(args.input_dir).expanduser().resolve()
@@ -247,19 +262,16 @@ def main() -> int:
     try:
         pdf_files = discover_pdfs(input_dir)
     except Exception as e:
-        print(json.dumps({"status": "failed", "error": str(e)}, ensure_ascii=False, indent=2))
+        emit_report({"status": "failed", "error": str(e)}, args.report_json)
         return 2
 
     if not pdf_files:
-        print(
-            json.dumps(
-                {
-                    "status": "failed",
-                    "error": f"No PDF files found under {input_dir}",
-                },
-                ensure_ascii=False,
-                indent=2,
-            )
+        emit_report(
+            {
+                "status": "failed",
+                "error": f"No PDF files found under {input_dir}",
+            },
+            args.report_json,
         )
         return 2
 
@@ -307,17 +319,17 @@ def main() -> int:
     }
 
     if args.dry_run:
-        print(json.dumps(report, ensure_ascii=False, indent=2))
+        emit_report(report, args.report_json)
         return 0
 
     try:
         write_excel(results, output_xlsx)
-        print(json.dumps(report, ensure_ascii=False, indent=2))
+        emit_report(report, args.report_json)
         return 0
     except Exception as e:
         report["status"] = "failed"
         report["error"] = str(e)
-        print(json.dumps(report, ensure_ascii=False, indent=2))
+        emit_report(report, args.report_json)
         return 3
 
 

--- a/tests/test_pdf_to_excel_ocr_delegate.py
+++ b/tests/test_pdf_to_excel_ocr_delegate.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DELEGATE_PATH = REPO_ROOT / "artifacts" / "scripts" / "pdf_to_excel_ocr.py"
+
+
+def load_delegate_module():
+    module_name = "pdf_to_excel_ocr"
+    spec = importlib.util.spec_from_file_location(module_name, DELEGATE_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load delegate module from {DELEGATE_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class PdfToExcelOcrDelegateTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.delegate = load_delegate_module()
+
+    def setUp(self) -> None:
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="pdf-to-excel-ocr-delegate-"))
+        self.input_dir = self.tmpdir / "input"
+        self.input_dir.mkdir(parents=True, exist_ok=True)
+        self.output_xlsx = self.tmpdir / "output.xlsx"
+        self.report_json = self.tmpdir / "report.json"
+        self.fake_pdf = self.input_dir / "sample.pdf"
+        self.fake_pdf.write_bytes(b"%PDF-1.4\n% test fixture\n")
+
+    def _invoke_main(self, extra_args: list[str] | None = None) -> tuple[int, dict[str, object], dict[str, object]]:
+        argv = [
+            "pdf_to_excel_ocr.py",
+            "--input-dir",
+            str(self.input_dir),
+            "--output-xlsx",
+            str(self.output_xlsx),
+            "--report-json",
+            str(self.report_json),
+        ]
+        if extra_args:
+            argv.extend(extra_args)
+
+        stdout = io.StringIO()
+        with mock.patch.object(sys, "argv", argv), contextlib.redirect_stdout(stdout):
+            exit_code = self.delegate.main()
+
+        stdout_payload = json.loads(stdout.getvalue())
+        sidecar_payload = json.loads(self.report_json.read_text(encoding="utf-8"))
+        return exit_code, stdout_payload, sidecar_payload
+
+    def _mock_file_result(self, *, status: str = "success"):
+        return self.delegate.FileResult(
+            file_name="sample.pdf",
+            file_path=str(self.fake_pdf),
+            status=status,
+            extract_method="text",
+            page_count=1,
+            text_chars=12,
+            text_preview="hello world",
+            warnings="",
+            error="",
+        )
+
+    def test_report_json_is_written_for_dry_run(self) -> None:
+        with mock.patch.object(self.delegate, "discover_pdfs", return_value=[self.fake_pdf]), mock.patch.object(
+            self.delegate, "process_one_pdf", return_value=self._mock_file_result(status="success")
+        ):
+            exit_code, stdout_payload, sidecar_payload = self._invoke_main(extra_args=["--dry-run"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertTrue(self.report_json.exists())
+        self.assertEqual(stdout_payload, sidecar_payload)
+        self.assertEqual(sidecar_payload["status"], "success")
+        self.assertEqual(sidecar_payload["total_files"], 1)
+        self.assertEqual(sidecar_payload["dry_run"], True)
+
+    def test_report_json_is_written_on_write_failure(self) -> None:
+        with mock.patch.object(self.delegate, "discover_pdfs", return_value=[self.fake_pdf]), mock.patch.object(
+            self.delegate, "process_one_pdf", return_value=self._mock_file_result(status="success")
+        ), mock.patch.object(self.delegate, "write_excel", side_effect=RuntimeError("xlsx write failed")):
+            exit_code, stdout_payload, sidecar_payload = self._invoke_main()
+
+        self.assertEqual(exit_code, 3)
+        self.assertTrue(self.report_json.exists())
+        self.assertEqual(stdout_payload, sidecar_payload)
+        self.assertEqual(sidecar_payload["status"], "failed")
+        self.assertIn("xlsx write failed", str(sidecar_payload.get("error")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add optional --report-json support to artifacts/scripts/pdf_to_excel_ocr.py
- unify delegate JSON emission via emit_report so stdout and sidecar stay consistent across success/failure paths
- add focused regressions in tests/test_pdf_to_excel_ocr_delegate.py
- update BL-030 closure docs/backlog/work log and open next validation item BL-20260325-031

## Validation
- python3 -m unittest -v tests/test_pdf_to_excel_ocr_delegate.py
- python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh
- git diff --check

Closes #53