### PR TITLE
BL-033: close report-flag realignment validation and archive evidence

### DIFF
--- a/POST_REPORT_FLAG_REALIGNMENT_VALIDATION_REPORT.md
+++ b/POST_REPORT_FLAG_REALIGNMENT_VALIDATION_REPORT.md
@@ -1,0 +1,155 @@
+# Post-Report-Flag Realignment Validation Report
+
+## Objective
+
+Validate `BL-20260325-032` on one fresh same-origin governed candidate by
+running:
+
+- one live Trello read-only smoke
+- one explicit same-origin regeneration
+- one preview creation
+- one explicit approval
+- one real execute (`test_mode=off`)
+
+This phase objective is validation truth, not forcing a `pass` verdict.
+
+## Scope
+
+In scope:
+
+- one governed run against origin `trello:69c24cd3c1a2359ddd7a1bf8`
+- one regeneration token and one fresh preview candidate
+- runtime evidence capture for automation and critic outcomes
+- explicit recording of whether `BL-20260325-032` clears report-flag and
+  discovery drift findings from `BL-20260325-031`
+
+Out of scope:
+
+- source-code hardening inside this validation phase
+- git finalization and Trello Done writeback
+- additional live reruns beyond this one governed candidate
+
+## Pre-Run Checks
+
+- branch: `phase8y/validate-bl033-report-flag-realignment`
+- Trello env loaded from `/tmp/trello_env.sh`:
+  - `TRELLO_API_KEY` set
+  - `TRELLO_API_TOKEN` set
+  - `TRELLO_BOARD_ID` set
+- OpenAI runtime values available from:
+  - `secrets/openai_api_key.txt`
+  - `secrets/openai_api_base.txt`
+  - `secrets/openai_model_name.txt`
+- Docker sidecars/workers reachable for governed execute
+
+## Run Summary
+
+Target origin:
+
+- `trello:69c24cd3c1a2359ddd7a1bf8`
+
+Regeneration token:
+
+- `regen-20260325-bl033-001`
+
+### 1) Live Trello read-only smoke
+
+- `status = pass`
+- `read_count = 1`
+- archive snapshot:
+  - `runtime_archives/bl033/tmp/bl033_smoke_result.json`
+
+### 2) Regenerated payload and preview ingest
+
+- generated inbox payload from live `smoke_read.mapped_preview` with token
+  `regen-20260325-bl033-001`
+- ingest result sidecar:
+  - `processed/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl033-001.json.result.json`
+- ingest decision:
+  - `status = processed`
+  - `decision = preview_created_pending_approval`
+  - `preview_id = preview-trello-69c24cd3c1a2359ddd7a1bf8-2355ba57c8c0`
+
+### 3) Preview candidate
+
+Generated preview:
+
+- `preview-trello-69c24cd3c1a2359ddd7a1bf8-2355ba57c8c0`
+- preview file:
+  - `preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-2355ba57c8c0.json`
+
+Pre-execute state:
+
+- `approved = false`
+- `execution.status = pending_approval`
+- `execution.attempts = 0`
+- `source.regeneration_token = regen-20260325-bl033-001`
+
+### 4) Explicit approval
+
+- approval file:
+  - `approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-2355ba57c8c0.json`
+
+### 5) Real execute (`test_mode=off`)
+
+Final result sidecar:
+
+- `approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-2355ba57c8c0.result.json`
+- `status = rejected`
+- `decision_reason = critic_verdict=needs_revision`
+
+Worker outcomes:
+
+- automation:
+  - task `AUTO-20260325-857`
+  - `status = success`
+  - artifact: `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`
+- critic:
+  - task `CRITIC-20260325-278`
+  - `status = partial`
+  - verdict: `needs_revision`
+  - artifact: `artifacts/reviews/pdf_to_excel_ocr_inbox_review.md`
+
+## Critical Findings
+
+This validation still ended with `critic_verdict=needs_revision`, but the
+dominant blocker changed again.
+
+Current blocker from critic output:
+
+- reviewed wrapper snapshot was truncated in critic evidence context, so critic
+  could not fully validate syntax/completeness and returned `needs_revision`
+
+Observations from this run:
+
+- automation summary explicitly states wrapper uses `--report-json` handoff
+- critic output did not repeat prior explicit `--report-file` mismatch finding
+
+Inference from sources:
+
+- `BL-20260325-032` hardening appears to have reduced the prior report-flag
+  drift signal, but runtime review still fails because critic receives
+  incomplete wrapper evidence for full-file validation.
+
+## Validation Conclusion
+
+`BL-20260325-033` is complete as a governed validation phase.
+
+It answers the intended question after `BL-20260325-032`: the specific report
+flag drift signal is no longer the main reported blocker in this run, but the
+end-to-end path still fails review due truncated wrapper evidence in critic
+context.
+
+Next required phase: harden critic evidence handoff so full wrapper artifacts
+can be reviewed without truncation-driven false negatives, then rerun fresh
+governed validation.
+
+## Archive Preservation
+
+To preserve runtime evidence and avoid loss from tracked artifact overwrite, this
+phase archived outputs under:
+
+- `runtime_archives/bl033/artifacts/`
+- `runtime_archives/bl033/runtime/`
+- `runtime_archives/bl033/state/`
+- `runtime_archives/bl033/tmp/`

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -605,8 +605,8 @@ Allowed enum values:
 ### BL-20260325-033
 - title: Validate BL-20260325-032 report-flag and discovery hardening on a fresh same-origin governed candidate
 - type: mainline
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-032
@@ -614,7 +614,24 @@ Allowed enum values:
 - done_when: One governed validation creates a fresh same-origin preview candidate after BL-20260325-032, runs one explicit approval plus one real execute, and records whether automation/critic outcome now clears the `--report-file` vs `--report-json` and discovery-alignment findings observed in BL-20260325-031
 - source: `WRAPPER_DELEGATE_REPORT_FLAG_REALIGNMENT_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation rather than assuming source-side contract hardening success without live evidence
 - link: /Users/lingguozhong/openclaw-team/POST_REPORT_FLAG_REALIGNMENT_VALIDATION_REPORT.md
-- issue: deferred:phase=next until BL-20260325-032 lands on main
+- issue: https://github.com/Oscarling/openclaw-team/issues/59
+- evidence: `POST_REPORT_FLAG_REALIGNMENT_VALIDATION_REPORT.md` records one fresh same-origin governed run (`regen-20260325-bl033-001`) to preview `preview-trello-69c24cd3c1a2359ddd7a1bf8-2355ba57c8c0` with explicit approval and one real execute; automation (`AUTO-20260325-857`) succeeded with `--report-json` in wrapper summary while critic (`CRITIC-20260325-278`) still returned `needs_revision` because wrapper evidence snapshot was truncated for full-file validation
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-034
+- title: Harden critic artifact snapshot completeness to avoid truncation-driven validation rejects
+- type: blocker
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-033
+- start_when: `BL-20260325-033` has completed and confirmed the main runtime rejection shifted to critic-side truncated wrapper snapshot evidence rather than explicit report-flag mismatch
+- done_when: Critic evidence handoff preserves complete wrapper artifact content (or equivalent complete review context) for generated script reviews, focused tests cover snapshot-size/completeness behavior, and one phase report records the hardening outcome
+- source: `POST_REPORT_FLAG_REALIGNMENT_VALIDATION_REPORT.md` on 2026-03-25 records that fresh governed validation still returns `needs_revision` due critic-side truncated wrapper snapshot evidence
+- link: /Users/lingguozhong/openclaw-team/CRITIC_SNAPSHOT_COMPLETENESS_HARDENING_REPORT.md
+- issue: deferred:phase=next until BL-20260325-033 lands on main
 - evidence: -
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -1217,6 +1217,68 @@ Verification snapshot on 2026-03-25:
 - `python3 scripts/backlog_sync.py` passed with `BL-20260325-032` mirrored to
   issue `#57`
 
+### 41. Fresh Governed Validation After BL-032 Contract Hardening
+
+User objective:
+
+- continue from `BL-20260325-032` with a fresh same-origin governed validation
+- verify whether report-flag and discovery hardening clears the `BL-031` runtime
+  review blockers
+- preserve runtime artifacts and backlog traceability
+
+Main work areas:
+
+- activated `BL-20260325-033` and mirrored it to GitHub issue `#59`
+- ran one live Trello read-only smoke for origin
+  `trello:69c24cd3c1a2359ddd7a1bf8`
+- generated one explicit regeneration token:
+  - `regen-20260325-bl033-001`
+- ingested one fresh payload and created preview candidate:
+  - `preview-trello-69c24cd3c1a2359ddd7a1bf8-2355ba57c8c0`
+- wrote one explicit approval file and ran one governed real execute in
+  `test_mode=off`
+- archived runtime outputs under `runtime_archives/bl033/` before restoring
+  tracked `artifacts/` baselines
+- wrote validation report and promoted next blocker as `BL-20260325-034`
+
+Primary output:
+
+- [POST_REPORT_FLAG_REALIGNMENT_VALIDATION_REPORT.md](/Users/lingguozhong/openclaw-team/POST_REPORT_FLAG_REALIGNMENT_VALIDATION_REPORT.md)
+
+Key result:
+
+- `BL-20260325-033` completed as a governed validation phase
+- final execute still returned:
+  - `critic_verdict = needs_revision`
+- prior explicit report-flag mismatch signal did not reappear in critic output;
+  automation summary reports wrapper sidecar handoff using `--report-json`
+- new dominant blocker became critic evidence completeness:
+  - wrapper snapshot provided to critic was truncated, so full-file validation
+    was treated as insufficient
+- backlog updates from this phase:
+  - `BL-20260325-033` marked done with evidence
+  - `BL-20260325-034` created for critic snapshot completeness hardening
+
+Verification snapshot on 2026-03-25:
+
+- ingest output:
+  - `processed = 1`
+  - `preview_created = 1`
+  - preview id:
+    `preview-trello-69c24cd3c1a2359ddd7a1bf8-2355ba57c8c0`
+- execute sidecar:
+  - `approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-2355ba57c8c0.result.json`
+  - `status = rejected`
+  - `decision_reason = critic_verdict=needs_revision`
+- worker outcomes:
+  - automation `AUTO-20260325-857`: `success`
+  - critic `CRITIC-20260325-278`: `partial` with verdict `needs_revision`
+- runtime archive preserved under:
+  - `runtime_archives/bl033/artifacts/`
+  - `runtime_archives/bl033/runtime/`
+  - `runtime_archives/bl033/state/`
+  - `runtime_archives/bl033/tmp/`
+
 ### 31. Post-Timeout Governed Validation On Fresh Same-Origin Candidate
 
 User objective:

