### PR TITLE
BL-032: harden wrapper report-flag and discovery contract

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -588,8 +588,8 @@ Allowed enum values:
 ### BL-20260325-032
 - title: Re-align generated wrapper report-handoff flag and discovery contract after BL-20260325-031
 - type: blocker
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-031
@@ -597,7 +597,24 @@ Allowed enum values:
 - done_when: Source-side/runtime contract hardening prevents wrapper-side report-flag drift against reviewed delegate CLI, wrapper/delegate PDF discovery semantics are aligned or explicitly justified in contract/tests, and one phase report records the implementation outcome with focused regressions
 - source: `POST_CLI_ALIGNMENT_VALIDATION_REPORT.md` on 2026-03-25 confirms the fresh governed validation after BL-20260325-030 still yields `needs_revision` due wrapper-side report-handoff drift and discovery inconsistency
 - link: /Users/lingguozhong/openclaw-team/WRAPPER_DELEGATE_REPORT_FLAG_REALIGNMENT_REPORT.md
-- issue: deferred:phase=next until BL-20260325-031 lands on main
+- issue: https://github.com/Oscarling/openclaw-team/issues/57
+- evidence: `WRAPPER_DELEGATE_REPORT_FLAG_REALIGNMENT_REPORT.md` records source-side hardening in `adapters/local_inbox_adapter.py` that adds explicit report-flag contract guidance (`--report-json` vs undeclared aliases), wrapper/delegate discovery-consistency guidance, and matching constraint/acceptance gates, with focused regression updates in `tests/test_local_inbox_adapter.py`
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-033
+- title: Validate BL-20260325-032 report-flag and discovery hardening on a fresh same-origin governed candidate
+- type: mainline
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-032
+- start_when: `BL-20260325-032` is merged so a fresh same-origin governed run can verify whether strengthened source-side contract guidance now prevents wrapper report-flag drift and discovery inconsistency under real execute
+- done_when: One governed validation creates a fresh same-origin preview candidate after BL-20260325-032, runs one explicit approval plus one real execute, and records whether automation/critic outcome now clears the `--report-file` vs `--report-json` and discovery-alignment findings observed in BL-20260325-031
+- source: `WRAPPER_DELEGATE_REPORT_FLAG_REALIGNMENT_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation rather than assuming source-side contract hardening success without live evidence
+- link: /Users/lingguozhong/openclaw-team/POST_REPORT_FLAG_REALIGNMENT_VALIDATION_REPORT.md
+- issue: deferred:phase=next until BL-20260325-032 lands on main
 - evidence: -
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -1172,6 +1172,51 @@ Verification snapshot on 2026-03-25:
   - `runtime_archives/bl031/state/`
   - `runtime_archives/bl031/tmp/`
 
+### 40. Source-Side Realignment After BL-031 Runtime Findings
+
+User objective:
+
+- continue after `BL-20260325-031` without mixing a new live validation into
+  the same phase
+- harden source-side contract rules so generated wrappers stop drifting on
+  delegate report-flag usage and discovery semantics
+- keep phase closure backlog-first and test-backed
+
+Main work areas:
+
+- activated `BL-20260325-032` and mirrored it to GitHub issue `#57`
+- updated `adapters/local_inbox_adapter.py` automation contract guidance with:
+  - explicit report-flag compatibility requirement (`--report-json`, no
+    undeclared `--report-file` drift)
+  - wrapper/delegate PDF discovery consistency requirement
+- strengthened automation constraints and acceptance criteria to make both rules
+  gate-visible at source
+- updated `tests/test_local_inbox_adapter.py` assertions for:
+  - new contract hints
+  - new constraints
+  - new acceptance criteria
+- recorded next runtime verification phase as `BL-20260325-033`
+
+Primary output:
+
+- [WRAPPER_DELEGATE_REPORT_FLAG_REALIGNMENT_REPORT.md](/Users/lingguozhong/openclaw-team/WRAPPER_DELEGATE_REPORT_FLAG_REALIGNMENT_REPORT.md)
+
+Key result:
+
+- `BL-20260325-032` completed as a source-side hardening phase
+- source contract now explicitly targets the exact drift pattern observed in
+  `BL-20260325-031`
+- this phase does not claim runtime closure; it prepares the next fresh governed
+  validation phase (`BL-20260325-033`)
+
+Verification snapshot on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_local_inbox_adapter.py` passed
+- `python3 -m unittest -v tests/test_trello_readonly_ingress.py` passed
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed with `BL-20260325-032` mirrored to
+  issue `#57`
+
 ### 31. Post-Timeout Governed Validation On Fresh Same-Origin Candidate
 
 User objective:

