### PR TITLE
BL-034: harden critic snapshot completeness

### DIFF
--- a/CRITIC_SNAPSHOT_COMPLETENESS_HARDENING_REPORT.md
+++ b/CRITIC_SNAPSHOT_COMPLETENESS_HARDENING_REPORT.md
@@ -1,0 +1,67 @@
+# Critic Snapshot Completeness Hardening Report
+
+## Objective
+
+Complete `BL-20260325-034` by reducing truncation-driven false negatives in
+critic review input so wrapper/delegate reviews can evaluate sufficiently
+complete artifact context.
+
+## Scope
+
+In scope:
+
+- critic artifact snapshot limit hardening in execute path
+- configurable snapshot-size policy with safe bounds
+- focused regression coverage for non-truncation and truncation behavior
+
+Out of scope:
+
+- fresh governed live Trello validation run
+- prompt-policy redesign for critic semantics
+- git finalization / Trello Done writeback
+
+## Changes
+
+### 1) Increased default snapshot limit and made it configurable
+
+Updated `skills/execute_approved_previews.py`:
+
+- replaced fixed `MAX_SNAPSHOT_CHARS = 12000` with resolved policy:
+  - `DEFAULT_MAX_SNAPSHOT_CHARS = 120000`
+  - env override `ARGUS_CRITIC_MAX_SNAPSHOT_CHARS`
+  - bounded to `[4096, 500000]`
+- added `_resolve_max_snapshot_chars()` for robust parsing/fallback behavior
+
+This keeps defaults large enough for typical wrapper scripts while preserving
+operational guardrails.
+
+### 2) Added focused snapshot-size regressions
+
+Updated `tests/test_execute_approved_previews.py` with:
+
+- `test_build_critic_from_automation_keeps_full_content_under_default_limit`
+  - verifies a 15k+ wrapper artifact is no longer truncated under default
+    policy
+- `test_build_critic_from_automation_truncates_when_limit_exceeded`
+  - verifies truncation remains deterministic when limit is explicitly lowered
+
+Existing critic-artifact preservation tests remain intact.
+
+## Verification
+
+Passed on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_execute_approved_previews.py`
+- `python3 -m unittest -v tests/test_local_inbox_adapter.py`
+- `python3 scripts/backlog_lint.py`
+- `python3 scripts/backlog_sync.py`
+
+## Conclusion
+
+`BL-20260325-034` can be treated as complete as a source-side hardening phase.
+
+The critic snapshot handoff now defaults to materially larger artifact context
+with bounded configurability and focused coverage.
+
+Next required step: run a fresh same-origin governed validation to verify
+runtime critic outcomes under the updated snapshot policy.

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -622,8 +622,8 @@ Allowed enum values:
 ### BL-20260325-034
 - title: Harden critic artifact snapshot completeness to avoid truncation-driven validation rejects
 - type: blocker
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-033
@@ -631,7 +631,24 @@ Allowed enum values:
 - done_when: Critic evidence handoff preserves complete wrapper artifact content (or equivalent complete review context) for generated script reviews, focused tests cover snapshot-size/completeness behavior, and one phase report records the hardening outcome
 - source: `POST_REPORT_FLAG_REALIGNMENT_VALIDATION_REPORT.md` on 2026-03-25 records that fresh governed validation still returns `needs_revision` due critic-side truncated wrapper snapshot evidence
 - link: /Users/lingguozhong/openclaw-team/CRITIC_SNAPSHOT_COMPLETENESS_HARDENING_REPORT.md
-- issue: deferred:phase=next until BL-20260325-033 lands on main
+- issue: https://github.com/Oscarling/openclaw-team/issues/61
+- evidence: `CRITIC_SNAPSHOT_COMPLETENESS_HARDENING_REPORT.md` records hardening in `skills/execute_approved_previews.py` that raises and bounds critic artifact snapshot limits (default 120000 chars with env override), plus focused regressions in `tests/test_execute_approved_previews.py` covering both non-truncation under default policy and deterministic truncation when limits are intentionally lowered
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-035
+- title: Validate BL-20260325-034 critic snapshot completeness hardening on a fresh same-origin governed candidate
+- type: mainline
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-034
+- start_when: `BL-20260325-034` is merged so a fresh same-origin governed run can verify whether increased critic snapshot completeness removes truncation-driven `needs_revision` outcomes under real execute
+- done_when: One governed validation creates a fresh same-origin preview candidate after BL-20260325-034, runs one explicit approval plus one real execute, and records whether critic can now complete full wrapper/delegate review without truncation-driven rejection
+- source: `CRITIC_SNAPSHOT_COMPLETENESS_HARDENING_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation rather than assuming snapshot hardening success without live evidence
+- link: /Users/lingguozhong/openclaw-team/POST_CRITIC_SNAPSHOT_HARDENING_VALIDATION_REPORT.md
+- issue: deferred:phase=next until BL-20260325-034 lands on main
 - evidence: -
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -1279,6 +1279,49 @@ Verification snapshot on 2026-03-25:
   - `runtime_archives/bl033/state/`
   - `runtime_archives/bl033/tmp/`
 