--- a/runtime_archives/bl033/runtime/AUTO-20260325-857.json
+++ b/runtime_archives/bl033/runtime/AUTO-20260325-857.json
@@ -1,0 +1,188 @@
+{
+  "task_id": "AUTO-20260325-857",
+  "worker": "automation",
+  "status": "success",
+  "created_at": "2026-03-25T02:32:38.410336Z",
+  "updated_at": "2026-03-25T02:33:41.195144Z",
+  "retries": 0,
+  "max_retries": 0,
+  "attempts": [
+    {
+      "attempt": 1,
+      "status": "success",
+      "retryable": false,
+      "error": null,
+      "runtime_log": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-857/runtime.attempt-1.log",
+      "exit_code": 0,
+      "timed_out": false,
+      "wait_error": null,
+      "output_path": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-857/output.json",
+      "started_at": "2026-03-25T02:32:38.411439Z",
+      "finished_at": "2026-03-25T02:33:41.174462Z"
+    }
+  ],
+  "task_dir": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-857",
+  "payload": {
+    "task_id": "AUTO-20260325-857",
+    "worker": "automation",
+    "task_type": "generate_script",
+    "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+    "inputs": {
+      "params": {
+        "input_dir": "~/Desktop/pdf样本",
+        "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+        "ocr": "auto",
+        "dry_run": false,
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "description": "Purpose: | Controlled Trello live preview smoke for openclaw-team. | Expected behavior: | - read-only Trello ingest | - preview creation smoke only | - no business execution claim | - no Trello writeback expected in this step | Traceability: | - backlog: BL-20260324-014 | - blocker context: BL-20260324-015 | - created_by: Oscarling | - created_at: 2026-03-24 Asia/Shanghai | Note: | This card is only for governed smoke verification and should remain open until the smoke is finished.",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "preferred_wrapper_script": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "preferred_base_script": "artifacts/scripts/pdf_to_excel_ocr.py",
+        "reference_docs": [
+          "artifacts/docs/pdf_to_excel_ocr_usage.md",
+          "artifacts/reviews/pdf_to_excel_ocr_review.md"
+        ],
+        "contract_hints": {
+          "output_format_fidelity": "If output_xlsx ends with .xlsx, produce a real XLSX workbook container or fail honestly before writing mismatched text/XML/CSV content to a .xlsx path.",
+          "path_portability": "Use the provided input_dir parameter as runtime input. Do not hardcode a user-home or absolute input path when params already declare the path.",
+          "traceability": "Preserve meaningful description context from the external input; do not collapse it to a heading fragment such as Purpose:.",
+          "reuse_preference": "Prefer reusing artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py as the wrapper baseline and artifacts/scripts/pdf_to_excel_ocr.py as the reviewed delegate when compatible, so workbook semantics and contract behavior stay aligned with repository evidence.",
+          "outcome_status_model": "Use the reviewable status model success/partial/failed. Dry-run requests or zero-PDF discovery should resolve to partial rather than claiming success without an output artifact.",
+          "delegate_resolution": "If preferred_base_script is relative, resolve it from the repository or script location instead of Path.cwd() so behavior stays portable across shells and CI.",
+          "reviewed_delegate_contract": "For readonly reviewable preview flows, delegate only to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py or fail honestly instead of broadening behavior through an arbitrary helper.",
+          "delegate_success_evidence": "Do not treat zero exit code plus output-file existence as sufficient wrapper success evidence on their own. Prefer a structured delegate report that confirms a real success outcome with at least one processed input and no failed-file counterexamples before the wrapper claims success.",
+          "delegate_timeout": "Bound delegate subprocess execution with an explicit timeout and report timeout as an honest failed/partial outcome instead of allowing smoke automation to hang indefinitely.",
+          "runtime_summary": "The generated script should emit a structured summary of what it produced so later review can inspect behavior without guessing.",
+          "delegate_report_schema": "Treat delegate JSON report fields status/total_files/status_counter/dry_run as the canonical evidence contract. Do not require undeclared processed_files/succeeded_files/failed_files counters.",
+          "delegate_report_handoff": "When the delegate prints a JSON report to stdout, parse that JSON directly instead of relying only on sidecar-report file path discovery.",
+          "delegate_report_flag_contract": "If wrapper passes a sidecar report path to the reviewed delegate, use the reviewed delegate CLI flag --report-json (or another explicitly supported alias). Do not invent undeclared flags such as --report-file.",
+          "dry_run_semantics": "If wrapper dry-run short-circuits before delegate execution, keep execution.delegated=false and report partial honestly. If wrapper does delegate under dry-run, pass through --dry-run explicitly.",
+          "pdf_discovery_consistency": "Keep wrapper preflight PDF discovery semantics aligned with the reviewed delegate (for example recursive vs non-recursive), so wrapper evidence and delegated execution count the same candidate set."
+        }
+      }
+    },
+    "expected_outputs": [
+      {
+        "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "type": "script"
+      }
+    ],
+    "constraints": [
+      "Follow the local inbox normalized request",
+      "Do not claim unsupported runtime dependencies",
+      "Keep output deterministic and executable",
+      "Produce only the expected script artifact",
+      "Prefer honest, reviewable intermediate behavior over unsupported OCR claims",
+      "If the requested output path ends with .xlsx, do not write non-XLSX text/XML/CSV content to that path.",
+      "Do not hardcode an input directory when the task params already provide input_dir.",
+      "Preserve meaningful traceability from the incoming description instead of collapsing it to a heading fragment.",
+      "Prefer wrapping or adapting artifacts/scripts/pdf_to_excel_ocr.py when that existing repo script already matches the requested behavior.",
+      "When artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py already exists, prefer updating that reviewed wrapper baseline instead of rewriting a new control flow from scratch.",
+      "If dry_run is true or no PDFs are discovered, report a reviewable partial outcome instead of claiming success without an XLSX artifact.",
+      "Resolve relative delegate script paths from the repository or script location, not from Path.cwd().",
+      "For readonly reviewable preview flows, only delegate to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py unless failing honestly.",
+      "Do not claim wrapper success from exit code plus output existence alone when the reviewed delegate report does not provide strong enough success evidence.",
+      "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
+      "When delegate emits JSON to stdout, parse that report directly instead of depending only on sidecar report-file discovery.",
+      "When wrapper passes a sidecar report path to the reviewed delegate, use --report-json exactly unless the reviewed delegate explicitly supports another alias.",
+      "If wrapper supports dry-run short-circuit semantics, keep execution.delegated=false and preserve partial status honestly.",
+      "Keep wrapper PDF discovery semantics aligned with reviewed delegate discovery semantics to avoid preflight/execution evidence drift.",
+      "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely."
+    ],
+    "priority": "medium",
+    "source": {
+      "kind": "local_inbox",
+      "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+      "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl033-001.json",
+      "received_at": "2026-03-25T02:31:52.463880Z",
+      "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "provider": "trello",
+      "mode": "readonly",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "regeneration_token": "regen-20260325-bl033-001"
+    },
+    "acceptance_criteria": [
+      "Produce the expected script artifact at expected_outputs[0].path",
+      "Script behavior remains runnable, deterministic, and reviewable",
+      "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
+      "Artifact behavior remains parameter-driven for input_dir and output_xlsx rather than hardcoding unrelated local defaults.",
+      "Dry-run or zero-input behavior is represented as a reviewable partial outcome instead of artifact-production success.",
+      "Relative preferred_base_script resolution remains portable and does not depend on Path.cwd().",
+      "Wrapper success requires stronger delegate evidence than zero exit code plus a non-empty output file alone.",
+      "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
+      "Delegate report handoff can consume JSON printed to stdout without relying exclusively on report sidecar file discovery.",
+      "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",
+      "Dry-run semantics remain explicit: short-circuit stays partial with no delegated execution, or delegated dry-run is passed through honestly.",
+      "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
+      "Delegate execution is bounded by an explicit timeout and reports timeout honestly."
+    ],
+    "metadata": {
+      "integration_phase": "8B",
+      "pipeline": "inbox->adapter->manager->automation->critic",
+      "request_type": "pdf_to_excel_ocr",
+      "payload_hash": "2355ba57c8c083a1e475c973e71dd1164a05ccb489125d7e22eb782738bed37a",
+      "regeneration_token": "regen-20260325-bl033-001",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "external_metadata": {
+        "source_system": "trello",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "card_short_id": 7,
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "date_last_activity": "2026-03-24T08:35:56.234Z",
+        "readonly_mapped_at": "2026-03-25T02:31:45.497271Z",
+        "contract_profile": "best_effort_evidence_backed",
+        "ocr_claim_policy": "do_not_claim_success_without_evidence",
+        "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+        "regeneration_token": "regen-20260325-bl033-001"
+      },
+      "automation_contract_profile": "narrow_script_artifact_with_repo_reuse_and_reviewable_runner_contract"
+    }
+  },
+  "result": {
+    "task_id": "AUTO-20260325-857",
+    "worker": "automation",
+    "status": "success",
+    "summary": "Generated exactly one runnable local helper wrapper script artifact that prefers the reviewed repository delegate, preserves parameter-driven input/output handling, uses bounded delegate execution with --report-json, parses delegate JSON from stdout or sidecar, applies honest success/partial/failed evidence rules, and avoids writing mismatched non-XLSX content.",
+    "artifacts": [
+      {
+        "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "type": "script"
+      }
+    ],
+    "timestamp": "2026-03-25T02:33:41.001826Z",
+    "duration_ms": 62352,
+    "notes": [
+      "The script is designed as a reusable local wrapper baseline around artifacts/scripts/pdf_to_excel_ocr.py rather than re-implementing PDF extraction logic.",
+      "It keeps reviewable status semantics: dry-run and zero-PDF discovery resolve to partial, and wrapper success requires stronger delegate evidence than exit code plus output existence alone.",
+      "Relative delegate resolution is performed from the wrapper/repository location instead of Path.cwd()."
+    ],
+    "metadata": {
+      "task_id": "AUTO-20260325-857",
+      "worker": "automation",
+      "generated_files": 1
+    }
+  }
+}