--- a/WRAPPER_DELEGATE_REPORT_FLAG_REALIGNMENT_REPORT.md
+++ b/WRAPPER_DELEGATE_REPORT_FLAG_REALIGNMENT_REPORT.md
@@ -1,0 +1,84 @@
+# Wrapper Delegate Report-Flag Realignment Report
+
+## Objective
+
+Complete `BL-20260325-032` by hardening source-side generation contract rules so
+future generated wrappers are less likely to drift from reviewed delegate CLI
+report-handoff semantics and discovery behavior.
+
+## Scope
+
+In scope:
+
+- tighten local inbox automation contract hints/constraints/acceptance criteria
+- encode explicit report-flag compatibility requirements
+- encode wrapper/delegate PDF discovery consistency requirements
+- add/update focused regression coverage
+
+Out of scope:
+
+- fresh governed live Trello validation run
+- branch-protection or governance policy changes
+- git finalization / Trello Done writeback
+
+## Changes
+
+### 1) Added explicit report-flag compatibility guidance
+
+Updated `adapters/local_inbox_adapter.py` contract hints with:
+
+- `delegate_report_flag_contract`:
+  requires using reviewed delegate flag `--report-json` (or explicitly
+  supported alias), and explicitly warns against undeclared drift such as
+  `--report-file`.
+
+### 2) Added explicit discovery-consistency guidance
+
+Updated contract hints with:
+
+- `pdf_discovery_consistency`:
+  wrapper preflight PDF discovery semantics must align with delegate discovery
+  semantics (for example recursive vs non-recursive) to keep evidence counts
+  consistent.
+
+### 3) Strengthened constraints and acceptance criteria
+
+Updated automation constraints to require:
+
+- report sidecar handoff uses `--report-json` unless reviewed delegate supports
+  another alias
+- wrapper/delegate discovery semantics remain aligned
+
+Updated acceptance criteria to require:
+
+- wrapper/delegate sidecar handoff remains CLI-compatible with reviewed delegate
+  flag contract
+- wrapper preflight and delegate discovery semantics remain aligned
+
+### 4) Focused regression update
+
+Updated `tests/test_local_inbox_adapter.py` assertions to verify:
+
+- new contract hints
+  (`delegate_report_flag_contract`, `pdf_discovery_consistency`)
+- new constraints for report-flag and discovery alignment
+- new acceptance criteria for report-flag compatibility and discovery parity
+
+## Verification
+
+Passed on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_local_inbox_adapter.py`
+- `python3 -m unittest -v tests/test_trello_readonly_ingress.py`
+- `python3 scripts/backlog_lint.py`
+- `python3 scripts/backlog_sync.py`
+
+## Conclusion
+
+`BL-20260325-032` can be treated as complete as a source-side hardening phase.
+
+The contract now explicitly blocks the specific wrapper report-flag drift seen
+in `BL-20260325-031` and adds discovery-consistency guardrails.
+
+Next required step: one fresh same-origin governed validation run to verify
+runtime artifact generation and critic outcomes under the strengthened contract.

--- a/adapters/local_inbox_adapter.py
+++ b/adapters/local_inbox_adapter.py
@@ -348,10 +348,21 @@ def normalize_local_inbox_payload(
                         "When the delegate prints a JSON report to stdout, parse that JSON "
                         "directly instead of relying only on sidecar-report file path discovery."
                     ),
+                    "delegate_report_flag_contract": (
+                        "If wrapper passes a sidecar report path to the reviewed delegate, "
+                        "use the reviewed delegate CLI flag --report-json (or another "
+                        "explicitly supported alias). Do not invent undeclared flags such "
+                        "as --report-file."
+                    ),
                     "dry_run_semantics": (
                         "If wrapper dry-run short-circuits before delegate execution, keep "
                         "execution.delegated=false and report partial honestly. If wrapper "
                         "does delegate under dry-run, pass through --dry-run explicitly."
+                    ),
+                    "pdf_discovery_consistency": (
+                        "Keep wrapper preflight PDF discovery semantics aligned with the "
+                        "reviewed delegate (for example recursive vs non-recursive), so "
+                        "wrapper evidence and delegated execution count the same candidate set."
                     ),
                 },
             }
@@ -376,7 +387,9 @@ def normalize_local_inbox_payload(
             "Do not claim wrapper success from exit code plus output existence alone when the reviewed delegate report does not provide strong enough success evidence.",
             "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
             "When delegate emits JSON to stdout, parse that report directly instead of depending only on sidecar report-file discovery.",
+            "When wrapper passes a sidecar report path to the reviewed delegate, use --report-json exactly unless the reviewed delegate explicitly supports another alias.",
             "If wrapper supports dry-run short-circuit semantics, keep execution.delegated=false and preserve partial status honestly.",
+            "Keep wrapper PDF discovery semantics aligned with reviewed delegate discovery semantics to avoid preflight/execution evidence drift.",
             "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely.",
         ],
         "priority": priority,
@@ -391,7 +404,9 @@ def normalize_local_inbox_payload(
             "Wrapper success requires stronger delegate evidence than zero exit code plus a non-empty output file alone.",
             "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
             "Delegate report handoff can consume JSON printed to stdout without relying exclusively on report sidecar file discovery.",
+            "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",
             "Dry-run semantics remain explicit: short-circuit stays partial with no delegated execution, or delegated dry-run is passed through honestly.",
+            "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
             "Delegate execution is bounded by an explicit timeout and reports timeout honestly.",
         ],
         "metadata": {

--- a/tests/test_local_inbox_adapter.py
+++ b/tests/test_local_inbox_adapter.py
@@ -111,8 +111,20 @@ Execution contract: treat this as a best-effort, evidence-backed PDF extraction/
             contract_hints["delegate_report_handoff"],
         )
         self.assertIn(
+            "--report-json",
+            contract_hints["delegate_report_flag_contract"],
+        )
+        self.assertIn(
+            "--report-file",
+            contract_hints["delegate_report_flag_contract"],
+        )
+        self.assertIn(
             "execution.delegated=false",
             contract_hints["dry_run_semantics"],
+        )
+        self.assertIn(
+            "recursive vs non-recursive",
+            contract_hints["pdf_discovery_consistency"],
         )
         self.assertTrue(
             any(
@@ -146,7 +158,19 @@ Execution contract: treat this as a best-effort, evidence-backed PDF extraction/
         )
         self.assertTrue(
             any(
+                "--report-json exactly" in item
+                for item in auto_task["constraints"]
+            )
+        )
+        self.assertTrue(
+            any(
                 "execution.delegated=false" in item
+                for item in auto_task["constraints"]
+            )
+        )
+        self.assertTrue(
+            any(
+                "PDF discovery semantics aligned" in item
                 for item in auto_task["constraints"]
             )
         )
@@ -171,7 +195,15 @@ Execution contract: treat this as a best-effort, evidence-backed PDF extraction/
             auto_task["acceptance_criteria"],
         )
         self.assertIn(
+            "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",
+            auto_task["acceptance_criteria"],
+        )
+        self.assertIn(
             "Dry-run semantics remain explicit: short-circuit stays partial with no delegated execution, or delegated dry-run is passed through honestly.",
+            auto_task["acceptance_criteria"],
+        )
+        self.assertIn(
+            "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
             auto_task["acceptance_criteria"],
         )
         self.assertIn(


### PR DESCRIPTION
## Summary
- harden local inbox automation contract hints to prevent wrapper report-flag drift against reviewed delegate CLI
- add explicit discovery-consistency guidance between wrapper preflight and delegate execution
- extend constraints and acceptance criteria for report-flag compatibility and discovery parity
- update focused adapter regression assertions and close BL-20260325-032 with report evidence

## Validation
- python3 -m unittest -v tests/test_local_inbox_adapter.py
- python3 -m unittest -v tests/test_trello_readonly_ingress.py
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh
- git diff --check

Closes #57