+### 42. Critic Snapshot Completeness Hardening After BL-033
+
+User objective:
+
+- continue after `BL-20260325-033` without mixing live validation into the same
+  phase
+- reduce truncation-driven critic false negatives by improving artifact snapshot
+  completeness at execute-time handoff
+- keep changes minimal, bounded, and test-backed
+
+Main work areas:
+
+- activated `BL-20260325-034` and mirrored it to GitHub issue `#61`
+- updated `skills/execute_approved_previews.py`:
+  - replaced fixed small snapshot cap with bounded policy:
+    - default increased to `120000`
+    - env override `ARGUS_CRITIC_MAX_SNAPSHOT_CHARS`
+    - clamp range `[4096, 500000]`
+- expanded `tests/test_execute_approved_previews.py` with focused cases:
+  - default policy keeps medium-large wrapper content untruncated
+  - explicit low limit still truncates deterministically
+- recorded next fresh governed validation as `BL-20260325-035`
+
+Primary output:
+
+- [CRITIC_SNAPSHOT_COMPLETENESS_HARDENING_REPORT.md](/Users/lingguozhong/openclaw-team/CRITIC_SNAPSHOT_COMPLETENESS_HARDENING_REPORT.md)
+
+Key result:
+
+- `BL-20260325-034` completed as a source-side hardening phase
+- critic snapshot handoff now has materially larger default review context with
+  explicit operational bounds
+- phase outcome remains intentionally source-side; runtime closure is deferred
+  to `BL-20260325-035`
+
+Verification snapshot on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_execute_approved_previews.py` passed
+- `python3 -m unittest -v tests/test_local_inbox_adapter.py` passed
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed with `BL-20260325-034` mirrored to
+  issue `#61`
+
 ### 31. Post-Timeout Governed Validation On Fresh Same-Origin Candidate
 
 User objective:

--- a/skills/execute_approved_previews.py
+++ b/skills/execute_approved_previews.py
@@ -20,7 +20,23 @@ from skills.delegate_task import delegate_task
 PREVIEW_DIR = REPO_ROOT / "preview"
 APPROVALS_DIR = REPO_ROOT / "approvals"
 VERDICT_VALUES = {"pass", "fail", "needs_revision"}
-MAX_SNAPSHOT_CHARS = 12000
+DEFAULT_MAX_SNAPSHOT_CHARS = 120000
+MIN_MAX_SNAPSHOT_CHARS = 4096
+MAX_ALLOWED_SNAPSHOT_CHARS = 500000
+
+
+def _resolve_max_snapshot_chars() -> int:
+    raw = os.environ.get("ARGUS_CRITIC_MAX_SNAPSHOT_CHARS", "").strip()
+    if not raw:
+        return DEFAULT_MAX_SNAPSHOT_CHARS
+    try:
+        parsed = int(raw)
+    except Exception:
+        return DEFAULT_MAX_SNAPSHOT_CHARS
+    return max(MIN_MAX_SNAPSHOT_CHARS, min(parsed, MAX_ALLOWED_SNAPSHOT_CHARS))
+
+
+MAX_SNAPSHOT_CHARS = _resolve_max_snapshot_chars()
 
 
 def utc_now() -> str:

--- a/tests/test_execute_approved_previews.py
+++ b/tests/test_execute_approved_previews.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from skills import execute_approved_previews as executor
 