--- a/runtime_archives/bl033/runtime/CRITIC-20260325-278.json
+++ b/runtime_archives/bl033/runtime/CRITIC-20260325-278.json
@@ -1,0 +1,205 @@
+{
+  "task_id": "CRITIC-20260325-278",
+  "worker": "critic",
+  "status": "partial",
+  "created_at": "2026-03-25T02:33:41.201427Z",
+  "updated_at": "2026-03-25T02:34:04.319477Z",
+  "retries": 0,
+  "max_retries": 0,
+  "attempts": [
+    {
+      "attempt": 1,
+      "status": "partial",
+      "retryable": false,
+      "error": "The snapshot for artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py is truncated, so full-file syntax and final CLI/output behavior cannot be conclusively validated.",
+      "runtime_log": "/Users/lingguozhong/openclaw-team/workspaces/critic/CRITIC-20260325-278/runtime.attempt-1.log",
+      "exit_code": 0,
+      "timed_out": false,
+      "wait_error": null,
+      "output_path": "/Users/lingguozhong/openclaw-team/workspaces/critic/CRITIC-20260325-278/output.json",
+      "started_at": "2026-03-25T02:33:41.204416Z",
+      "finished_at": "2026-03-25T02:34:04.287211Z"
+    }
+  ],
+  "task_dir": "/Users/lingguozhong/openclaw-team/workspaces/critic/CRITIC-20260325-278",
+  "payload": {
+    "task_id": "CRITIC-20260325-278",
+    "worker": "critic",
+    "task_type": "review_artifact",
+    "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+    "inputs": {
+      "artifacts": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        },
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+          "type": "script"
+        }
+      ],
+      "params": {
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "review_scope": {
+          "primary_artifact": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "paired_artifacts": [
+            "artifacts/scripts/pdf_to_excel_ocr.py"
+          ],
+          "goal": "Audit the wrapper and the reviewed delegate together so the review evidence can speak to the end-to-end readonly smoke path."
+        },
+        "artifact_snapshots": [
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "available": true,
+            "content": "#!/usr/bin/env python3\nfrom __future__ import annotations\n\nimport argparse\nimport json\nimport os\nimport subprocess\nimport sys\nimport tempfile\nfrom dataclasses import dataclass\nfrom pathlib import Path\nfrom typing import Any, Dict, List, Optional\n\n\nDEFAULT_TIMEOUT_SECONDS = 1800\n\n\n@dataclass\nclass WrapperResult:\n    status: str\n    summary: str\n    report: Dict[str, Any]\n    exit_code: int = 0\n\n\ndef _expand_path(value: str) -> Path:\n    return Path(os.path.expandvars(os.path.expanduser(value))).resolve()\n\n\ndef _script_dir() -> Path:\n    return Path(__file__).resolve().parent\n\n\ndef _repo_root() -> Path:\n    return _script_dir().parent.parent\n\n\ndef _resolve_delegate(preferred_base_script: str) -> Path:\n    candidate = Path(preferred_base_script)\n    if candidate.is_absolute():\n        return candidate\n\n    roots = [_repo_root(), _script_dir()]\n    tried: List[Path] = []\n    for root in roots:\n        resolved = (root / candidate).resolve()\n        tried.append(resolved)\n        if resolved.exists():\n            return resolved\n\n    return tried[0]\n\n\ndef _discover_pdfs(input_dir: Path) -> List[Path]:\n    if not input_dir.exists() or not input_dir.is_dir():\n        return []\n    return sorted(\n        p for p in input_dir.rglob(\"*.pdf\")\n        if p.is_file()\n    )\n\n\ndef _safe_read_json_file(path: Path) -> Optional[Dict[str, Any]]:\n    try:\n        if path.exists() and path.is_file():\n            return json.loads(path.read_text(encoding=\"utf-8\"))\n    except Exception:\n        return None\n    return None\n\n\ndef _extract_json_from_stdout(stdout: str) -> Optional[Dict[str, Any]]:\n    text = (stdout or \"\").strip()\n    if not text:\n        return None\n\n    try:\n        parsed = json.loads(text)\n        if isinstance(parsed, dict):\n            return parsed\n    except Exception:\n        pass\n\n    lines = [line.strip() for line in text.splitlines() if line.strip()]\n    for line in reversed(lines):\n        try:\n            parsed = json.loads(line)\n            if isinstance(parsed, dict):\n                return parsed\n        except Exception:\n            continue\n    return None\n\n\ndef _build_summary(\n    *,\n    status: str,\n    input_dir: Path,\n    output_xlsx: Path,\n    pdf_count: int,\n    delegated: bool,\n    delegate_path: Path,\n    delegate_report: Optional[Dict[str, Any]],\n    description: str,\n    origin_id: Optional[str],\n    title: Optional[str],\n    timeout_seconds: int,\n) -> Dict[str, Any]:\n    return {\n        \"status\": status,\n        \"title\": title,\n        \"origin_id\": origin_id,\n        \"input_dir\": str(input_dir),\n        \"output_xlsx\": str(output_xlsx),\n        \"pdf_count\": pdf_count,\n        \"execution\": {\n            \"delegated\": delegated,\n            \"delegate_script\": str(delegate_path),\n            \"timeout_seconds\": timeout_seconds,\n        },\n        \"traceability\": {\n            \"description\": description,\n        },\n        \"delegate_report\": delegate_report,\n    }\n\n\ndef _validate_success_evidence(\n    delegate_report: Dict[str, Any],\n    output_xlsx: Path,\n) -> bool:\n    status = str(delegate_report.get(\"status\", \"\")).lower()\n    total_files = delegate_report.get(\"total_files\")\n    dry_run = bool(delegate_report.get(\"dry_run\", False))\n    status_counter = delegate_report.get(\"status_counter\") or {}\n\n    try:\n        total_files_int = int(total_files)\n    except Exception:\n        total_files_int = 0\n\n    if dry_run:\n        return False\n    if status != \"success\":\n        return False\n    if total_files_int <= 0:\n        return False\n    if not isinstance(status_counter, dict):\n        return False\n\n    failed_like = 0\n    for key in (\"failed\", \"error\", \"errors\", \"timeout\"):\n        try:\n            failed_like += int(status_counter.get(key, 0) or 0)\n        except Exception:\n            pass\n    if failed_like > 0:\n        return False\n\n    succeeded = 0\n    for key in (\"success\", \"succeeded\", \"converted\"):\n        try:\n            succeeded += int(status_counter.get(key, 0) or 0)\n        except Exception:\n            pass\n    if succeeded <= 0:\n        return False\n\n    if output_xlsx.suffix.lower() == \".xlsx\" and not output_xlsx.exists():\n        return False\n\n    return True\n\n\ndef run(args: argparse.Namespace) -> WrapperResult:\n    input_dir = _expand_path(args.input_dir)\n    output_xlsx = _expand_path(args.output_xlsx)\n    delegate_path = _resolve_delegate(args.preferred_base_script)\n    timeout_seconds = int(args.timeout_seconds)\n\n    if output_xlsx.suffix.lower() != \".xlsx\":\n        report = _build_summary(\n            status=\"failed\",\n            input_dir=input_dir,\n            output_xlsx=output_xlsx,\n            pdf_count=0,\n            delegated=False,\n            delegate_path=delegate_path,\n            delegate_report=None,\n            description=args.description,\n            origin_id=args.origin_id,\n            title=args.title,\n            timeout_seconds=timeout_seconds,\n        )\n        return WrapperResult(\n            status=\"failed\",\n            summary=\"Requested output path must end with .xlsx for this reviewed runner contract.\",\n            report=report,\n            exit_code=2,\n        )\n\n    if not delegate_path.exists():\n        report = _build_summary(\n            status=\"failed\",\n            input_dir=input_dir,\n            output_xlsx=output_xlsx,\n            pdf_count=0,\n            delegated=False,\n            delegate_path=delegate_path,\n            delegate_report=None,\n            description=args.description,\n            origin_id=args.origin_id,\n            title=args.title,\n            timeout_seconds=timeout_seconds,\n        )\n        return WrapperResult(\n            status=\"failed\",\n            summary=f\"Reviewed delegate script not found: {delegate_path}\",\n            report=report,\n            exit_code=2,\n        )\n\n    pdfs = _discover_pdfs(input_dir)\n    pdf_count = len(pdfs)\n\n    if args.dry_run:\n        report = _build_summary(\n            status=\"partial\",\n            input_dir=input_dir,\n            output_xlsx=output_xlsx,\n            pdf_count=pdf_count,\n            delegated=False,\n            delegate_path=delegate_path,\n            delegate_report={\n                \"status\": \"partial\",\n                \"dry_run\": True,\n                \"total_files\": pdf_count,\n                \"status_counter\": {},\n            },\n            description=args.description,\n            origin_id=args.origin_id,\n            title=args.title,\n            timeout_seconds=timeout_seconds,\n        )\n        return WrapperResult(\n            status=\"partial\",\n            summary=\"Dry-run requested; wrapper short-circuited before delegate execution.\",\n            report=report,\n            exit_code=0,\n        )\n\n    if pdf_count == 0:\n        report = _build_summary(\n            status=\"partial\",\n            input_dir=input_dir,\n            output_xlsx=output_xlsx,\n            pdf_count=0,\n            delegated=False,\n            delegate_path=delegate_path,\n            delegate_report={\n                \"status\": \"partial\",\n                \"dry_run\": False,\n                \"total_files\": 0,\n                \"status_counter\": {},\n            },\n            description=args.description,\n            origin_id=args.origin_id,\n            title=args.title,\n            timeout_seconds=timeout_seconds,\n        )\n        return WrapperResult(\n            status=\"partial\",\n            summary=\"No PDF files discovered; no delegate execution performed.\",\n            report=report,\n            exit_code=0,\n        )\n\n    output_xlsx.parent.mkdir(parents=True, exist_ok=True)\n\n    with tempfile.TemporaryDirectory(prefix=\"pdf_to_excel_runner_\") as tmpdir:\n        report_path = Path(tmpdir) / \"delegate_report.json\"\n        cmd = [\n            sys.executable,\n            str(delegate_path),\n            \"--input-dir\", str(input_dir),\n            \"--output-xlsx\", str(output_xlsx),\n            \"--ocr\", args.ocr,\n            \"--report-json\", str(report_path),\n        ]\n\n        completed = None\n        try:\n            completed = subprocess.run(\n                cmd,\n                stdout=subprocess.PIPE,\n                stderr=subprocess.PIPE,\n                text=True,\n                timeout=timeout_seconds,\n                check=False,\n            )\n        except subprocess.TimeoutExpired as exc:\n            report = _build_summary(\n                status=\"failed\",\n                input_dir=input_dir,\n                output_xlsx=output_xlsx,\n                pdf_count=pdf_count,\n                delegated=True,\n                delegate_path=delegate_path,\n                delegate_report={\n                    \"status\": \"failed\",\n                    \"dry_run\": False,\n                    \"total_files\": pdf_count,\n                    \"status_counter\": {\"timeout\": pdf_count},\n                    \"timeout_seconds\": timeout_seconds,\n                    \"stderr\": (exc.stderr or \"\") if isinstance(exc.stderr, str) else \"\",\n                },\n                description=args.description,\n                origin_id=args.origin_id,\n                title=args.title,\n                timeout_seconds=timeout_seconds,\n            )\n            return WrapperResult(\n                status=\"failed\",\n                summary=f\"Delegate execution timed out after {timeout_seconds} seconds.\",\n                report=report,\n                exit_code=124,\n            )\n\n        delegate_report = _extract_json_from_stdout(completed.stdout)\n        if delegate_report is None:\n            delegate_report = _safe_read_json_file(report_path)\n\n        if delegate_report is None:\n            delegate_report = {\n                \"status\": \"failed\" if completed.returncode != 0 else \"partial\",\n                \"dry_run\": False,\n                \"total_files\": pdf_count,\n                \"status_counter\": {},\n                \"stdout\": completed.stdout,\n                \"stderr\": completed.stderr,\n                \"returncode\": completed.returncode,\n            }\n\n        if _validate_success_evidence(delegate_report, output_xlsx):\n            status = \"success\"\n            summary = \"Delegate reported reviewable success with at least one processed PDF and no reported failures.\"\n        else:\n            delegate_status = str(delegate_report.get(\"status\", \"\")).lower()\n            if delegate_status == \"partial\" or completed.returncode == 0:\n                status = \"partial\"\n                summary = \"Delegate completed without strong enough evidence to claim wrapper success.\"\n            else:\n                status = \"failed\"\n                summary = \"Delegate did not provide sufficient evidence of successful XLSX conversion.\"\n\n        report = _build_summary(\n            status=status,\n            input_dir=input_dir,\n            output_xlsx=output_xlsx,\n            pdf_count=pdf_count,\n            delegated=True,\n            delegate_path=delegate_path,\n            delegate_report=delegate_report,\n            description=args.description,\n            origin_id=args.origin_id,\n            title=args.title,\n            timeout_seconds=timeout_seconds,\n        )\n        report[\"execution\"] = {\n            **report[\"execution\"],\n            \"command\": cmd,\n            \"returncode\": completed.returncode,\n        }\n        return WrapperResult(\n            status=status,\n            summary=summary,\n            report=report,\n            exit_code=0 if status in {\"success\", \"partial\"} else max(completed.returncode, 1),\n        )\n\n\ndef build_parser() -> argparse.ArgumentParser:\n    parser = argparse.ArgumentParser(\n        description=\"Reviewable inbox wrapper for the reviewed PDF-to-Excel delegate.\"\n    )\n    parser.add_argument(\"--input-dir\", required=True)\n    parser.add_argument(\"--output-xlsx\", required=True)\n    parser.add_argument(\"--ocr\", default=\"auto\")\n    parser.add_argument(\"--dry-run\", action=\"store_true\")\n    parser.add_argument(\"--origin-id\", default=\"\")\n    parser.add_argument(\"--title\", default=\"\")\n    parser.add_argument(\"--description\", default=\"\")\n    parser.add_argume",
+            "truncated": true
+          },
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+            "available": true,
+            "content": "#!/usr/bin/env python3\n\"\"\"\nBatch PDF -> Excel extractor with optional OCR fallback.\n\nDesign goals:\n- Batch processing with per-file isolation (single file failure must not stop the batch)\n- OCR mode: auto | on | off\n- Chinese-friendly OCR defaults (chi_sim+eng)\n- Dry-run support for pilot validation when dependencies are unavailable\n\"\"\"\n\nfrom __future__ import annotations\n\nimport argparse\nimport json\nimport shutil\nimport sys\nfrom dataclasses import asdict, dataclass\nfrom pathlib import Path\nfrom typing import Any\n\n\ntry:\n    from pypdf import PdfReader  # type: ignore\nexcept Exception:\n    PdfReader = None\n\ntry:\n    import pandas as pd  # type: ignore\nexcept Exception:\n    pd = None\n\ntry:\n    import pytesseract  # type: ignore\nexcept Exception:\n    pytesseract = None\n\ntry:\n    from pdf2image import convert_from_path  # type: ignore\nexcept Exception:\n    convert_from_path = None\n\n\n@dataclass\nclass FileResult:\n    file_name: str\n    file_path: str\n    status: str\n    extract_method: str\n    page_count: int\n    text_chars: int\n    text_preview: str\n    warnings: str\n    error: str\n\n\ndef parse_args() -> argparse.Namespace:\n    parser = argparse.ArgumentParser(description=\"Batch PDF to Excel extractor with OCR fallback.\")\n    parser.add_argument(\"--input-dir\", required=True, help=\"Directory containing PDF files.\")\n    parser.add_argument(\"--output-xlsx\", required=True, help=\"Output Excel path.\")\n    parser.add_argument(\n        \"--ocr\",\n        choices=(\"auto\", \"on\", \"off\"),\n        default=\"auto\",\n        help=\"OCR mode. auto=use OCR when plain text extraction is weak.\",\n    )\n    parser.add_argument(\n        \"--dry-run\",\n        action=\"store_true\",\n        help=\"Do not write Excel file. Print execution summary only.\",\n    )\n    parser.add_argument(\n        \"--ocr-lang\",\n        default=\"chi_sim+eng\",\n        help=\"OCR language pack for pytesseract, default supports Chinese + English.\",\n    )\n    parser.add_argument(\n        \"--auto-ocr-min-chars\",\n        type=int,\n        default=50,\n        help=\"In auto mode, run OCR when extracted text chars < this threshold.\",\n    )\n    parser.add_argument(\n        \"--report-json\",\n        default=\"\",\n        help=\"Optional sidecar path for writing the same JSON report emitted to stdout.\",\n    )\n    return parser.parse_args()\n\n\ndef discover_pdfs(input_dir: Path) -> list[Path]:\n    if not input_dir.exists():\n        raise FileNotFoundError(f\"Input directory does not exist: {input_dir}\")\n    if not input_dir.is_dir():\n        raise NotADirectoryError(f\"Input path is not a directory: {input_dir}\")\n    files = sorted([p for p in input_dir.rglob(\"*\") if p.is_file() and p.suffix.lower() == \".pdf\"])\n    return files\n\n\ndef detect_ocr_runtime_status() -> tuple[str, list[str]]:\n    missing: list[str] = []\n    present: list[str] = []\n\n    if pytesseract is None:\n        missing.append(\"python module pytesseract\")\n    else:\n        present.append(\"python module pytesseract\")\n    if convert_from_path is None:\n        missing.append(\"python module pdf2image\")\n    else:\n        present.append(\"python module pdf2image\")\n    if shutil.which(\"tesseract\") is None:\n        missing.append(\"binary tesseract\")\n    else:\n        present.append(\"binary tesseract\")\n    if shutil.which(\"pdftoppm\") is None:\n        missing.append(\"binary pdftoppm (poppler)\")\n    else:\n        present.append(\"binary pdftoppm (poppler)\")\n\n    if not missing:\n        return \"available\", []\n    if present:\n        return \"partial\", missing\n    return \"blocked\", missing\n\n\ndef extract_text_pypdf(pdf_path: Path) -> tuple[str, int]:\n    if PdfReader is None:\n        raise RuntimeError(\"pypdf not installed\")\n    reader = PdfReader(str(pdf_path))\n    page_texts: list[str] = []\n    for page in reader.pages:\n        text = page.extract_text() or \"\"\n        page_texts.append(text)\n    return \"\\n\".join(page_texts), len(reader.pages)\n\n\ndef extract_text_ocr(pdf_path: Path, ocr_lang: str) -> str:\n    if pytesseract is None:\n        raise RuntimeError(\"pytesseract not installed\")\n    if convert_from_path is None:\n        raise RuntimeError(\"pdf2image not installed\")\n    if shutil.which(\"tesseract\") is None:\n        raise RuntimeError(\"tesseract binary not found\")\n    if shutil.which(\"pdftoppm\") is None:\n        raise RuntimeError(\"pdftoppm binary not found (install poppler)\")\n\n    images = convert_from_path(str(pdf_path), dpi=220)\n    chunks: list[str] = []\n    for image in images:\n        chunks.append(pytesseract.image_to_string(image, lang=ocr_lang))\n    return \"\\n\".join(chunks)\n\n\ndef compact_preview(text: str, limit: int = 160) -> str:\n    single_line = \" \".join(text.split())\n    if len(single_line) <= limit:\n        return single_line\n    return single_line[: limit - 3] + \"...\"\n\n\ndef process_one_pdf(\n    pdf_path: Path,\n    ocr_mode: str,\n    ocr_lang: str,\n    auto_ocr_min_chars: int,\n) -> FileResult:\n    warnings: list[str] = []\n    errors: list[str] = []\n    method = \"none\"\n    text = \"\"\n    page_count = 0\n\n    try:\n        text, page_count = extract_text_pypdf(pdf_path)\n        method = \"text\"\n    except Exception as e:\n        warnings.append(f\"text extraction unavailable: {e}\")\n\n    needs_ocr = False\n    if ocr_mode == \"on\":\n        needs_ocr = True\n    elif ocr_mode == \"auto\" and len(text.strip()) < auto_ocr_min_chars:\n        needs_ocr = True\n\n    if needs_ocr:\n        try:\n            ocr_text = extract_text_ocr(pdf_path, ocr_lang).strip()\n            if ocr_text:\n                if text.strip():\n                    text = f\"{text.strip()}\\n\\n[OCR Fallback]\\n{ocr_text}\"\n                    method = \"text+ocr\"\n                else:\n                    text = ocr_text\n                    method = \"ocr\"\n            else:\n                warnings.append(\"OCR returned empty text\")\n        except Exception as e:\n            errors.append(f\"OCR failed: {e}\")\n\n    if not text.strip():\n        if errors:\n            status = \"failed\"\n        else:\n            status = \"partial\"\n            warnings.append(\"No extractable text captured\")\n    else:\n        status = \"success\"\n\n    return FileResult(\n        file_name=pdf_path.name,\n        file_path=str(pdf_path),\n        status=status,\n        extract_method=method,\n        page_count=page_count,\n        text_chars=len(text),\n        text_preview=compact_preview(text),\n        warnings=\" | \".join(warnings),\n        error=\" | \".join(errors),\n    )\n\n\ndef write_excel(results: list[FileResult], output_xlsx: Path) -> None:\n    if pd is None:\n        raise RuntimeError(\"pandas is required to write Excel output\")\n    output_xlsx.parent.mkdir(parents=True, exist_ok=True)\n\n    rows = [asdict(r) for r in results]\n    detail_df = pd.DataFrame(rows)\n\n    summary_rows: list[dict[str, Any]] = []\n    by_status = detail_df.groupby(\"status\").size().to_dict()\n    by_method = detail_df.groupby(\"extract_method\").size().to_dict()\n    for key, value in sorted(by_status.items()):\n        summary_rows.append({\"metric\": \"status_count\", \"name\": key, \"value\": int(value)})\n    for key, value in sorted(by_method.items()):\n        summary_rows.append({\"metric\": \"method_count\", \"name\": key, \"value\": int(value)})\n    summary_rows.append({\"metric\": \"total_files\", \"name\": \"all\", \"value\": int(len(results))})\n    summary_df = pd.DataFrame(summary_rows)\n\n    with pd.ExcelWriter(output_xlsx) as writer:\n        summary_df.to_excel(writer, sheet_name=\"summary\", index=False)\n        detail_df.to_excel(writer, sheet_name=\"files\", index=False)\n\n\ndef emit_report(report: dict[str, Any], report_json: str) -> None:\n    rendered = json.dumps(report, ensure_ascii=False, indent=2)\n    print(rendered)\n    if not report_json:\n        return\n    out_path = Path(report_json).expanduser().resolve()\n    out_path.parent.mkdir(parents=True, exist_ok=True)\n    out_path.write_text(rendered + \"\\n\", encoding=\"utf-8\")\n\n\ndef main() -> int:\n    args = parse_args()\n    input_dir = Path(args.input_dir).expanduser().resolve()\n    output_xlsx = Path(args.output_xlsx).expanduser().resolve()\n\n    try:\n        pdf_files = discover_pdfs(input_dir)\n    except Exception as e:\n        emit_report({\"status\": \"failed\", \"error\": str(e)}, args.report_json)\n        return 2\n\n    if not pdf_files:\n        emit_report(\n            {\n                \"status\": \"failed\",\n                \"error\": f\"No PDF files found under {input_dir}\",\n            },\n            args.report_json,\n        )\n        return 2\n\n    ocr_runtime, missing = detect_ocr_runtime_status()\n    results: list[FileResult] = []\n    for pdf in pdf_files:\n        try:\n            results.append(\n                process_one_pdf(\n                    pdf,\n                    ocr_mode=args.ocr,\n                    ocr_lang=args.ocr_lang,\n                    auto_ocr_min_chars=args.auto_ocr_min_chars,\n                )\n            )\n        except Exception as e:\n            results.append(\n                FileResult(\n                    file_name=pdf.name,\n                    file_path=str(pdf),\n                    status=\"failed\",\n                    extract_method=\"none\",\n                    page_count=0,\n                    text_chars=0,\n                    text_preview=\"\",\n                    warnings=\"\",\n                    error=f\"Unhandled processing exception: {e}\",\n                )\n            )\n\n    status_counter: dict[str, int] = {}\n    for item in results:\n        status_counter[item.status] = status_counter.get(item.status, 0) + 1\n\n    report = {\n        \"status\": \"success\" if status_counter.get(\"failed\", 0) == 0 else \"partial\",\n        \"input_dir\": str(input_dir),\n        \"output_xlsx\": str(output_xlsx),\n        \"ocr_mode\": args.ocr,\n        \"ocr_runtime_status\": ocr_runtime,\n        \"ocr_missing_dependencies\": missing,\n        \"total_files\": len(results),\n        \"status_counter\": status_counter,\n        \"dry_run\": bool(args.dry_run),\n    }\n\n    if args.dry_run:\n        emit_report(report, args.report_json)\n        return 0\n\n    try:\n        write_excel(results, output_xlsx)\n        emit_report(report, args.report_json)\n        return 0\n    except Exception as e:\n        report[\"status\"] = \"failed\"\n        report[\"error\"] = str(e)\n        emit_report(report, args.report_json)\n        return 3\n\n\nif __name__ == \"__main__\":\n    raise SystemExit(main())\n",
+            "truncated": false
+          }
+        ],
+        "review_contract": {
+          "required_status": [
+            "success",
+            "partial",
+            "failed"
+          ],
+          "required_verdict_values": [
+            "fail",
+            "needs_revision",
+            "pass"
+          ],
+          "required_metadata_key": "verdict",
+          "must_write_review_artifact_to": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "artifact_policy": "Always include either `file_contents` for the review artifact path or `artifacts` referencing that exact path.",
+          "fallback_policy": "If evidence is insufficient, return `status=partial`, include explicit `errors`, still generate review artifact content, and set verdict=needs_revision."
+        },
+        "review_template": {
+          "title": "Review: <artifact name>",
+          "sections": [
+            "Scope",
+            "Findings",
+            "Verdict",
+            "Rationale"
+          ],
+          "verdict_required": true
+        }
+      }
+    },
+    "expected_outputs": [
+      {
+        "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+        "type": "review"
+      }
+    ],
+    "constraints": [
+      "Review must be grounded in produced automation artifact",
+      "When both wrapper and reviewed delegate snapshots are supplied, evaluate them as one end-to-end readonly pair instead of ignoring the delegate evidence.",
+      "Do not invent missing artifact content",
+      "Return a clear verdict: pass, fail, or needs_revision",
+      "Include metadata.verdict in output",
+      "Generate review artifact markdown for expected_outputs[0].path",
+      "Use artifact_snapshots when provided; avoid claiming access problems if snapshot content exists.",
+      "When both the generated wrapper and reviewed delegate snapshots are provided, review them together rather than silently narrowing scope to one file.",
+      "Return metadata.verdict with one of: pass, fail, needs_revision.",
+      "Always generate review artifact content for expected_outputs[0].path.",
+      "If evidence is insufficient, use partial + errors + verdict=needs_revision, but still output review artifact."
+    ],
+    "priority": "medium",
+    "source": {
+      "kind": "local_inbox",
+      "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+      "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl033-001.json",
+      "received_at": "2026-03-25T02:31:52.463880Z",
+      "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "provider": "trello",
+      "mode": "readonly",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "regeneration_token": "regen-20260325-bl033-001"
+    },
+    "acceptance_criteria": [
+      "Produce a review artifact with explicit verdict (pass/fail/needs_revision)"
+    ],
+    "metadata": {
+      "integration_phase": "8B",
+      "pipeline": "inbox->adapter->manager->automation->critic",
+      "request_type": "pdf_to_excel_ocr",
+      "payload_hash": "2355ba57c8c083a1e475c973e71dd1164a05ccb489125d7e22eb782738bed37a",
+      "regeneration_token": "regen-20260325-bl033-001",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "external_metadata": {
+        "source_system": "trello",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "card_short_id": 7,
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "date_last_activity": "2026-03-24T08:35:56.234Z",
+        "readonly_mapped_at": "2026-03-25T02:31:45.497271Z",
+        "contract_profile": "best_effort_evidence_backed",
+        "ocr_claim_policy": "do_not_claim_success_without_evidence",
+        "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+        "regeneration_token": "regen-20260325-bl033-001"
+      }
+    }
+  },
+  "result": {
+    "task_id": "CRITIC-20260325-278",
+    "worker": "critic",
+    "status": "partial",
+    "summary": "Reviewed the inbox runner together with its delegate as an end-to-end readonly pair. The overall design is aligned with a best-effort evidence-backed smoke path, but the supplied runner snapshot is truncated and therefore cannot be fully validated for syntax/completeness. Verdict: needs_revision.",
+    "artifacts": [
+      {
+        "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+        "type": "review"
+      }
+    ],
+    "timestamp": "2026-03-25T02:34:04.160608Z",
+    "duration_ms": 22753,
+    "errors": [
+      "The snapshot for artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py is truncated, so full-file syntax and final CLI/output behavior cannot be conclusively validated.",
+      "Because the runner snapshot ends mid-parser definition, there is insufficient evidence that the script is complete and executable as provided."
+    ],
+    "notes": [
+      "Review was grounded in the supplied artifact snapshots and evaluated the wrapper and delegate together.",
+      "The delegate script provides evidence-aware reporting and avoids overstating OCR success, which is consistent with the stated contract.",
+      "The wrapper logic shown includes cautious success validation and partial/failure handling, which is positive, but incomplete snapshot evidence prevents a pass verdict."
+    ],
+    "metadata": {
+      "task_id": "CRITIC-20260325-278",
+      "worker": "critic",
+      "verdict": "needs_revision",
+      "reviewed_artifacts": [
+        "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "artifacts/scripts/pdf_to_excel_ocr.py"
+      ],
+      "review_scope": "end-to-end readonly wrapper+delegate review"
+    }
+  }
+}

--- a/runtime_archives/bl033/runtime/automation-output.json
+++ b/runtime_archives/bl033/runtime/automation-output.json
@@ -1,0 +1,24 @@
+{
+  "task_id": "AUTO-20260325-857",
+  "worker": "automation",
+  "status": "success",
+  "summary": "Generated exactly one runnable local helper wrapper script artifact that prefers the reviewed repository delegate, preserves parameter-driven input/output handling, uses bounded delegate execution with --report-json, parses delegate JSON from stdout or sidecar, applies honest success/partial/failed evidence rules, and avoids writing mismatched non-XLSX content.",
+  "artifacts": [
+    {
+      "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+      "type": "script"
+    }
+  ],
+  "timestamp": "2026-03-25T02:33:41.001826Z",
+  "duration_ms": 62352,
+  "notes": [
+    "The script is designed as a reusable local wrapper baseline around artifacts/scripts/pdf_to_excel_ocr.py rather than re-implementing PDF extraction logic.",
+    "It keeps reviewable status semantics: dry-run and zero-PDF discovery resolve to partial, and wrapper success requires stronger delegate evidence than exit code plus output existence alone.",
+    "Relative delegate resolution is performed from the wrapper/repository location instead of Path.cwd()."
+  ],
+  "metadata": {
+    "task_id": "AUTO-20260325-857",
+    "worker": "automation",
+    "generated_files": 1
+  }
+}