@@ -128,6 +129,87 @@ class CriticVerdictExtractionTests(unittest.TestCase):
             )
             self.assertIn("runner", snapshots[0]["content"])
             self.assertIn("delegate", snapshots[1]["content"])
+
+    def test_build_critic_from_automation_keeps_full_content_under_default_limit(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="execute-approved-previews-") as tmp:
+            repo_root = Path(tmp)
+            runner_path = repo_root / "artifacts" / "scripts" / "pdf_to_excel_ocr_inbox_runner.py"
+            delegate_path = repo_root / "artifacts" / "scripts" / "pdf_to_excel_ocr.py"
+            runner_path.parent.mkdir(parents=True, exist_ok=True)
+            # Size chosen above legacy 12k truncation threshold and below new default limit.
+            large_runner = ("x" * 15050) + "\n"
+            runner_path.write_text(large_runner, encoding="utf-8")
+            delegate_path.write_text("print('delegate')\n", encoding="utf-8")
+
+            critic_task = {
+                "inputs": {
+                    "artifacts": [
+                        {"path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py", "type": "script"},
+                        {"path": "artifacts/scripts/pdf_to_excel_ocr.py", "type": "script"},
+                    ],
+                    "params": {"review_scope": "pair"},
+                },
+                "expected_outputs": [
+                    {"path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md", "type": "review"}
+                ],
+                "constraints": [],
+            }
+            auto_result = {
+                "artifacts": [
+                    {"path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py", "type": "script"}
+                ]
+            }
+
+            original_repo_root = executor.REPO_ROOT
+            try:
+                executor.REPO_ROOT = repo_root
+                updated = executor.build_critic_from_automation(critic_task, auto_result)
+            finally:
+                executor.REPO_ROOT = original_repo_root
+
+            runner_snapshot = updated["inputs"]["params"]["artifact_snapshots"][0]
+            self.assertFalse(runner_snapshot["truncated"])
+            self.assertEqual(runner_snapshot["content"], large_runner)
+
+    def test_build_critic_from_automation_truncates_when_limit_exceeded(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="execute-approved-previews-") as tmp:
+            repo_root = Path(tmp)
+            runner_path = repo_root / "artifacts" / "scripts" / "pdf_to_excel_ocr_inbox_runner.py"
+            delegate_path = repo_root / "artifacts" / "scripts" / "pdf_to_excel_ocr.py"
+            runner_path.parent.mkdir(parents=True, exist_ok=True)
+            runner_path.write_text("abcdefghijklmnopqrstuvwxyz", encoding="utf-8")
+            delegate_path.write_text("print('delegate')\n", encoding="utf-8")
+
+            critic_task = {
+                "inputs": {
+                    "artifacts": [
+                        {"path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py", "type": "script"},
+                        {"path": "artifacts/scripts/pdf_to_excel_ocr.py", "type": "script"},
+                    ],
+                    "params": {"review_scope": "pair"},
+                },
+                "expected_outputs": [
+                    {"path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md", "type": "review"}
+                ],
+                "constraints": [],
+            }
+            auto_result = {
+                "artifacts": [
+                    {"path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py", "type": "script"}
+                ]
+            }
+
+            original_repo_root = executor.REPO_ROOT
+            try:
+                executor.REPO_ROOT = repo_root
+                with mock.patch.object(executor, "MAX_SNAPSHOT_CHARS", 8):
+                    updated = executor.build_critic_from_automation(critic_task, auto_result)
+            finally:
+                executor.REPO_ROOT = original_repo_root
+
+            runner_snapshot = updated["inputs"]["params"]["artifact_snapshots"][0]
+            self.assertTrue(runner_snapshot["truncated"])
+            self.assertEqual(runner_snapshot["content"], "abcdefgh")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace fixed critic artifact snapshot cap with bounded configurable policy in execute_approved_previews
- raise default snapshot completeness to reduce truncation-driven false negatives
- add focused tests for non-truncation under default limit and deterministic truncation under explicit low limits
- close BL-20260325-034 with report/backlog/work-log evidence and open next governed validation item BL-20260325-035

## Validation
- python3 -m unittest -v tests/test_execute_approved_previews.py
- python3 -m unittest -v tests/test_local_inbox_adapter.py
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh
- git diff --check

Closes #61