--- a/runtime_archives/bl033/runtime/automation-runtime.attempt-1.log
+++ b/runtime_archives/bl033/runtime/automation-runtime.attempt-1.log
@@ -1,0 +1,19 @@
+task_id: AUTO-20260325-857
+worker: automation
+attempt: 1
+container_name: argus-automation-auto-20260325-857
+worker_image: argus-worker:latest
+started_at: 2026-03-25T02:32:38.411439Z
+finished_at: 2026-03-25T02:33:41.174462Z
+exit_code: 0
+timed_out: False
+wait_error: 
+
+=== stdout ===
+[2026-03-25T02:32:38.650113Z] [automation] [INFO] Worker started using endpoint https://fast.vpsairobot.com/v1/chat/completions (timeout=120s, attempts=3)
+[2026-03-25T02:33:41.001459Z] [automation] [INFO] Artifact written: artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
+[2026-03-25T02:33:41.002260Z] [automation] [INFO] Task completed AUTO-20260325-857 with status success
+[2026-03-25T02:33:41.003167Z] [automation] [INFO] Worker exiting from /app/workspaces/automation/AUTO-20260325-857
+
+=== stderr ===
+

--- a/runtime_archives/bl033/runtime/critic-output.json
+++ b/runtime_archives/bl033/runtime/critic-output.json
@@ -1,0 +1,33 @@
+{
+  "task_id": "CRITIC-20260325-278",
+  "worker": "critic",
+  "status": "partial",
+  "summary": "Reviewed the inbox runner together with its delegate as an end-to-end readonly pair. The overall design is aligned with a best-effort evidence-backed smoke path, but the supplied runner snapshot is truncated and therefore cannot be fully validated for syntax/completeness. Verdict: needs_revision.",
+  "artifacts": [
+    {
+      "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+      "type": "review"
+    }
+  ],
+  "timestamp": "2026-03-25T02:34:04.160608Z",
+  "duration_ms": 22753,
+  "errors": [
+    "The snapshot for artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py is truncated, so full-file syntax and final CLI/output behavior cannot be conclusively validated.",
+    "Because the runner snapshot ends mid-parser definition, there is insufficient evidence that the script is complete and executable as provided."
+  ],
+  "notes": [
+    "Review was grounded in the supplied artifact snapshots and evaluated the wrapper and delegate together.",
+    "The delegate script provides evidence-aware reporting and avoids overstating OCR success, which is consistent with the stated contract.",
+    "The wrapper logic shown includes cautious success validation and partial/failure handling, which is positive, but incomplete snapshot evidence prevents a pass verdict."
+  ],
+  "metadata": {
+    "task_id": "CRITIC-20260325-278",
+    "worker": "critic",
+    "verdict": "needs_revision",
+    "reviewed_artifacts": [
+      "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+      "artifacts/scripts/pdf_to_excel_ocr.py"
+    ],
+    "review_scope": "end-to-end readonly wrapper+delegate review"
+  }
+}

--- a/runtime_archives/bl033/runtime/critic-runtime.attempt-1.log
+++ b/runtime_archives/bl033/runtime/critic-runtime.attempt-1.log
@@ -1,0 +1,19 @@
+task_id: CRITIC-20260325-278
+worker: critic
+attempt: 1
+container_name: argus-critic-critic-20260325-278
+worker_image: argus-worker:latest
+started_at: 2026-03-25T02:33:41.204416Z
+finished_at: 2026-03-25T02:34:04.287211Z
+exit_code: 0
+timed_out: False
+wait_error: 
+
+=== stdout ===
+[2026-03-25T02:33:41.408688Z] [critic] [INFO] Worker started using endpoint https://fast.vpsairobot.com/v1/chat/completions (timeout=120s, attempts=3)
+[2026-03-25T02:34:04.160004Z] [critic] [INFO] Artifact written: artifacts/reviews/pdf_to_excel_ocr_inbox_review.md
+[2026-03-25T02:34:04.161135Z] [critic] [INFO] Task completed CRITIC-20260325-278 with status partial
+[2026-03-25T02:34:04.162211Z] [critic] [INFO] Worker exiting from /app/workspaces/critic/CRITIC-20260325-278
+
+=== stderr ===
+

--- a/runtime_archives/bl033/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-2355ba57c8c0.json
+++ b/runtime_archives/bl033/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-2355ba57c8c0.json
@@ -1,0 +1,396 @@
+{
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-2355ba57c8c0",
+  "created_at": "2026-03-25T02:31:52.464200Z",
+  "approved": true,
+  "source": {
+    "kind": "local_inbox",
+    "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+    "received_at": "2026-03-25T02:31:52.463880Z",
+    "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl033-001.json",
+    "regeneration_token": "regen-20260325-bl033-001"
+  },
+  "external_input": {
+    "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+    "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+    "labels": [
+      "best_effort",
+      "evidence_backed",
+      "readonly",
+      "reviewable",
+      "trello"
+    ],
+    "metadata": {
+      "source_system": "trello",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "card_short_id": 7,
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "date_last_activity": "2026-03-24T08:35:56.234Z",
+      "readonly_mapped_at": "2026-03-25T02:31:45.497271Z",
+      "contract_profile": "best_effort_evidence_backed",
+      "ocr_claim_policy": "do_not_claim_success_without_evidence",
+      "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+      "regeneration_token": "regen-20260325-bl033-001"
+    },
+    "request_type": "pdf_to_excel_ocr",
+    "input": {
+      "input_dir": "~/Desktop/pdf样本",
+      "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+      "ocr": "auto",
+      "dry_run": false
+    }
+  },
+  "task_summary": {
+    "automation": {
+      "task_id": "AUTO-20260325-857",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+      "expected_outputs": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ]
+    },
+    "critic": {
+      "task_id": "CRITIC-20260325-278",
+      "worker": "critic",
+      "task_type": "review_artifact",
+      "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+      "expected_outputs": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ]
+    }
+  },
+  "internal_tasks": {
+    "automation": {
+      "task_id": "AUTO-20260325-857",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+      "inputs": {
+        "params": {
+          "input_dir": "~/Desktop/pdf样本",
+          "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+          "ocr": "auto",
+          "dry_run": false,
+          "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+          "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+          "description": "Purpose: | Controlled Trello live preview smoke for openclaw-team. | Expected behavior: | - read-only Trello ingest | - preview creation smoke only | - no business execution claim | - no Trello writeback expected in this step | Traceability: | - backlog: BL-20260324-014 | - blocker context: BL-20260324-015 | - created_by: Oscarling | - created_at: 2026-03-24 Asia/Shanghai | Note: | This card is only for governed smoke verification and should remain open until the smoke is finished.",
+          "labels": [
+            "best_effort",
+            "evidence_backed",
+            "readonly",
+            "reviewable",
+            "trello"
+          ],
+          "preferred_wrapper_script": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "preferred_base_script": "artifacts/scripts/pdf_to_excel_ocr.py",
+          "reference_docs": [
+            "artifacts/docs/pdf_to_excel_ocr_usage.md",
+            "artifacts/reviews/pdf_to_excel_ocr_review.md"
+          ],
+          "contract_hints": {
+            "output_format_fidelity": "If output_xlsx ends with .xlsx, produce a real XLSX workbook container or fail honestly before writing mismatched text/XML/CSV content to a .xlsx path.",
+            "path_portability": "Use the provided input_dir parameter as runtime input. Do not hardcode a user-home or absolute input path when params already declare the path.",
+            "traceability": "Preserve meaningful description context from the external input; do not collapse it to a heading fragment such as Purpose:.",
+            "reuse_preference": "Prefer reusing artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py as the wrapper baseline and artifacts/scripts/pdf_to_excel_ocr.py as the reviewed delegate when compatible, so workbook semantics and contract behavior stay aligned with repository evidence.",
+            "outcome_status_model": "Use the reviewable status model success/partial/failed. Dry-run requests or zero-PDF discovery should resolve to partial rather than claiming success without an output artifact.",
+            "delegate_resolution": "If preferred_base_script is relative, resolve it from the repository or script location instead of Path.cwd() so behavior stays portable across shells and CI.",
+            "reviewed_delegate_contract": "For readonly reviewable preview flows, delegate only to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py or fail honestly instead of broadening behavior through an arbitrary helper.",
+            "delegate_success_evidence": "Do not treat zero exit code plus output-file existence as sufficient wrapper success evidence on their own. Prefer a structured delegate report that confirms a real success outcome with at least one processed input and no failed-file counterexamples before the wrapper claims success.",
+            "delegate_timeout": "Bound delegate subprocess execution with an explicit timeout and report timeout as an honest failed/partial outcome instead of allowing smoke automation to hang indefinitely.",
+            "runtime_summary": "The generated script should emit a structured summary of what it produced so later review can inspect behavior without guessing.",
+            "delegate_report_schema": "Treat delegate JSON report fields status/total_files/status_counter/dry_run as the canonical evidence contract. Do not require undeclared processed_files/succeeded_files/failed_files counters.",
+            "delegate_report_handoff": "When the delegate prints a JSON report to stdout, parse that JSON directly instead of relying only on sidecar-report file path discovery.",
+            "delegate_report_flag_contract": "If wrapper passes a sidecar report path to the reviewed delegate, use the reviewed delegate CLI flag --report-json (or another explicitly supported alias). Do not invent undeclared flags such as --report-file.",
+            "dry_run_semantics": "If wrapper dry-run short-circuits before delegate execution, keep execution.delegated=false and report partial honestly. If wrapper does delegate under dry-run, pass through --dry-run explicitly.",
+            "pdf_discovery_consistency": "Keep wrapper preflight PDF discovery semantics aligned with the reviewed delegate (for example recursive vs non-recursive), so wrapper evidence and delegated execution count the same candidate set."
+          }
+        }
+      },
+      "expected_outputs": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ],
+      "constraints": [
+        "Follow the local inbox normalized request",
+        "Do not claim unsupported runtime dependencies",
+        "Keep output deterministic and executable",
+        "Produce only the expected script artifact",
+        "Prefer honest, reviewable intermediate behavior over unsupported OCR claims",
+        "If the requested output path ends with .xlsx, do not write non-XLSX text/XML/CSV content to that path.",
+        "Do not hardcode an input directory when the task params already provide input_dir.",
+        "Preserve meaningful traceability from the incoming description instead of collapsing it to a heading fragment.",
+        "Prefer wrapping or adapting artifacts/scripts/pdf_to_excel_ocr.py when that existing repo script already matches the requested behavior.",
+        "When artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py already exists, prefer updating that reviewed wrapper baseline instead of rewriting a new control flow from scratch.",
+        "If dry_run is true or no PDFs are discovered, report a reviewable partial outcome instead of claiming success without an XLSX artifact.",
+        "Resolve relative delegate script paths from the repository or script location, not from Path.cwd().",
+        "For readonly reviewable preview flows, only delegate to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py unless failing honestly.",
+        "Do not claim wrapper success from exit code plus output existence alone when the reviewed delegate report does not provide strong enough success evidence.",
+        "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
+        "When delegate emits JSON to stdout, parse that report directly instead of depending only on sidecar report-file discovery.",
+        "When wrapper passes a sidecar report path to the reviewed delegate, use --report-json exactly unless the reviewed delegate explicitly supports another alias.",
+        "If wrapper supports dry-run short-circuit semantics, keep execution.delegated=false and preserve partial status honestly.",
+        "Keep wrapper PDF discovery semantics aligned with reviewed delegate discovery semantics to avoid preflight/execution evidence drift.",
+        "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely."
+      ],
+      "priority": "medium",
+      "source": {
+        "kind": "local_inbox",
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl033-001.json",
+        "received_at": "2026-03-25T02:31:52.463880Z",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "regeneration_token": "regen-20260325-bl033-001"
+      },
+      "acceptance_criteria": [
+        "Produce the expected script artifact at expected_outputs[0].path",
+        "Script behavior remains runnable, deterministic, and reviewable",
+        "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
+        "Artifact behavior remains parameter-driven for input_dir and output_xlsx rather than hardcoding unrelated local defaults.",
+        "Dry-run or zero-input behavior is represented as a reviewable partial outcome instead of artifact-production success.",
+        "Relative preferred_base_script resolution remains portable and does not depend on Path.cwd().",
+        "Wrapper success requires stronger delegate evidence than zero exit code plus a non-empty output file alone.",
+        "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
+        "Delegate report handoff can consume JSON printed to stdout without relying exclusively on report sidecar file discovery.",
+        "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",
+        "Dry-run semantics remain explicit: short-circuit stays partial with no delegated execution, or delegated dry-run is passed through honestly.",
+        "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
+        "Delegate execution is bounded by an explicit timeout and reports timeout honestly."
+      ],
+      "metadata": {
+        "integration_phase": "8B",
+        "pipeline": "inbox->adapter->manager->automation->critic",
+        "request_type": "pdf_to_excel_ocr",
+        "payload_hash": "2355ba57c8c083a1e475c973e71dd1164a05ccb489125d7e22eb782738bed37a",
+        "regeneration_token": "regen-20260325-bl033-001",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "external_metadata": {
+          "source_system": "trello",
+          "card_id": "69c24cd3c1a2359ddd7a1bf8",
+          "card_short_id": 7,
+          "board_id": "69be462743bfa0038ca10f7a",
+          "list_id": "69be462743bfa0038ca10f8f",
+          "date_last_activity": "2026-03-24T08:35:56.234Z",
+          "readonly_mapped_at": "2026-03-25T02:31:45.497271Z",
+          "contract_profile": "best_effort_evidence_backed",
+          "ocr_claim_policy": "do_not_claim_success_without_evidence",
+          "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+          "regeneration_token": "regen-20260325-bl033-001"
+        },
+        "automation_contract_profile": "narrow_script_artifact_with_repo_reuse_and_reviewable_runner_contract"
+      }
+    },
+    "critic": {
+      "task_id": "CRITIC-20260325-278",
+      "worker": "critic",
+      "task_type": "review_artifact",
+      "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+      "inputs": {
+        "artifacts": [
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "type": "script"
+          },
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+            "type": "script"
+          }
+        ],
+        "params": {
+          "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+          "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+          "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+          "labels": [
+            "best_effort",
+            "evidence_backed",
+            "readonly",
+            "reviewable",
+            "trello"
+          ],
+          "review_scope": {
+            "primary_artifact": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "paired_artifacts": [
+              "artifacts/scripts/pdf_to_excel_ocr.py"
+            ],
+            "goal": "Audit the wrapper and the reviewed delegate together so the review evidence can speak to the end-to-end readonly smoke path."
+          }
+        }
+      },
+      "expected_outputs": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ],
+      "constraints": [
+        "Review must be grounded in produced automation artifact",
+        "When both wrapper and reviewed delegate snapshots are supplied, evaluate them as one end-to-end readonly pair instead of ignoring the delegate evidence.",
+        "Do not invent missing artifact content",
+        "Return a clear verdict: pass, fail, or needs_revision",
+        "Include metadata.verdict in output",
+        "Generate review artifact markdown for expected_outputs[0].path"
+      ],
+      "priority": "medium",
+      "source": {
+        "kind": "local_inbox",
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl033-001.json",
+        "received_at": "2026-03-25T02:31:52.463880Z",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "regeneration_token": "regen-20260325-bl033-001"
+      },
+      "acceptance_criteria": [
+        "Produce a review artifact with explicit verdict (pass/fail/needs_revision)"
+      ],
+      "metadata": {
+        "integration_phase": "8B",
+        "pipeline": "inbox->adapter->manager->automation->critic",
+        "request_type": "pdf_to_excel_ocr",
+        "payload_hash": "2355ba57c8c083a1e475c973e71dd1164a05ccb489125d7e22eb782738bed37a",
+        "regeneration_token": "regen-20260325-bl033-001",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "external_metadata": {
+          "source_system": "trello",
+          "card_id": "69c24cd3c1a2359ddd7a1bf8",
+          "card_short_id": 7,
+          "board_id": "69be462743bfa0038ca10f7a",
+          "list_id": "69be462743bfa0038ca10f8f",
+          "date_last_activity": "2026-03-24T08:35:56.234Z",
+          "readonly_mapped_at": "2026-03-25T02:31:45.497271Z",
+          "contract_profile": "best_effort_evidence_backed",
+          "ocr_claim_policy": "do_not_claim_success_without_evidence",
+          "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+          "regeneration_token": "regen-20260325-bl033-001"
+        }
+      }
+    }
+  },
+  "expected_artifacts": [
+    "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+    "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py"
+  ],
+  "dedupe_keys": [
+    "origin_regeneration:trello:69c24cd3c1a2359ddd7a1bf8:regen-20260325-bl033-001",
+    "hash:2355ba57c8c083a1e475c973e71dd1164a05ccb489125d7e22eb782738bed37a"
+  ],
+  "risk_warnings": [],
+  "execution": {
+    "status": "rejected",
+    "executed": true,
+    "attempts": 1,
+    "executed_at": "2026-03-25T02:34:04.320380Z",
+    "decision_reason": "critic_verdict=needs_revision"
+  },
+  "approval": {
+    "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-2355ba57c8c0.json",
+    "approved_by": "Oscarling",
+    "approved_at": "2026-03-25T02:32:11.256658Z",
+    "note": "BL-20260325-033 governed validation execute only; no Git finalization; no Trello Done."
+  },
+  "last_execution": {
+    "decision": "rejected",
+    "decision_reason": "critic_verdict=needs_revision",
+    "automation_result": {
+      "task_id": "AUTO-20260325-857",
+      "worker": "automation",
+      "status": "success",
+      "summary": "Generated exactly one runnable local helper wrapper script artifact that prefers the reviewed repository delegate, preserves parameter-driven input/output handling, uses bounded delegate execution with --report-json, parses delegate JSON from stdout or sidecar, applies honest success/partial/failed evidence rules, and avoids writing mismatched non-XLSX content.",
+      "artifacts": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ],
+      "timestamp": "2026-03-25T02:33:41.001826Z",
+      "duration_ms": 62352,
+      "notes": [
+        "The script is designed as a reusable local wrapper baseline around artifacts/scripts/pdf_to_excel_ocr.py rather than re-implementing PDF extraction logic.",
+        "It keeps reviewable status semantics: dry-run and zero-PDF discovery resolve to partial, and wrapper success requires stronger delegate evidence than exit code plus output existence alone.",
+        "Relative delegate resolution is performed from the wrapper/repository location instead of Path.cwd()."
+      ],
+      "metadata": {
+        "task_id": "AUTO-20260325-857",
+        "worker": "automation",
+        "generated_files": 1
+      }
+    },
+    "critic_result": {
+      "task_id": "CRITIC-20260325-278",
+      "worker": "critic",
+      "status": "partial",
+      "summary": "Reviewed the inbox runner together with its delegate as an end-to-end readonly pair. The overall design is aligned with a best-effort evidence-backed smoke path, but the supplied runner snapshot is truncated and therefore cannot be fully validated for syntax/completeness. Verdict: needs_revision.",
+      "artifacts": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ],
+      "timestamp": "2026-03-25T02:34:04.160608Z",
+      "duration_ms": 22753,
+      "errors": [
+        "The snapshot for artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py is truncated, so full-file syntax and final CLI/output behavior cannot be conclusively validated.",
+        "Because the runner snapshot ends mid-parser definition, there is insufficient evidence that the script is complete and executable as provided."
+      ],
+      "notes": [
+        "Review was grounded in the supplied artifact snapshots and evaluated the wrapper and delegate together.",
+        "The delegate script provides evidence-aware reporting and avoids overstating OCR success, which is consistent with the stated contract.",
+        "The wrapper logic shown includes cautious success validation and partial/failure handling, which is positive, but incomplete snapshot evidence prevents a pass verdict."
+      ],
+      "metadata": {
+        "task_id": "CRITIC-20260325-278",
+        "worker": "critic",
+        "verdict": "needs_revision",
+        "reviewed_artifacts": [
+          "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "artifacts/scripts/pdf_to_excel_ocr.py"
+        ],
+        "review_scope": "end-to-end readonly wrapper+delegate review"
+      }
+    },
+    "critic_verdict": "needs_revision"
+  }
+}

--- a/runtime_archives/bl033/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-2355ba57c8c0.result.json
+++ b/runtime_archives/bl033/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-2355ba57c8c0.result.json
@@ -1,0 +1,9 @@
+{
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-2355ba57c8c0",
+  "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-2355ba57c8c0.json",
+  "executed_at": "2026-03-25T02:34:04.321149Z",
+  "status": "rejected",
+  "decision_reason": "critic_verdict=needs_revision",
+  "critic_verdict": "needs_revision",
+  "test_mode": "off"
+}

--- a/runtime_archives/bl033/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl033-001.json
+++ b/runtime_archives/bl033/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl033-001.json
@@ -1,0 +1,41 @@
+{
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "metadata": {
+    "source_system": "trello",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "card_short_id": 7,
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "date_last_activity": "2026-03-24T08:35:56.234Z",
+    "readonly_mapped_at": "2026-03-25T02:31:45.497271Z",
+    "contract_profile": "best_effort_evidence_backed",
+    "ocr_claim_policy": "do_not_claim_success_without_evidence",
+    "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+    "regeneration_token": "regen-20260325-bl033-001"
+  },
+  "source": {
+    "provider": "trello",
+    "mode": "readonly",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "regeneration_token": "regen-20260325-bl033-001"
+  },
+  "request_type": "pdf_to_excel_ocr",
+  "input": {
+    "input_dir": "~/Desktop/pdf样本",
+    "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+    "ocr": "auto",
+    "dry_run": false
+  },
+  "regeneration_token": "regen-20260325-bl033-001"
+}

--- a/runtime_archives/bl033/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl033-001.json.result.json
+++ b/runtime_archives/bl033/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl033-001.json.result.json
@@ -1,0 +1,23 @@
+{
+  "ingested_at": "2026-03-25T02:31:52.464552Z",
+  "status": "processed",
+  "decision": "preview_created_pending_approval",
+  "decision_reason": "preview_created; waiting_for_explicit_approval",
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "payload_hash": "2355ba57c8c083a1e475c973e71dd1164a05ccb489125d7e22eb782738bed37a",
+  "dedupe_keys": [
+    "origin_regeneration:trello:69c24cd3c1a2359ddd7a1bf8:regen-20260325-bl033-001",
+    "hash:2355ba57c8c083a1e475c973e71dd1164a05ccb489125d7e22eb782738bed37a"
+  ],
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-2355ba57c8c0",
+  "preview_file": "/Users/lingguozhong/openclaw-team/preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-2355ba57c8c0.json",
+  "regeneration_token": "regen-20260325-bl033-001"
+}

--- a/runtime_archives/bl033/tmp/bl033_live_mapped_preview.json
+++ b/runtime_archives/bl033/tmp/bl033_live_mapped_preview.json
@@ -1,0 +1,38 @@
+{
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "metadata": {
+    "source_system": "trello",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "card_short_id": 7,
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "date_last_activity": "2026-03-24T08:35:56.234Z",
+    "readonly_mapped_at": "2026-03-25T02:31:45.497271Z",
+    "contract_profile": "best_effort_evidence_backed",
+    "ocr_claim_policy": "do_not_claim_success_without_evidence",
+    "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable"
+  },
+  "source": {
+    "provider": "trello",
+    "mode": "readonly",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f"
+  },
+  "request_type": "pdf_to_excel_ocr",
+  "input": {
+    "input_dir": "~/Desktop/pdf样本",
+    "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+    "ocr": "auto",
+    "dry_run": false
+  }
+}

--- a/runtime_archives/bl033/tmp/bl033_smoke_result.json
+++ b/runtime_archives/bl033/tmp/bl033_smoke_result.json
@@ -1,0 +1,63 @@
+{
+  "status": "pass",
+  "read_count": 1,
+  "scope": {
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": null
+  },
+  "scope_kind": "board",
+  "mapped_preview": {
+    "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+    "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+    "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+    "labels": [
+      "best_effort",
+      "evidence_backed",
+      "readonly",
+      "reviewable",
+      "trello"
+    ],
+    "metadata": {
+      "source_system": "trello",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "card_short_id": 7,
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "date_last_activity": "2026-03-24T08:35:56.234Z",
+      "readonly_mapped_at": "2026-03-25T02:31:45.497271Z",
+      "contract_profile": "best_effort_evidence_backed",
+      "ocr_claim_policy": "do_not_claim_success_without_evidence",
+      "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable"
+    },
+    "source": {
+      "provider": "trello",
+      "mode": "readonly",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f"
+    },
+    "request_type": "pdf_to_excel_ocr",
+    "input": {
+      "input_dir": "~/Desktop/pdf样本",
+      "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+      "ocr": "auto",
+      "dry_run": false
+    }
+  },
+  "auth_env": {
+    "selected_names": {
+      "key": "TRELLO_API_KEY",
+      "token": "TRELLO_API_TOKEN"
+    },
+    "priority": "TRELLO_API_* first, fallback to TRELLO_*",
+    "presence": {
+      "TRELLO_API_KEY": "set",
+      "TRELLO_KEY": "set",
+      "TRELLO_API_TOKEN": "set",
+      "TRELLO_TOKEN": "set",
+      "TRELLO_BOARD_ID": "set",
+      "TRELLO_LIST_ID": "missing"
+    }
+  },
+  "note": "Read-only GET only. No write operations performed."
+}


### PR DESCRIPTION
## Summary
- add POST_REPORT_FLAG_REALIGNMENT_VALIDATION_REPORT.md for BL-20260325-033 governed validation outcome
- archive BL-033 runtime artifacts/logs/state under runtime_archives/bl033
- restore tracked generated artifacts and update backlog/work log
- record follow-up blocker BL-20260325-034 for critic snapshot truncation hardening

## Validation
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh
- git diff --check

Closes #59