### PR TITLE
docs: close BL-035 governed validation and archive runtime evidence

### DIFF
--- a/POST_CRITIC_SNAPSHOT_HARDENING_VALIDATION_REPORT.md
+++ b/POST_CRITIC_SNAPSHOT_HARDENING_VALIDATION_REPORT.md
@@ -1,0 +1,183 @@
+# Post-Critic Snapshot Hardening Validation Report
+
+## Objective
+
+Validate `BL-20260325-034` on one fresh same-origin governed candidate by
+running:
+
+- one live Trello read-only smoke
+- one explicit same-origin regeneration
+- one preview creation
+- one explicit approval
+- one real execute (`test_mode=off`)
+
+This phase objective is validation truth, not forcing a `pass` verdict.
+
+## Scope
+
+In scope:
+
+- one governed run against origin `trello:69c24cd3c1a2359ddd7a1bf8`
+- one regeneration token and one fresh preview candidate
+- runtime evidence capture for automation and critic outcomes
+- explicit recording of whether `BL-20260325-034` removes truncation-driven
+  critic rejection under real execute
+
+Out of scope:
+
+- source-code hardening inside this validation phase
+- git finalization and Trello Done writeback
+- additional live reruns beyond this one governed candidate
+
+## Pre-Run Checks
+
+- branch: `phase8z/validate-bl035-critic-snapshot-hardening`
+- Trello env loaded from `/tmp/trello_env.sh`:
+  - `TRELLO_API_KEY` set
+  - `TRELLO_API_TOKEN` set
+  - `TRELLO_BOARD_ID` set
+- OpenAI runtime values available from:
+  - `secrets/openai_api_key.txt`
+  - `secrets/openai_api_base.txt`
+  - `secrets/openai_model_name.txt`
+- governed execute requires Docker worker access:
+  - first sandboxed execute attempt is captured as environment evidence
+  - elevated replay is used to complete governed runtime validation intent
+
+## Run Summary
+
+Target origin:
+
+- `trello:69c24cd3c1a2359ddd7a1bf8`
+
+Regeneration token:
+
+- `regen-20260325-bl035-001`
+
+### 1) Live Trello read-only smoke
+
+First sandboxed read:
+
+- blocked by DNS / sandbox network policy
+- error: `ConnectionError` / `NameResolutionError`
+
+Elevated rerun:
+
+- `status = pass`
+- `read_count = 1`
+- archive snapshots:
+  - `runtime_archives/bl035/tmp/bl035_smoke_result.json`
+  - `runtime_archives/bl035/tmp/bl035_live_mapped_preview.json`
+
+### 2) Regenerated payload and preview ingest
+
+- generated inbox payload from live `smoke_read.mapped_preview` with token
+  `regen-20260325-bl035-001`
+- ingest result sidecar:
+  - `processed/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl035-001.json.result.json`
+- ingest decision:
+  - `status = processed`
+  - `decision = preview_created_pending_approval`
+  - `preview_id = preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8`
+
+### 3) Preview candidate
+
+Generated preview:
+
+- `preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8`
+- preview file:
+  - `preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8.json`
+
+Pre-execute state:
+
+- `approved = false`
+- `execution.status = pending_approval`
+- `execution.attempts = 0`
+- `source.regeneration_token = regen-20260325-bl035-001`
+
+### 4) Explicit approval
+
+- approval file:
+  - `approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8.json`
+
+### 5) Real execute (`test_mode=off`)
+
+First sandboxed execute:
+
+- rejected before worker dispatch
+- reason:
+  `Failed to initialize docker client from environment. Ensure Docker access is available or pass docker_client explicitly.`
+- archive snapshot:
+  - `runtime_archives/bl035/tmp/bl035_execute_once_sandbox.json`
+
+Elevated replay execute (`--allow-replay`):
+
+- final result sidecar:
+  - `approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8.result.json`
+- `status = rejected`
+- `decision_reason = critic_verdict=needs_revision`
+
+Worker outcomes:
+
+- automation:
+  - task `AUTO-20260325-858`
+  - `status = success`
+  - artifact: `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`
+- critic:
+  - task `CRITIC-20260325-279`
+  - `status = success`
+  - verdict: `needs_revision`
+  - artifact: `artifacts/reviews/pdf_to_excel_ocr_inbox_review.md`
+
+Final preview execution state:
+
+- `approved = true`
+- `execution.status = rejected`
+- `execution.executed = true`
+- `execution.attempts = 2`
+
+## Critical Findings
+
+This validation still ended with `critic_verdict=needs_revision`, but the
+dominant blocker is no longer snapshot truncation.
+
+Observed runtime signals:
+
+- critic produced a detailed full-pair review across wrapper and delegate, with
+  concrete findings about semantic contract alignment
+- critic output did not report truncated wrapper evidence as the primary blocker
+- new blocker cluster is contract semantics between wrapper and delegate:
+  - zero-input handling mismatch (`partial` intent in wrapper vs `failed` in
+    delegate)
+  - delegate aggregate status can report `success` despite partial file outcomes
+  - delegate canonical report lacks explicit output-write attestation fields
+
+Inference from this run:
+
+- `BL-20260325-034` appears to have addressed the truncation-driven rejection
+  pattern sufficiently for critic to complete broader contract review.
+- end-to-end pass is still blocked by runtime semantics in the wrapper/delegate
+  contract rather than evidence-window size.
+
+## Validation Conclusion
+
+`BL-20260325-035` is complete as a governed validation phase.
+
+It answers the intended question after `BL-20260325-034`: critic snapshot
+completeness hardening no longer presents as the dominant runtime blocker in
+this run, but the end-to-end path still fails review due remaining
+wrapper/delegate semantic contract mismatches.
+
+Next required phase: harden delegate/wrapper semantic alignment for zero-input,
+aggregate status truthfulness, and explicit output-write evidence, then rerun a
+fresh governed validation.
+
+## Archive Preservation
+
+To preserve runtime evidence and avoid loss from tracked artifact overwrite, this
+phase archived outputs under:
+
+- `runtime_archives/bl035/artifacts/`
+- `runtime_archives/bl035/runtime/`
+- `runtime_archives/bl035/state/`
+- `runtime_archives/bl035/tmp/`

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -639,8 +639,8 @@ Allowed enum values:
 ### BL-20260325-035
 - title: Validate BL-20260325-034 critic snapshot completeness hardening on a fresh same-origin governed candidate
 - type: mainline
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-034
@@ -648,7 +648,24 @@ Allowed enum values:
 - done_when: One governed validation creates a fresh same-origin preview candidate after BL-20260325-034, runs one explicit approval plus one real execute, and records whether critic can now complete full wrapper/delegate review without truncation-driven rejection
 - source: `CRITIC_SNAPSHOT_COMPLETENESS_HARDENING_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation rather than assuming snapshot hardening success without live evidence
 - link: /Users/lingguozhong/openclaw-team/POST_CRITIC_SNAPSHOT_HARDENING_VALIDATION_REPORT.md
-- issue: deferred:phase=next until BL-20260325-034 lands on main
+- issue: https://github.com/Oscarling/openclaw-team/issues/63
+- evidence: `POST_CRITIC_SNAPSHOT_HARDENING_VALIDATION_REPORT.md` records one fresh same-origin governed run (`regen-20260325-bl035-001`) to preview `preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8` with explicit approval and one elevated real execute replay; automation (`AUTO-20260325-858`) and critic (`CRITIC-20260325-279`) both completed, critic still returned `needs_revision`, and the dominant blocker shifted from snapshot truncation to wrapper/delegate semantic alignment issues (zero-input status semantics, aggregate partial accounting, and explicit output-write attestation)
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-036
+- title: Harden wrapper/delegate semantic contract alignment after BL-20260325-035 runtime findings
+- type: blocker
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-035
+- start_when: `BL-20260325-035` has completed and confirmed truncation is no longer the dominant blocker but runtime review still fails on wrapper/delegate semantic contract mismatches
+- done_when: Delegate/wrapper contract is aligned on zero-input semantics and aggregate status truthfulness, delegate report includes explicit output-write evidence fields required for reviewability, focused tests cover the new semantics, and one hardening report records the outcome
+- source: `POST_CRITIC_SNAPSHOT_HARDENING_VALIDATION_REPORT.md` on 2026-03-25 records `needs_revision` due semantic contract drift instead of snapshot truncation
+- link: /Users/lingguozhong/openclaw-team/SEMANTIC_CONTRACT_ALIGNMENT_HARDENING_REPORT.md
+- issue: deferred:phase=next until BL-20260325-035 lands on main
 - evidence: -
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -1322,6 +1322,72 @@ Verification snapshot on 2026-03-25:
 - `python3 scripts/backlog_sync.py` passed with `BL-20260325-034` mirrored to
   issue `#61`
 
+### 43. Fresh Governed Validation After BL-034 Snapshot Hardening
+
+User objective:
+
+- continue immediately with the next governed validation phase
+- validate `BL-20260325-034` on one fresh same-origin candidate instead of
+  assuming source-side hardening solved runtime behavior
+- preserve runtime evidence and keep workflow-gated delivery
+
+Main work areas:
+
+- activated `BL-20260325-035` and mirrored it to GitHub issue `#63`
+- ran live Trello read-only smoke for origin
+  `trello:69c24cd3c1a2359ddd7a1bf8`
+  - first sandboxed call blocked by DNS policy
+  - elevated rerun passed with `read_count=1`
+- generated one regeneration token:
+  - `regen-20260325-bl035-001`
+- created inbox payload from `smoke_read.mapped_preview`, ingested once, and
+  created fresh preview:
+  - `preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8`
+- wrote explicit approval and ran real execute in `test_mode=off`
+  - first sandboxed execute blocked before dispatch due Docker client access
+  - elevated replay (`--allow-replay`) completed governed runtime intent
+- archived runtime outputs under `runtime_archives/bl035/` before restoring
+  tracked `artifacts/` baselines
+- recorded next blocker phase as `BL-20260325-036`
+
+Primary output:
+
+- [POST_CRITIC_SNAPSHOT_HARDENING_VALIDATION_REPORT.md](/Users/lingguozhong/openclaw-team/POST_CRITIC_SNAPSHOT_HARDENING_VALIDATION_REPORT.md)
+
+Key result:
+
+- `BL-20260325-035` completed as a governed validation phase
+- final execute still returned:
+  - `critic_verdict = needs_revision`
+- prior dominant truncation blocker did not reappear in critic outcome
+- new dominant blocker is semantic contract alignment between wrapper and
+  delegate:
+  - zero-input status mismatch
+  - aggregate status truthfulness for partial outcomes
+  - missing explicit output-write evidence fields in delegate report
+- backlog updates from this phase:
+  - `BL-20260325-035` marked done with evidence
+  - `BL-20260325-036` created for source-side semantic contract hardening
+
+Verification snapshot on 2026-03-25:
+
+- smoke (elevated) returned `status=pass` with `read_count=1`
+- `python3 skills/ingest_tasks.py --once` returned:
+  - `processed = 1`
+  - `preview_created = 1`
+- sandboxed execute returned Docker-client initialization rejection
+- elevated replay execute returned:
+  - `status = rejected`
+  - `decision_reason = critic_verdict=needs_revision`
+- worker outcomes:
+  - automation `AUTO-20260325-858`: `success`
+  - critic `CRITIC-20260325-279`: `success` with verdict `needs_revision`
+- runtime archive preserved under:
+  - `runtime_archives/bl035/artifacts/`
+  - `runtime_archives/bl035/runtime/`
+  - `runtime_archives/bl035/state/`
+  - `runtime_archives/bl035/tmp/`
+
 ### 31. Post-Timeout Governed Validation On Fresh Same-Origin Candidate
 
 User objective:

--- a/runtime_archives/bl035/artifacts/pdf_to_excel_ocr_inbox_review.md
+++ b/runtime_archives/bl035/artifacts/pdf_to_excel_ocr_inbox_review.md
@@ -1,0 +1,100 @@
+# Review: pdf_to_excel_ocr_inbox_runner.py
+
+## Scope
+
+Reviewed the following artifacts together as a readonly end-to-end pair, per review scope:
+
+- `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`
+- `artifacts/scripts/pdf_to_excel_ocr.py`
+
+Assessment focus:
+
+- wrapper/delegate alignment
+- readonly smoke-path honesty
+- evidence-backed success/failure semantics
+- deterministic local-artifact behavior
+- JSON/reporting behavior suitable for reviewability
+
+## Findings
+
+### Strengths
+
+1. **Wrapper preserves readonly, reviewable behavior well**
+   - No Trello writeback behavior is present.
+   - Control flow is local-artifact oriented and deterministic.
+   - The wrapper explicitly avoids claiming success from process exit code alone.
+   - It requires canonical delegate evidence fields (`status`, `total_files`, `status_counter`, `dry_run`) and also checks XLSX existence/size.
+
+2. **Good preflight and partial-outcome handling in wrapper**
+   - Dry-run returns `partial` honestly without delegation.
+   - Missing input directory returns `failed`.
+   - Zero discovered PDFs returns `partial` with explicit notes instead of falsely claiming success.
+   - Delegate timeout is bounded and reported.
+
+3. **Good path resolution and reporting ergonomics in wrapper**
+   - Relative path handling is designed to be independent of `Path.cwd()`.
+   - Optional wrapper sidecar reporting is supported.
+   - Delegate stdout and sidecar JSON are both considered as evidence sources.
+
+4. **Delegate has solid batch-processing foundations**
+   - Recursive PDF discovery.
+   - Per-file isolation via `FileResult` and exception capture.
+   - OCR modes `auto|on|off` and Chinese-friendly default OCR language.
+   - JSON report emission to stdout and optional sidecar.
+   - Excel output includes summary and per-file sheets.
+
+### Issues
+
+1. **Zero-input semantics are misaligned between wrapper and delegate**
+   - Wrapper contract intentionally treats zero discovered PDFs as an honest `partial` outcome.
+   - Delegate emits:
+     - `status: "failed"`
+     - return code `2`
+     when no PDFs are found.
+   - This creates an end-to-end semantic mismatch for the readonly smoke path, where zero inputs should remain reviewable rather than be treated as a hard failure.
+
+2. **Delegate overall status can overstate success when partial files exist**
+   - Delegate computes overall status as:
+     - `success` if `failed == 0`
+     - otherwise `partial`
+   - This ignores `partial` file results.
+   - Therefore a batch with one or more `partial` items and zero `failed` items will be reported as overall `success`, which is too optimistic for an evidence-backed contract.
+   - The wrapper compensates by checking `status_counter.partial == 0` before declaring wrapper success, but this means the pair relies on wrapper correction of delegate semantics rather than consistent delegate truthfulness.
+
+3. **Delegate report does not directly attest to write success beyond status/error fields**
+   - The wrapper requires actual XLSX file existence and non-zero size, which is good.
+   - But the delegate’s canonical report omits an explicit `excel_written: true/false` or similar field.
+   - As a result, the success contract is split across delegate JSON plus wrapper filesystem checks rather than being fully self-describing in delegate evidence.
+
+4. **Dry-run semantics in delegate are somewhat broad but acceptable**
+   - Delegate still processes PDFs in dry-run mode and only skips Excel writing.
+   - This is not incorrect, but the wrapper’s own dry-run means “do not delegate at all,” so there are two different dry-run layers with different meanings.
+   - That can be reviewable, but should be documented more explicitly to avoid confusion.
+
+5. **Per-file details are not included in delegate’s canonical report**
+   - The delegate computes detailed `FileResult` rows, but the JSON report only contains aggregate counters.
+   - For a best-effort, evidence-backed smoke path, a compact per-file summary in the report would improve auditability, especially when Excel writing fails or is skipped.
+
+## Verdict
+
+**needs_revision**
+
+## Rationale
+
+The wrapper is thoughtfully implemented and strongly aligned with the readonly, evidence-backed smoke contract. It is cautious about success claims, handles partial scenarios honestly, and evaluates delegate output more rigorously than the delegate itself.
+
+However, when reviewed as the required end-to-end pair, there are notable semantic inconsistencies that prevent a full pass:
+
+- zero-input handling is `partial` in the wrapper conceptually but `failed` in the delegate,
+- delegate batch status can incorrectly report `success` even when partial file outcomes exist,
+- canonical report evidence could be stronger and more self-describing.
+
+These are revision-level issues rather than total failure because the wrapper already mitigates some of the delegate weaknesses and the overall design is close to the stated contract.
+
+## Recommended revisions
+
+1. Change delegate zero-PDF outcome from hard `failed` to an honest reviewable `partial` status, or otherwise align both components on one documented contract.
+2. Change delegate aggregate status logic so any `partial` file result prevents overall `success`.
+3. Add explicit output-write evidence in delegate report, such as `excel_written`, `output_exists`, and `output_size_bytes` after write.
+4. Optionally include lightweight per-file results in the delegate JSON report to improve reviewability without requiring Excel inspection.
+5. Clarify dry-run semantics between wrapper dry-run and delegate dry-run in comments/help text.

--- a/runtime_archives/bl035/artifacts/pdf_to_excel_ocr_inbox_runner.py
+++ b/runtime_archives/bl035/artifacts/pdf_to_excel_ocr_inbox_runner.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""Reviewable inbox wrapper for the reviewed PDF-to-Excel delegate.
+
+This wrapper prefers delegating to the repository-reviewed implementation at
+artifacts/scripts/pdf_to_excel_ocr.py and keeps a narrow, evidence-backed
+control flow suitable for readonly smoke previews.
+
+Key contract behaviors:
+- parameter-driven input/output paths
+- portable delegate resolution independent of Path.cwd()
+- honest partial outcome for dry-run short-circuit or zero discovered PDFs
+- explicit delegate timeout
+- canonical evidence from delegate JSON fields:
+  status, total_files, status_counter, dry_run
+- JSON report handoff via stdout and optional --report-json sidecar
+- no claim of success from exit code/output existence alone
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+DEFAULT_INPUT_DIR = "~/Desktop/pdf样本"
+DEFAULT_OUTPUT_XLSX = "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx"
+DEFAULT_OCR = "auto"
+DEFAULT_ORIGIN_ID = "trello:69c24cd3c1a2359ddd7a1bf8"
+DEFAULT_TITLE = "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)"
+DEFAULT_DESCRIPTION = (
+    "Purpose:\n"
+    "Controlled Trello live preview smoke for openclaw-team.\n"
+    "Expected behavior:\n"
+    "- read-only Trello ingest\n"
+    "- preview creation smoke only\n"
+    "- no business execution claim\n"
+    "- no Trello writeback expected in this step\n"
+    "Traceability:\n"
+    "- backlog: BL-20260324-014\n"
+    "- blocker context: BL-20260324-015\n"
+    "- created_by: Oscarling\n"
+    "- created_at: 2026-03-24 Asia/Shanghai\n"
+    "Note:\n"
+    "This card is only for governed smoke verification and should remain open until the smoke is finished."
+)
+DEFAULT_LABELS = ["best_effort", "evidence_backed", "readonly", "reviewable", "trello"]
+DEFAULT_TIMEOUT_SECONDS = 600
+DEFAULT_BASE_SCRIPT = "artifacts/scripts/pdf_to_excel_ocr.py"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def make_jsonable(value: Any) -> Any:
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, dict):
+        return {str(k): make_jsonable(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [make_jsonable(v) for v in value]
+    return value
+
+
+def emit_summary(payload: Dict[str, Any]) -> None:
+    print(json.dumps(make_jsonable(payload), ensure_ascii=False, indent=2, sort_keys=True))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Readonly reviewable wrapper around the reviewed PDF-to-Excel OCR delegate."
+    )
+    parser.add_argument("--input-dir", default=DEFAULT_INPUT_DIR, help="Directory containing PDF inputs.")
+    parser.add_argument("--output-xlsx", default=DEFAULT_OUTPUT_XLSX, help="Target XLSX output path.")
+    parser.add_argument("--ocr", default=DEFAULT_OCR, help="OCR mode to pass through to the delegate.")
+    parser.add_argument("--dry-run", action="store_true", help="Short-circuit reviewable preflight without delegate execution.")
+    parser.add_argument("--origin-id", default=DEFAULT_ORIGIN_ID, help="External source origin identifier.")
+    parser.add_argument("--title", default=DEFAULT_TITLE, help="Traceability title.")
+    parser.add_argument("--description", default=DEFAULT_DESCRIPTION, help="Traceability description.")
+    parser.add_argument("--label", dest="labels", action="append", default=None, help="Repeatable label.")
+    parser.add_argument(
+        "--base-script",
+        default=DEFAULT_BASE_SCRIPT,
+        help="Preferred reviewed delegate script path. Relative paths resolve from repo/script location.",
+    )
+    parser.add_argument(
+        "--report-json",
+        default=None,
+        help="Optional wrapper summary output path. If provided, writes wrapper summary JSON there.",
+    )
+    parser.add_argument(
+        "--delegate-timeout-seconds",
+        type=int,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help="Timeout for delegate execution in seconds.",
+    )
+    return parser.parse_args()
+
+
+def infer_repo_root(script_path: Path) -> Path:
+    # Expected location: <repo>/artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
+    if script_path.parent.name == "scripts" and script_path.parent.parent.name == "artifacts":
+        return script_path.parent.parent.parent
+    return script_path.parent
+
+
+def resolve_path(raw_path: str, repo_root: Path, script_dir: Path) -> Path:
+    expanded = Path(os.path.expanduser(raw_path))
+    if expanded.is_absolute():
+        return expanded
+
+    candidate_repo = (repo_root / expanded).resolve()
+    if candidate_repo.exists() or raw_path.startswith("artifacts/"):
+        return candidate_repo
+    return (script_dir / expanded).resolve()
+
+
+def discover_pdfs(input_dir: Path) -> List[Path]:
+    # Recursive discovery to stay aligned with typical delegate processing semantics.
+    return sorted(p for p in input_dir.rglob("*.pdf") if p.is_file())
+
+
+def try_parse_json_object(text: str) -> Optional[Dict[str, Any]]:
+    text = text.strip()
+    if not text:
+        return None
+    try:
+        parsed = json.loads(text)
+        return parsed if isinstance(parsed, dict) else None
+    except json.JSONDecodeError:
+        pass
+
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    for idx in range(len(lines)):
+        candidate = "\n".join(lines[idx:])
+        try:
+            parsed = json.loads(candidate)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            continue
+    return None
+
+
+def load_json_file(path: Path) -> Optional[Dict[str, Any]]:
+    if not path.exists() or not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def evaluate_delegate_report(report: Dict[str, Any], output_xlsx: Path) -> Dict[str, Any]:
+    status = report.get("status")
+    total_files = report.get("total_files")
+    status_counter = report.get("status_counter") or {}
+    dry_run = bool(report.get("dry_run", False))
+
+    succeeded = int(status_counter.get("success", 0) or 0)
+    failed = int(status_counter.get("failed", 0) or 0)
+    partial = int(status_counter.get("partial", 0) or 0)
+
+    evidence_ok = (
+        status == "success"
+        and isinstance(total_files, int)
+        and total_files > 0
+        and succeeded > 0
+        and failed == 0
+        and partial == 0
+        and not dry_run
+        and output_xlsx.exists()
+        and output_xlsx.is_file()
+        and output_xlsx.stat().st_size > 0
+    )
+
+    if evidence_ok:
+        wrapper_status = "success"
+        rationale = "delegate_report_confirmed_success"
+    elif dry_run:
+        wrapper_status = "partial"
+        rationale = "delegate_report_is_dry_run"
+    elif isinstance(total_files, int) and total_files == 0:
+        wrapper_status = "partial"
+        rationale = "delegate_report_zero_inputs"
+    elif status in {"partial", "failed"}:
+        wrapper_status = status
+        rationale = "delegate_report_non_success"
+    else:
+        wrapper_status = "partial"
+        rationale = "delegate_report_insufficient_success_evidence"
+
+    return {
+        "wrapper_status": wrapper_status,
+        "rationale": rationale,
+        "canonical": {
+            "status": status,
+            "total_files": total_files,
+            "status_counter": status_counter,
+            "dry_run": dry_run,
+        },
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    script_path = Path(__file__).resolve()
+    script_dir = script_path.parent
+    repo_root = infer_repo_root(script_path)
+
+    input_dir = resolve_path(args.input_dir, repo_root=repo_root, script_dir=script_dir)
+    output_xlsx = resolve_path(args.output_xlsx, repo_root=repo_root, script_dir=script_dir)
+    delegate_script = resolve_path(args.base_script, repo_root=repo_root, script_dir=script_dir)
+    wrapper_report_path = resolve_path(args.report_json, repo_root=repo_root, script_dir=script_dir) if args.report_json else None
+    labels = args.labels if args.labels is not None else list(DEFAULT_LABELS)
+
+    summary: Dict[str, Any] = {
+        "status": "failed",
+        "title": args.title,
+        "origin_id": args.origin_id,
+        "description": args.description,
+        "labels": labels,
+        "timestamps": {
+            "started_at": utc_now(),
+        },
+        "request": {
+            "input_dir": str(input_dir),
+            "output_xlsx": str(output_xlsx),
+            "ocr": args.ocr,
+            "dry_run": bool(args.dry_run),
+        },
+        "execution": {
+            "wrapper_script": str(script_path),
+            "delegated": False,
+            "delegate_script": str(delegate_script),
+            "delegate_timeout_seconds": int(args.delegate_timeout_seconds),
+        },
+        "preflight": {},
+        "delegate": None,
+        "artifacts": {
+            "output_xlsx": str(output_xlsx),
+            "wrapper_report_json": str(wrapper_report_path) if wrapper_report_path else None,
+        },
+        "errors": [],
+    }
+
+    if output_xlsx.suffix.lower() != ".xlsx":
+        summary["status"] = "failed"
+        summary["errors"].append("output_xlsx must end with .xlsx to preserve real XLSX semantics")
+        summary["timestamps"]["finished_at"] = utc_now()
+        if wrapper_report_path:
+            wrapper_report_path.parent.mkdir(parents=True, exist_ok=True)
+            wrapper_report_path.write_text(json.dumps(make_jsonable(summary), ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+        emit_summary(summary)
+        return 1
+
+    if not delegate_script.exists() or not delegate_script.is_file():
+        summary["status"] = "failed"
+        summary["errors"].append(f"reviewed delegate not found: {delegate_script}")
+        summary["timestamps"]["finished_at"] = utc_now()
+        if wrapper_report_path:
+            wrapper_report_path.parent.mkdir(parents=True, exist_ok=True)
+            wrapper_report_path.write_text(json.dumps(make_jsonable(summary), ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+        emit_summary(summary)
+        return 1
+
+    existing_pdfs = discover_pdfs(input_dir) if input_dir.exists() and input_dir.is_dir() else []
+    summary["preflight"] = {
+        "input_dir_exists": input_dir.exists(),
+        "input_dir_is_dir": input_dir.is_dir(),
+        "discovered_pdf_count": len(existing_pdfs),
+        "discovered_pdf_samples": [str(p) for p in existing_pdfs[:10]],
+    }
+
+    if args.dry_run:
+        summary["status"] = "partial"
+        summary["timestamps"]["finished_at"] = utc_now()
+        summary["notes"] = [
+            "Dry-run requested; wrapper intentionally did not delegate.",
+            "Reviewable partial outcome with execution.delegated=false.",
+        ]
+        if wrapper_report_path:
+            wrapper_report_path.parent.mkdir(parents=True, exist_ok=True)
+            wrapper_report_path.write_text(json.dumps(make_jsonable(summary), ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+        emit_summary(summary)
+        return 0
+
+    if not input_dir.exists() or not input_dir.is_dir():
+        summary["status"] = "failed"
+        summary["errors"].append(f"input_dir is not a readable directory: {input_dir}")
+        summary["timestamps"]["finished_at"] = utc_now()
+        if wrapper_report_path:
+            wrapper_report_path.parent.mkdir(parents=True, exist_ok=True)
+            wrapper_report_path.write_text(json.dumps(make_jsonable(summary), ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+        emit_summary(summary)
+        return 1
+
+    if len(existing_pdfs) == 0:
+        summary["status"] = "partial"
+        summary["timestamps"]["finished_at"] = utc_now()
+        summary["notes"] = [
+            "No PDF files discovered during preflight.",
+            "Partial outcome reported honestly without claiming XLSX production success.",
+        ]
+        if wrapper_report_path:
+            wrapper_report_path.parent.mkdir(parents=True, exist_ok=True)
+            wrapper_report_path.write_text(json.dumps(make_jsonable(summary), ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+        emit_summary(summary)
+        return 0
+
+    output_xlsx.parent.mkdir(parents=True, exist_ok=True)
+    delegate_report_path = output_xlsx.with_suffix(output_xlsx.suffix + ".delegate_report.json")
+
+    cmd = [
+        sys.executable,
+        str(delegate_script),
+        "--input-dir",
+        str(input_dir),
+        "--output-xlsx",
+        str(output_xlsx),
+        "--ocr",
+        str(args.ocr),
+        "--report-json",
+        str(delegate_report_path),
+    ]
+
+    summary["execution"]["delegated"] = True
+    summary["execution"]["delegate_command"] = cmd
+
+    try:
+        completed = subprocess.run(
+            cmd,
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            timeout=int(args.delegate_timeout_seconds),
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        summary["status"] = "failed"
+        summary["delegate"] = {
+            "timeout": True,
+            "returncode": None,
+            "stdout": exc.stdout,
+            "stderr": exc.stderr,
+            "report_path": str(delegate_report_path),
+        }
+        summary["errors"].append(f"delegate timed out after {args.delegate_timeout_seconds} seconds")
+        summary["timestamps"]["finished_at"] = utc_now()
+        if wrapper_report_path:
+            wrapper_report_path.parent.mkdir(parents=True, exist_ok=True)
+            wrapper_report_path.write_text(json.dumps(make_jsonable(summary), ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+        emit_summary(summary)
+        return 1
+
+    stdout_report = try_parse_json_object(completed.stdout or "")
+    sidecar_report = load_json_file(delegate_report_path)
+    delegate_report = stdout_report if stdout_report else sidecar_report
+
+    summary["delegate"] = {
+        "timeout": False,
+        "returncode": completed.returncode,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+        "report_path": str(delegate_report_path),
+        "report_source": "stdout" if stdout_report else ("sidecar" if sidecar_report else None),
+        "report": delegate_report,
+    }
+
+    if not isinstance(delegate_report, dict):
+        summary["status"] = "partial" if completed.returncode == 0 else "failed"
+        summary["errors"].append("delegate did not provide a parseable canonical JSON report via stdout or --report-json sidecar")
+        summary["timestamps"]["finished_at"] = utc_now()
+        if wrapper_report_path:
+            wrapper_report_path.parent.mkdir(parents=True, exist_ok=True)
+            wrapper_report_path.write_text(json.dumps(make_jsonable(summary), ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+        emit_summary(summary)
+        return 0 if summary["status"] == "partial" else 1
+
+    evaluation = evaluate_delegate_report(delegate_report, output_xlsx=output_xlsx)
+    summary["status"] = evaluation["wrapper_status"]
+    summary["delegate"]["evaluation"] = evaluation
+
+    if summary["status"] == "success":
+        summary["notes"] = [
+            "Wrapper success is backed by canonical delegate report evidence.",
+            "Delegate reported successful processing with at least one input and no failed/partial counterexamples.",
+        ]
+    elif summary["status"] == "partial":
+        summary["notes"] = [
+            "Wrapper preserved a reviewable partial outcome because canonical success evidence was incomplete.",
+            f"Rationale: {evaluation['rationale']}",
+        ]
+    else:
+        summary["errors"].append(f"delegate outcome failed: {evaluation['rationale']}")
+
+    summary["timestamps"]["finished_at"] = utc_now()
+
+    if wrapper_report_path:
+        wrapper_report_path.parent.mkdir(parents=True, exist_ok=True)
+        wrapper_report_path.write_text(json.dumps(make_jsonable(summary), ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+
+    emit_summary(summary)
+    return 0 if summary["status"] in {"success", "partial"} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runtime_archives/bl035/runtime/AUTO-20260325-858.json
+++ b/runtime_archives/bl035/runtime/AUTO-20260325-858.json
@@ -1,0 +1,191 @@
+{
+  "task_id": "AUTO-20260325-858",
+  "worker": "automation",
+  "status": "success",
+  "created_at": "2026-03-25T04:21:11.796875Z",
+  "updated_at": "2026-03-25T04:22:35.160297Z",
+  "retries": 0,
+  "max_retries": 0,
+  "attempts": [
+    {
+      "attempt": 1,
+      "status": "success",
+      "retryable": false,
+      "error": null,
+      "runtime_log": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-858/runtime.attempt-1.log",
+      "exit_code": 0,
+      "timed_out": false,
+      "wait_error": null,
+      "output_path": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-858/output.json",
+      "started_at": "2026-03-25T04:21:11.798701Z",
+      "finished_at": "2026-03-25T04:22:35.135250Z"
+    }
+  ],
+  "task_dir": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-858",
+  "payload": {
+    "task_id": "AUTO-20260325-858",
+    "worker": "automation",
+    "task_type": "generate_script",
+    "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+    "inputs": {
+      "params": {
+        "input_dir": "~/Desktop/pdf样本",
+        "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+        "ocr": "auto",
+        "dry_run": false,
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "description": "Purpose: | Controlled Trello live preview smoke for openclaw-team. | Expected behavior: | - read-only Trello ingest | - preview creation smoke only | - no business execution claim | - no Trello writeback expected in this step | Traceability: | - backlog: BL-20260324-014 | - blocker context: BL-20260324-015 | - created_by: Oscarling | - created_at: 2026-03-24 Asia/Shanghai | Note: | This card is only for governed smoke verification and should remain open until the smoke is finished.",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "preferred_wrapper_script": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "preferred_base_script": "artifacts/scripts/pdf_to_excel_ocr.py",
+        "reference_docs": [
+          "artifacts/docs/pdf_to_excel_ocr_usage.md",
+          "artifacts/reviews/pdf_to_excel_ocr_review.md"
+        ],
+        "contract_hints": {
+          "output_format_fidelity": "If output_xlsx ends with .xlsx, produce a real XLSX workbook container or fail honestly before writing mismatched text/XML/CSV content to a .xlsx path.",
+          "path_portability": "Use the provided input_dir parameter as runtime input. Do not hardcode a user-home or absolute input path when params already declare the path.",
+          "traceability": "Preserve meaningful description context from the external input; do not collapse it to a heading fragment such as Purpose:.",
+          "reuse_preference": "Prefer reusing artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py as the wrapper baseline and artifacts/scripts/pdf_to_excel_ocr.py as the reviewed delegate when compatible, so workbook semantics and contract behavior stay aligned with repository evidence.",
+          "outcome_status_model": "Use the reviewable status model success/partial/failed. Dry-run requests or zero-PDF discovery should resolve to partial rather than claiming success without an output artifact.",
+          "delegate_resolution": "If preferred_base_script is relative, resolve it from the repository or script location instead of Path.cwd() so behavior stays portable across shells and CI.",
+          "reviewed_delegate_contract": "For readonly reviewable preview flows, delegate only to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py or fail honestly instead of broadening behavior through an arbitrary helper.",
+          "delegate_success_evidence": "Do not treat zero exit code plus output-file existence as sufficient wrapper success evidence on their own. Prefer a structured delegate report that confirms a real success outcome with at least one processed input and no failed-file counterexamples before the wrapper claims success.",
+          "delegate_timeout": "Bound delegate subprocess execution with an explicit timeout and report timeout as an honest failed/partial outcome instead of allowing smoke automation to hang indefinitely.",
+          "runtime_summary": "The generated script should emit a structured summary of what it produced so later review can inspect behavior without guessing.",
+          "delegate_report_schema": "Treat delegate JSON report fields status/total_files/status_counter/dry_run as the canonical evidence contract. Do not require undeclared processed_files/succeeded_files/failed_files counters.",
+          "delegate_report_handoff": "When the delegate prints a JSON report to stdout, parse that JSON directly instead of relying only on sidecar-report file path discovery.",
+          "delegate_report_flag_contract": "If wrapper passes a sidecar report path to the reviewed delegate, use the reviewed delegate CLI flag --report-json (or another explicitly supported alias). Do not invent undeclared flags such as --report-file.",
+          "dry_run_semantics": "If wrapper dry-run short-circuits before delegate execution, keep execution.delegated=false and report partial honestly. If wrapper does delegate under dry-run, pass through --dry-run explicitly.",
+          "pdf_discovery_consistency": "Keep wrapper preflight PDF discovery semantics aligned with the reviewed delegate (for example recursive vs non-recursive), so wrapper evidence and delegated execution count the same candidate set."
+        }
+      }
+    },
+    "expected_outputs": [
+      {
+        "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "type": "script"
+      }
+    ],
+    "constraints": [
+      "Follow the local inbox normalized request",
+      "Do not claim unsupported runtime dependencies",
+      "Keep output deterministic and executable",
+      "Produce only the expected script artifact",
+      "Prefer honest, reviewable intermediate behavior over unsupported OCR claims",
+      "If the requested output path ends with .xlsx, do not write non-XLSX text/XML/CSV content to that path.",
+      "Do not hardcode an input directory when the task params already provide input_dir.",
+      "Preserve meaningful traceability from the incoming description instead of collapsing it to a heading fragment.",
+      "Prefer wrapping or adapting artifacts/scripts/pdf_to_excel_ocr.py when that existing repo script already matches the requested behavior.",
+      "When artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py already exists, prefer updating that reviewed wrapper baseline instead of rewriting a new control flow from scratch.",
+      "If dry_run is true or no PDFs are discovered, report a reviewable partial outcome instead of claiming success without an XLSX artifact.",
+      "Resolve relative delegate script paths from the repository or script location, not from Path.cwd().",
+      "For readonly reviewable preview flows, only delegate to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py unless failing honestly.",
+      "Do not claim wrapper success from exit code plus output existence alone when the reviewed delegate report does not provide strong enough success evidence.",
+      "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
+      "When delegate emits JSON to stdout, parse that report directly instead of depending only on sidecar report-file discovery.",
+      "When wrapper passes a sidecar report path to the reviewed delegate, use --report-json exactly unless the reviewed delegate explicitly supports another alias.",
+      "If wrapper supports dry-run short-circuit semantics, keep execution.delegated=false and preserve partial status honestly.",
+      "Keep wrapper PDF discovery semantics aligned with reviewed delegate discovery semantics to avoid preflight/execution evidence drift.",
+      "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely."
+    ],
+    "priority": "medium",
+    "source": {
+      "kind": "local_inbox",
+      "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+      "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl035-001.json",
+      "received_at": "2026-03-25T04:20:27.813413Z",
+      "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "provider": "trello",
+      "mode": "readonly",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "regeneration_token": "regen-20260325-bl035-001"
+    },
+    "acceptance_criteria": [
+      "Produce the expected script artifact at expected_outputs[0].path",
+      "Script behavior remains runnable, deterministic, and reviewable",
+      "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
+      "Artifact behavior remains parameter-driven for input_dir and output_xlsx rather than hardcoding unrelated local defaults.",
+      "Dry-run or zero-input behavior is represented as a reviewable partial outcome instead of artifact-production success.",
+      "Relative preferred_base_script resolution remains portable and does not depend on Path.cwd().",
+      "Wrapper success requires stronger delegate evidence than zero exit code plus a non-empty output file alone.",
+      "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
+      "Delegate report handoff can consume JSON printed to stdout without relying exclusively on report sidecar file discovery.",
+      "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",
+      "Dry-run semantics remain explicit: short-circuit stays partial with no delegated execution, or delegated dry-run is passed through honestly.",
+      "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
+      "Delegate execution is bounded by an explicit timeout and reports timeout honestly."
+    ],
+    "metadata": {
+      "integration_phase": "8B",
+      "pipeline": "inbox->adapter->manager->automation->critic",
+      "request_type": "pdf_to_excel_ocr",
+      "payload_hash": "103723900dc85c4a28b75178ffb0c01d55bbba1d864efb89c62c3da065fb3d24",
+      "regeneration_token": "regen-20260325-bl035-001",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "external_metadata": {
+        "source_system": "trello",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "card_short_id": 7,
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "date_last_activity": "2026-03-24T08:35:56.234Z",
+        "readonly_mapped_at": "2026-03-25T04:19:16.331224Z",
+        "contract_profile": "best_effort_evidence_backed",
+        "ocr_claim_policy": "do_not_claim_success_without_evidence",
+        "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+        "regeneration_token": "regen-20260325-bl035-001"
+      },
+      "automation_contract_profile": "narrow_script_artifact_with_repo_reuse_and_reviewable_runner_contract"
+    }
+  },
+  "result": {
+    "task_id": "AUTO-20260325-858",
+    "worker": "automation",
+    "status": "success",
+    "summary": "Generated one runnable wrapper script artifact that prefers the reviewed repository delegate, preserves parameter-driven paths, uses explicit delegate timeout, parses delegate JSON from stdout and optional --report-json sidecar, keeps dry-run/zero-PDF outcomes as partial, and emits structured reviewable summaries.",
+    "artifacts": [
+      {
+        "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "type": "script"
+      }
+    ],
+    "timestamp": "2026-03-25T04:22:34.971092Z",
+    "duration_ms": 82923,
+    "notes": [
+      "Produced exactly one script artifact as requested.",
+      "The wrapper is deterministic and local-only, with no unsupported external dependency claims.",
+      "The wrapper resolves the reviewed base delegate relative to repository/script location instead of Path.cwd().",
+      "Success requires canonical delegate evidence via status/total_files/status_counter/dry_run rather than exit code plus file existence alone."
+    ],
+    "metadata": {
+      "task_id": "AUTO-20260325-858",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "source_origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+      "expected_output_path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py"
+    }
+  }
+}

--- a/runtime_archives/bl035/runtime/CRITIC-20260325-279.json
+++ b/runtime_archives/bl035/runtime/CRITIC-20260325-279.json
@@ -1,0 +1,199 @@
+{
+  "task_id": "CRITIC-20260325-279",
+  "worker": "critic",
+  "status": "success",
+  "created_at": "2026-03-25T04:22:35.168157Z",
+  "updated_at": "2026-03-25T04:23:06.021012Z",
+  "retries": 0,
+  "max_retries": 0,
+  "attempts": [
+    {
+      "attempt": 1,
+      "status": "success",
+      "retryable": false,
+      "error": null,
+      "runtime_log": "/Users/lingguozhong/openclaw-team/workspaces/critic/CRITIC-20260325-279/runtime.attempt-1.log",
+      "exit_code": 0,
+      "timed_out": false,
+      "wait_error": null,
+      "output_path": "/Users/lingguozhong/openclaw-team/workspaces/critic/CRITIC-20260325-279/output.json",
+      "started_at": "2026-03-25T04:22:35.173165Z",
+      "finished_at": "2026-03-25T04:23:05.984349Z"
+    }
+  ],
+  "task_dir": "/Users/lingguozhong/openclaw-team/workspaces/critic/CRITIC-20260325-279",
+  "payload": {
+    "task_id": "CRITIC-20260325-279",
+    "worker": "critic",
+    "task_type": "review_artifact",
+    "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+    "inputs": {
+      "artifacts": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        },
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+          "type": "script"
+        }
+      ],
+      "params": {
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "review_scope": {
+          "primary_artifact": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "paired_artifacts": [
+            "artifacts/scripts/pdf_to_excel_ocr.py"
+          ],
+          "goal": "Audit the wrapper and the reviewed delegate together so the review evidence can speak to the end-to-end readonly smoke path."
+        },
+        "artifact_snapshots": [
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "available": true,
+            "content": "#!/usr/bin/env python3\n\"\"\"Reviewable inbox wrapper for the reviewed PDF-to-Excel delegate.\n\nThis wrapper prefers delegating to the repository-reviewed implementation at\nartifacts/scripts/pdf_to_excel_ocr.py and keeps a narrow, evidence-backed\ncontrol flow suitable for readonly smoke previews.\n\nKey contract behaviors:\n- parameter-driven input/output paths\n- portable delegate resolution independent of Path.cwd()\n- honest partial outcome for dry-run short-circuit or zero discovered PDFs\n- explicit delegate timeout\n- canonical evidence from delegate JSON fields:\n  status, total_files, status_counter, dry_run\n- JSON report handoff via stdout and optional --report-json sidecar\n- no claim of success from exit code/output existence alone\n\"\"\"\n\nfrom __future__ import annotations\n\nimport argparse\nimport json\nimport os\nimport subprocess\nimport sys\nfrom datetime import datetime, timezone\nfrom pathlib import Path\nfrom typing import Any, Dict, List, Optional\n\nDEFAULT_INPUT_DIR = \"~/Desktop/pdf样本\"\nDEFAULT_OUTPUT_XLSX = \"artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx\"\nDEFAULT_OCR = \"auto\"\nDEFAULT_ORIGIN_ID = \"trello:69c24cd3c1a2359ddd7a1bf8\"\nDEFAULT_TITLE = \"BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)\"\nDEFAULT_DESCRIPTION = (\n    \"Purpose:\\n\"\n    \"Controlled Trello live preview smoke for openclaw-team.\\n\"\n    \"Expected behavior:\\n\"\n    \"- read-only Trello ingest\\n\"\n    \"- preview creation smoke only\\n\"\n    \"- no business execution claim\\n\"\n    \"- no Trello writeback expected in this step\\n\"\n    \"Traceability:\\n\"\n    \"- backlog: BL-20260324-014\\n\"\n    \"- blocker context: BL-20260324-015\\n\"\n    \"- created_by: Oscarling\\n\"\n    \"- created_at: 2026-03-24 Asia/Shanghai\\n\"\n    \"Note:\\n\"\n    \"This card is only for governed smoke verification and should remain open until the smoke is finished.\"\n)\nDEFAULT_LABELS = [\"best_effort\", \"evidence_backed\", \"readonly\", \"reviewable\", \"trello\"]\nDEFAULT_TIMEOUT_SECONDS = 600\nDEFAULT_BASE_SCRIPT = \"artifacts/scripts/pdf_to_excel_ocr.py\"\n\n\ndef utc_now() -> str:\n    return datetime.now(timezone.utc).isoformat()\n\n\ndef make_jsonable(value: Any) -> Any:\n    if isinstance(value, Path):\n        return str(value)\n    if isinstance(value, dict):\n        return {str(k): make_jsonable(v) for k, v in value.items()}\n    if isinstance(value, list):\n        return [make_jsonable(v) for v in value]\n    return value\n\n\ndef emit_summary(payload: Dict[str, Any]) -> None:\n    print(json.dumps(make_jsonable(payload), ensure_ascii=False, indent=2, sort_keys=True))\n\n\ndef parse_args() -> argparse.Namespace:\n    parser = argparse.ArgumentParser(\n        description=\"Readonly reviewable wrapper around the reviewed PDF-to-Excel OCR delegate.\"\n    )\n    parser.add_argument(\"--input-dir\", default=DEFAULT_INPUT_DIR, help=\"Directory containing PDF inputs.\")\n    parser.add_argument(\"--output-xlsx\", default=DEFAULT_OUTPUT_XLSX, help=\"Target XLSX output path.\")\n    parser.add_argument(\"--ocr\", default=DEFAULT_OCR, help=\"OCR mode to pass through to the delegate.\")\n    parser.add_argument(\"--dry-run\", action=\"store_true\", help=\"Short-circuit reviewable preflight without delegate execution.\")\n    parser.add_argument(\"--origin-id\", default=DEFAULT_ORIGIN_ID, help=\"External source origin identifier.\")\n    parser.add_argument(\"--title\", default=DEFAULT_TITLE, help=\"Traceability title.\")\n    parser.add_argument(\"--description\", default=DEFAULT_DESCRIPTION, help=\"Traceability description.\")\n    parser.add_argument(\"--label\", dest=\"labels\", action=\"append\", default=None, help=\"Repeatable label.\")\n    parser.add_argument(\n        \"--base-script\",\n        default=DEFAULT_BASE_SCRIPT,\n        help=\"Preferred reviewed delegate script path. Relative paths resolve from repo/script location.\",\n    )\n    parser.add_argument(\n        \"--report-json\",\n        default=None,\n        help=\"Optional wrapper summary output path. If provided, writes wrapper summary JSON there.\",\n    )\n    parser.add_argument(\n        \"--delegate-timeout-seconds\",\n        type=int,\n        default=DEFAULT_TIMEOUT_SECONDS,\n        help=\"Timeout for delegate execution in seconds.\",\n    )\n    return parser.parse_args()\n\n\ndef infer_repo_root(script_path: Path) -> Path:\n    # Expected location: <repo>/artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py\n    if script_path.parent.name == \"scripts\" and script_path.parent.parent.name == \"artifacts\":\n        return script_path.parent.parent.parent\n    return script_path.parent\n\n\ndef resolve_path(raw_path: str, repo_root: Path, script_dir: Path) -> Path:\n    expanded = Path(os.path.expanduser(raw_path))\n    if expanded.is_absolute():\n        return expanded\n\n    candidate_repo = (repo_root / expanded).resolve()\n    if candidate_repo.exists() or raw_path.startswith(\"artifacts/\"):\n        return candidate_repo\n    return (script_dir / expanded).resolve()\n\n\ndef discover_pdfs(input_dir: Path) -> List[Path]:\n    # Recursive discovery to stay aligned with typical delegate processing semantics.\n    return sorted(p for p in input_dir.rglob(\"*.pdf\") if p.is_file())\n\n\ndef try_parse_json_object(text: str) -> Optional[Dict[str, Any]]:\n    text = text.strip()\n    if not text:\n        return None\n    try:\n        parsed = json.loads(text)\n        return parsed if isinstance(parsed, dict) else None\n    except json.JSONDecodeError:\n        pass\n\n    lines = [line.strip() for line in text.splitlines() if line.strip()]\n    for idx in range(len(lines)):\n        candidate = \"\\n\".join(lines[idx:])\n        try:\n            parsed = json.loads(candidate)\n            if isinstance(parsed, dict):\n                return parsed\n        except json.JSONDecodeError:\n            continue\n    return None\n\n\ndef load_json_file(path: Path) -> Optional[Dict[str, Any]]:\n    if not path.exists() or not path.is_file():\n        return None\n    try:\n        return json.loads(path.read_text(encoding=\"utf-8\"))\n    except Exception:\n        return None\n\n\ndef evaluate_delegate_report(report: Dict[str, Any], output_xlsx: Path) -> Dict[str, Any]:\n    status = report.get(\"status\")\n    total_files = report.get(\"total_files\")\n    status_counter = report.get(\"status_counter\") or {}\n    dry_run = bool(report.get(\"dry_run\", False))\n\n    succeeded = int(status_counter.get(\"success\", 0) or 0)\n    failed = int(status_counter.get(\"failed\", 0) or 0)\n    partial = int(status_counter.get(\"partial\", 0) or 0)\n\n    evidence_ok = (\n        status == \"success\"\n        and isinstance(total_files, int)\n        and total_files > 0\n        and succeeded > 0\n        and failed == 0\n        and partial == 0\n        and not dry_run\n        and output_xlsx.exists()\n        and output_xlsx.is_file()\n        and output_xlsx.stat().st_size > 0\n    )\n\n    if evidence_ok:\n        wrapper_status = \"success\"\n        rationale = \"delegate_report_confirmed_success\"\n    elif dry_run:\n        wrapper_status = \"partial\"\n        rationale = \"delegate_report_is_dry_run\"\n    elif isinstance(total_files, int) and total_files == 0:\n        wrapper_status = \"partial\"\n        rationale = \"delegate_report_zero_inputs\"\n    elif status in {\"partial\", \"failed\"}:\n        wrapper_status = status\n        rationale = \"delegate_report_non_success\"\n    else:\n        wrapper_status = \"partial\"\n        rationale = \"delegate_report_insufficient_success_evidence\"\n\n    return {\n        \"wrapper_status\": wrapper_status,\n        \"rationale\": rationale,\n        \"canonical\": {\n            \"status\": status,\n            \"total_files\": total_files,\n            \"status_counter\": status_counter,\n            \"dry_run\": dry_run,\n        },\n    }\n\n\ndef main() -> int:\n    args = parse_args()\n    script_path = Path(__file__).resolve()\n    script_dir = script_path.parent\n    repo_root = infer_repo_root(script_path)\n\n    input_dir = resolve_path(args.input_dir, repo_root=repo_root, script_dir=script_dir)\n    output_xlsx = resolve_path(args.output_xlsx, repo_root=repo_root, script_dir=script_dir)\n    delegate_script = resolve_path(args.base_script, repo_root=repo_root, script_dir=script_dir)\n    wrapper_report_path = resolve_path(args.report_json, repo_root=repo_root, script_dir=script_dir) if args.report_json else None\n    labels = args.labels if args.labels is not None else list(DEFAULT_LABELS)\n\n    summary: Dict[str, Any] = {\n        \"status\": \"failed\",\n        \"title\": args.title,\n        \"origin_id\": args.origin_id,\n        \"description\": args.description,\n        \"labels\": labels,\n        \"timestamps\": {\n            \"started_at\": utc_now(),\n        },\n        \"request\": {\n            \"input_dir\": str(input_dir),\n            \"output_xlsx\": str(output_xlsx),\n            \"ocr\": args.ocr,\n            \"dry_run\": bool(args.dry_run),\n        },\n        \"execution\": {\n            \"wrapper_script\": str(script_path),\n            \"delegated\": False,\n            \"delegate_script\": str(delegate_script),\n            \"delegate_timeout_seconds\": int(args.delegate_timeout_seconds),\n        },\n        \"preflight\": {},\n        \"delegate\": None,\n        \"artifacts\": {\n            \"output_xlsx\": str(output_xlsx),\n            \"wrapper_report_json\": str(wrapper_report_path) if wrapper_report_path else None,\n        },\n        \"errors\": [],\n    }\n\n    if output_xlsx.suffix.lower() != \".xlsx\":\n        summary[\"status\"] = \"failed\"\n        summary[\"errors\"].append(\"output_xlsx must end with .xlsx to preserve real XLSX semantics\")\n        summary[\"timestamps\"][\"finished_at\"] = utc_now()\n        if wrapper_report_path:\n            wrapper_report_path.parent.mkdir(parents=True, exist_ok=True)\n            wrapper_report_path.write_text(json.dumps(make_jsonable(summary), ensure_ascii=False, indent=2, sort_keys=True), encoding=\"utf-8\")\n        emit_summary(summary)\n        return 1\n\n    if not delegate_script.exists() or not delegate_script.is_file():\n        summary[\"status\"] = \"failed\"\n        summary[\"errors\"].append(f\"reviewed delegate not found: {delegate_script}\")\n        summary[\"timestamps\"][\"finished_at\"] = utc_now()\n        if wrapper_report_path:\n            wrapper_report_path.parent.mkdir(parents=True, exist_ok=True)\n            wrapper_report_path.write_text(json.dumps(make_jsonable(summary), ensure_ascii=False, indent=2, sort_keys=True), encoding=\"utf-8\")\n        emit_summary(summary)\n        return 1\n\n    existing_pdfs = discover_pdfs(input_dir) if input_dir.exists() and input_dir.is_dir() else []\n    summary[\"preflight\"] = {\n        \"input_dir_exists\": input_dir.exists(),\n        \"input_dir_is_dir\": input_dir.is_dir(),\n        \"discovered_pdf_count\": len(existing_pdfs),\n        \"discovered_pdf_samples\": [str(p) for p in existing_pdfs[:10]],\n    }\n\n    if args.dry_run:\n        summary[\"status\"] = \"partial\"\n        summary[\"timestamps\"][\"finished_at\"] = utc_now()\n        summary[\"notes\"] = [\n            \"Dry-run requested; wrapper intentionally did not delegate.\",\n            \"Reviewable partial outcome with execution.delegated=false.\",\n        ]\n        if wrapper_report_path:\n            wrapper_report_path.parent.mkdir(parents=True, exist_ok=True)\n            wrapper_report_path.write_text(json.dumps(make_jsonable(summary), ensure_ascii=False, indent=2, sort_keys=True), encoding=\"utf-8\")\n        emit_summary(summary)\n        return 0\n\n    if not input_dir.exists() or not input_dir.is_dir():\n        summary[\"status\"] = \"failed\"\n        summary[\"errors\"].append(f\"input_dir is not a readable directory: {input_dir}\")\n        summary[\"timestamps\"][\"finished_at\"] = utc_now()\n        if wrapper_report_path:\n            wrapper_report_path.parent.mkdir(parents=True, exist_ok=True)\n            wrapper_report_path.write_text(json.dumps(make_jsonable(summary), ensure_ascii=False, indent=2, sort_keys=True), encoding=\"utf-8\")\n        emit_summary(summary)\n        return 1\n\n    if len(existing_pdfs) == 0:\n        summary[\"status\"] = \"partial\"\n        summary[\"timestamps\"][\"finished_at\"] = utc_now()\n        summary[\"notes\"] = [\n            \"No PDF files discovered during preflight.\",\n            \"Partial outcome reported honestly without claiming XLSX production success.\",\n        ]\n        if wrapper_report_path:\n            wrapper_report_path.parent.mkdir(parents=True, exist_ok=True)\n            wrapper_report_path.write_text(json.dumps(make_jsonable(summary), ensure_ascii=False, indent=2, sort_keys=True), encoding=\"utf-8\")\n        emit_summary(summary)\n        return 0\n\n    output_xlsx.parent.mkdir(parents=True, exist_ok=True)\n    delegate_report_path = output_xlsx.with_suffix(output_xlsx.suffix + \".delegate_report.json\")\n\n    cmd = [\n        sys.executable,\n        str(delegate_script),\n        \"--input-dir\",\n        str(input_dir),\n        \"--output-xlsx\",\n        str(output_xlsx),\n        \"--ocr\",\n        str(args.ocr),\n        \"--report-json\",\n        str(delegate_report_path),\n    ]\n\n    summary[\"execution\"][\"delegated\"] = True\n    summary[\"execution\"][\"delegate_command\"] = cmd\n\n    try:\n        completed = subprocess.run(\n            cmd,\n            cwd=str(repo_root),\n            capture_output=True,\n            text=True,\n            timeout=int(args.delegate_timeout_seconds),\n            check=False,\n        )\n    except subprocess.TimeoutExpired as exc:\n        summary[\"status\"] = \"failed\"\n        summary[\"delegate\"] = {\n            \"timeout\": True,\n            \"returncode\": None,\n            \"stdout\": exc.stdout,\n            \"stderr\": exc.stderr,\n            \"report_path\": str(delegate_report_path),\n        }\n        summary[\"errors\"].append(f\"delegate timed out after {args.delegate_timeout_seconds} seconds\")\n        summary[\"timestamps\"][\"finished_at\"] = utc_now()\n        if wrapper_report_path:\n            wrapper_report_path.parent.mkdir(parents=True, exist_ok=True)\n            wrapper_report_path.write_text(json.dumps(make_jsonable(summary), ensure_ascii=False, indent=2, sort_keys=True), encoding=\"utf-8\")\n        emit_summary(summary)\n        return 1\n\n    stdout_report = try_parse_json_object(completed.stdout or \"\")\n    sidecar_report = load_json_file(delegate_report_path)\n    delegate_report = stdout_report if stdout_report else sidecar_report\n\n    summary[\"delegate\"] = {\n        \"timeout\": False,\n        \"returncode\": completed.returncode,\n        \"stdout\": completed.stdout,\n        \"stderr\": completed.stderr,\n        \"report_path\": str(delegate_report_path),\n        \"report_source\": \"stdout\" if stdout_report else (\"sidecar\" if sidecar_report else None),\n        \"report\": delegate_report,\n    }\n\n    if not isinstance(delegate_report, dict):\n        summary[\"status\"] = \"partial\" if completed.returncode == 0 else \"failed\"\n        summary[\"errors\"].append(\"delegate did not provide a parseable canonical JSON report via stdout or --report-json sidecar\")\n        summary[\"timestamps\"][\"finished_at\"] = utc_now()\n        if wrapper_report_path:\n            wrapper_report_path.parent.mkdir(parents=True, exist_ok=True)\n            wrapper_report_path.write_text(json.dumps(make_jsonable(summary), ensure_ascii=False, indent=2, sort_keys=True), encoding=\"utf-8\")\n        emit_summary(summary)\n        return 0 if summary[\"status\"] == \"partial\" else 1\n\n    evaluation = evaluate_delegate_report(delegate_report, output_xlsx=output_xlsx)\n    summary[\"status\"] = evaluation[\"wrapper_status\"]\n    summary[\"delegate\"][\"evaluation\"] = evaluation\n\n    if summary[\"status\"] == \"success\":\n        summary[\"notes\"] = [\n            \"Wrapper success is backed by canonical delegate report evidence.\",\n            \"Delegate reported successful processing with at least one input and no failed/partial counterexamples.\",\n        ]\n    elif summary[\"status\"] == \"partial\":\n        summary[\"notes\"] = [\n            \"Wrapper preserved a reviewable partial outcome because canonical success evidence was incomplete.\",\n            f\"Rationale: {evaluation['rationale']}\",\n        ]\n    else:\n        summary[\"errors\"].append(f\"delegate outcome failed: {evaluation['rationale']}\")\n\n    summary[\"timestamps\"][\"finished_at\"] = utc_now()\n\n    if wrapper_report_path:\n        wrapper_report_path.parent.mkdir(parents=True, exist_ok=True)\n        wrapper_report_path.write_text(json.dumps(make_jsonable(summary), ensure_ascii=False, indent=2, sort_keys=True), encoding=\"utf-8\")\n\n    emit_summary(summary)\n    return 0 if summary[\"status\"] in {\"success\", \"partial\"} else 1\n\n\nif __name__ == \"__main__\":\n    raise SystemExit(main())\n",
+            "truncated": false
+          },
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+            "available": true,
+            "content": "#!/usr/bin/env python3\n\"\"\"\nBatch PDF -> Excel extractor with optional OCR fallback.\n\nDesign goals:\n- Batch processing with per-file isolation (single file failure must not stop the batch)\n- OCR mode: auto | on | off\n- Chinese-friendly OCR defaults (chi_sim+eng)\n- Dry-run support for pilot validation when dependencies are unavailable\n\"\"\"\n\nfrom __future__ import annotations\n\nimport argparse\nimport json\nimport shutil\nimport sys\nfrom dataclasses import asdict, dataclass\nfrom pathlib import Path\nfrom typing import Any\n\n\ntry:\n    from pypdf import PdfReader  # type: ignore\nexcept Exception:\n    PdfReader = None\n\ntry:\n    import pandas as pd  # type: ignore\nexcept Exception:\n    pd = None\n\ntry:\n    import pytesseract  # type: ignore\nexcept Exception:\n    pytesseract = None\n\ntry:\n    from pdf2image import convert_from_path  # type: ignore\nexcept Exception:\n    convert_from_path = None\n\n\n@dataclass\nclass FileResult:\n    file_name: str\n    file_path: str\n    status: str\n    extract_method: str\n    page_count: int\n    text_chars: int\n    text_preview: str\n    warnings: str\n    error: str\n\n\ndef parse_args() -> argparse.Namespace:\n    parser = argparse.ArgumentParser(description=\"Batch PDF to Excel extractor with OCR fallback.\")\n    parser.add_argument(\"--input-dir\", required=True, help=\"Directory containing PDF files.\")\n    parser.add_argument(\"--output-xlsx\", required=True, help=\"Output Excel path.\")\n    parser.add_argument(\n        \"--ocr\",\n        choices=(\"auto\", \"on\", \"off\"),\n        default=\"auto\",\n        help=\"OCR mode. auto=use OCR when plain text extraction is weak.\",\n    )\n    parser.add_argument(\n        \"--dry-run\",\n        action=\"store_true\",\n        help=\"Do not write Excel file. Print execution summary only.\",\n    )\n    parser.add_argument(\n        \"--ocr-lang\",\n        default=\"chi_sim+eng\",\n        help=\"OCR language pack for pytesseract, default supports Chinese + English.\",\n    )\n    parser.add_argument(\n        \"--auto-ocr-min-chars\",\n        type=int,\n        default=50,\n        help=\"In auto mode, run OCR when extracted text chars < this threshold.\",\n    )\n    parser.add_argument(\n        \"--report-json\",\n        default=\"\",\n        help=\"Optional sidecar path for writing the same JSON report emitted to stdout.\",\n    )\n    return parser.parse_args()\n\n\ndef discover_pdfs(input_dir: Path) -> list[Path]:\n    if not input_dir.exists():\n        raise FileNotFoundError(f\"Input directory does not exist: {input_dir}\")\n    if not input_dir.is_dir():\n        raise NotADirectoryError(f\"Input path is not a directory: {input_dir}\")\n    files = sorted([p for p in input_dir.rglob(\"*\") if p.is_file() and p.suffix.lower() == \".pdf\"])\n    return files\n\n\ndef detect_ocr_runtime_status() -> tuple[str, list[str]]:\n    missing: list[str] = []\n    present: list[str] = []\n\n    if pytesseract is None:\n        missing.append(\"python module pytesseract\")\n    else:\n        present.append(\"python module pytesseract\")\n    if convert_from_path is None:\n        missing.append(\"python module pdf2image\")\n    else:\n        present.append(\"python module pdf2image\")\n    if shutil.which(\"tesseract\") is None:\n        missing.append(\"binary tesseract\")\n    else:\n        present.append(\"binary tesseract\")\n    if shutil.which(\"pdftoppm\") is None:\n        missing.append(\"binary pdftoppm (poppler)\")\n    else:\n        present.append(\"binary pdftoppm (poppler)\")\n\n    if not missing:\n        return \"available\", []\n    if present:\n        return \"partial\", missing\n    return \"blocked\", missing\n\n\ndef extract_text_pypdf(pdf_path: Path) -> tuple[str, int]:\n    if PdfReader is None:\n        raise RuntimeError(\"pypdf not installed\")\n    reader = PdfReader(str(pdf_path))\n    page_texts: list[str] = []\n    for page in reader.pages:\n        text = page.extract_text() or \"\"\n        page_texts.append(text)\n    return \"\\n\".join(page_texts), len(reader.pages)\n\n\ndef extract_text_ocr(pdf_path: Path, ocr_lang: str) -> str:\n    if pytesseract is None:\n        raise RuntimeError(\"pytesseract not installed\")\n    if convert_from_path is None:\n        raise RuntimeError(\"pdf2image not installed\")\n    if shutil.which(\"tesseract\") is None:\n        raise RuntimeError(\"tesseract binary not found\")\n    if shutil.which(\"pdftoppm\") is None:\n        raise RuntimeError(\"pdftoppm binary not found (install poppler)\")\n\n    images = convert_from_path(str(pdf_path), dpi=220)\n    chunks: list[str] = []\n    for image in images:\n        chunks.append(pytesseract.image_to_string(image, lang=ocr_lang))\n    return \"\\n\".join(chunks)\n\n\ndef compact_preview(text: str, limit: int = 160) -> str:\n    single_line = \" \".join(text.split())\n    if len(single_line) <= limit:\n        return single_line\n    return single_line[: limit - 3] + \"...\"\n\n\ndef process_one_pdf(\n    pdf_path: Path,\n    ocr_mode: str,\n    ocr_lang: str,\n    auto_ocr_min_chars: int,\n) -> FileResult:\n    warnings: list[str] = []\n    errors: list[str] = []\n    method = \"none\"\n    text = \"\"\n    page_count = 0\n\n    try:\n        text, page_count = extract_text_pypdf(pdf_path)\n        method = \"text\"\n    except Exception as e:\n        warnings.append(f\"text extraction unavailable: {e}\")\n\n    needs_ocr = False\n    if ocr_mode == \"on\":\n        needs_ocr = True\n    elif ocr_mode == \"auto\" and len(text.strip()) < auto_ocr_min_chars:\n        needs_ocr = True\n\n    if needs_ocr:\n        try:\n            ocr_text = extract_text_ocr(pdf_path, ocr_lang).strip()\n            if ocr_text:\n                if text.strip():\n                    text = f\"{text.strip()}\\n\\n[OCR Fallback]\\n{ocr_text}\"\n                    method = \"text+ocr\"\n                else:\n                    text = ocr_text\n                    method = \"ocr\"\n            else:\n                warnings.append(\"OCR returned empty text\")\n        except Exception as e:\n            errors.append(f\"OCR failed: {e}\")\n\n    if not text.strip():\n        if errors:\n            status = \"failed\"\n        else:\n            status = \"partial\"\n            warnings.append(\"No extractable text captured\")\n    else:\n        status = \"success\"\n\n    return FileResult(\n        file_name=pdf_path.name,\n        file_path=str(pdf_path),\n        status=status,\n        extract_method=method,\n        page_count=page_count,\n        text_chars=len(text),\n        text_preview=compact_preview(text),\n        warnings=\" | \".join(warnings),\n        error=\" | \".join(errors),\n    )\n\n\ndef write_excel(results: list[FileResult], output_xlsx: Path) -> None:\n    if pd is None:\n        raise RuntimeError(\"pandas is required to write Excel output\")\n    output_xlsx.parent.mkdir(parents=True, exist_ok=True)\n\n    rows = [asdict(r) for r in results]\n    detail_df = pd.DataFrame(rows)\n\n    summary_rows: list[dict[str, Any]] = []\n    by_status = detail_df.groupby(\"status\").size().to_dict()\n    by_method = detail_df.groupby(\"extract_method\").size().to_dict()\n    for key, value in sorted(by_status.items()):\n        summary_rows.append({\"metric\": \"status_count\", \"name\": key, \"value\": int(value)})\n    for key, value in sorted(by_method.items()):\n        summary_rows.append({\"metric\": \"method_count\", \"name\": key, \"value\": int(value)})\n    summary_rows.append({\"metric\": \"total_files\", \"name\": \"all\", \"value\": int(len(results))})\n    summary_df = pd.DataFrame(summary_rows)\n\n    with pd.ExcelWriter(output_xlsx) as writer:\n        summary_df.to_excel(writer, sheet_name=\"summary\", index=False)\n        detail_df.to_excel(writer, sheet_name=\"files\", index=False)\n\n\ndef emit_report(report: dict[str, Any], report_json: str) -> None:\n    rendered = json.dumps(report, ensure_ascii=False, indent=2)\n    print(rendered)\n    if not report_json:\n        return\n    out_path = Path(report_json).expanduser().resolve()\n    out_path.parent.mkdir(parents=True, exist_ok=True)\n    out_path.write_text(rendered + \"\\n\", encoding=\"utf-8\")\n\n\ndef main() -> int:\n    args = parse_args()\n    input_dir = Path(args.input_dir).expanduser().resolve()\n    output_xlsx = Path(args.output_xlsx).expanduser().resolve()\n\n    try:\n        pdf_files = discover_pdfs(input_dir)\n    except Exception as e:\n        emit_report({\"status\": \"failed\", \"error\": str(e)}, args.report_json)\n        return 2\n\n    if not pdf_files:\n        emit_report(\n            {\n                \"status\": \"failed\",\n                \"error\": f\"No PDF files found under {input_dir}\",\n            },\n            args.report_json,\n        )\n        return 2\n\n    ocr_runtime, missing = detect_ocr_runtime_status()\n    results: list[FileResult] = []\n    for pdf in pdf_files:\n        try:\n            results.append(\n                process_one_pdf(\n                    pdf,\n                    ocr_mode=args.ocr,\n                    ocr_lang=args.ocr_lang,\n                    auto_ocr_min_chars=args.auto_ocr_min_chars,\n                )\n            )\n        except Exception as e:\n            results.append(\n                FileResult(\n                    file_name=pdf.name,\n                    file_path=str(pdf),\n                    status=\"failed\",\n                    extract_method=\"none\",\n                    page_count=0,\n                    text_chars=0,\n                    text_preview=\"\",\n                    warnings=\"\",\n                    error=f\"Unhandled processing exception: {e}\",\n                )\n            )\n\n    status_counter: dict[str, int] = {}\n    for item in results:\n        status_counter[item.status] = status_counter.get(item.status, 0) + 1\n\n    report = {\n        \"status\": \"success\" if status_counter.get(\"failed\", 0) == 0 else \"partial\",\n        \"input_dir\": str(input_dir),\n        \"output_xlsx\": str(output_xlsx),\n        \"ocr_mode\": args.ocr,\n        \"ocr_runtime_status\": ocr_runtime,\n        \"ocr_missing_dependencies\": missing,\n        \"total_files\": len(results),\n        \"status_counter\": status_counter,\n        \"dry_run\": bool(args.dry_run),\n    }\n\n    if args.dry_run:\n        emit_report(report, args.report_json)\n        return 0\n\n    try:\n        write_excel(results, output_xlsx)\n        emit_report(report, args.report_json)\n        return 0\n    except Exception as e:\n        report[\"status\"] = \"failed\"\n        report[\"error\"] = str(e)\n        emit_report(report, args.report_json)\n        return 3\n\n\nif __name__ == \"__main__\":\n    raise SystemExit(main())\n",
+            "truncated": false
+          }
+        ],
+        "review_contract": {
+          "required_status": [
+            "success",
+            "partial",
+            "failed"
+          ],
+          "required_verdict_values": [
+            "fail",
+            "needs_revision",
+            "pass"
+          ],
+          "required_metadata_key": "verdict",
+          "must_write_review_artifact_to": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "artifact_policy": "Always include either `file_contents` for the review artifact path or `artifacts` referencing that exact path.",
+          "fallback_policy": "If evidence is insufficient, return `status=partial`, include explicit `errors`, still generate review artifact content, and set verdict=needs_revision."
+        },
+        "review_template": {
+          "title": "Review: <artifact name>",
+          "sections": [
+            "Scope",
+            "Findings",
+            "Verdict",
+            "Rationale"
+          ],
+          "verdict_required": true
+        }
+      }
+    },
+    "expected_outputs": [
+      {
+        "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+        "type": "review"
+      }
+    ],
+    "constraints": [
+      "Review must be grounded in produced automation artifact",
+      "When both wrapper and reviewed delegate snapshots are supplied, evaluate them as one end-to-end readonly pair instead of ignoring the delegate evidence.",
+      "Do not invent missing artifact content",
+      "Return a clear verdict: pass, fail, or needs_revision",
+      "Include metadata.verdict in output",
+      "Generate review artifact markdown for expected_outputs[0].path",
+      "Use artifact_snapshots when provided; avoid claiming access problems if snapshot content exists.",
+      "When both the generated wrapper and reviewed delegate snapshots are provided, review them together rather than silently narrowing scope to one file.",
+      "Return metadata.verdict with one of: pass, fail, needs_revision.",
+      "Always generate review artifact content for expected_outputs[0].path.",
+      "If evidence is insufficient, use partial + errors + verdict=needs_revision, but still output review artifact."
+    ],
+    "priority": "medium",
+    "source": {
+      "kind": "local_inbox",
+      "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+      "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl035-001.json",
+      "received_at": "2026-03-25T04:20:27.813413Z",
+      "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "provider": "trello",
+      "mode": "readonly",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "regeneration_token": "regen-20260325-bl035-001"
+    },
+    "acceptance_criteria": [
+      "Produce a review artifact with explicit verdict (pass/fail/needs_revision)"
+    ],
+    "metadata": {
+      "integration_phase": "8B",
+      "pipeline": "inbox->adapter->manager->automation->critic",
+      "request_type": "pdf_to_excel_ocr",
+      "payload_hash": "103723900dc85c4a28b75178ffb0c01d55bbba1d864efb89c62c3da065fb3d24",
+      "regeneration_token": "regen-20260325-bl035-001",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "external_metadata": {
+        "source_system": "trello",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "card_short_id": 7,
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "date_last_activity": "2026-03-24T08:35:56.234Z",
+        "readonly_mapped_at": "2026-03-25T04:19:16.331224Z",
+        "contract_profile": "best_effort_evidence_backed",
+        "ocr_claim_policy": "do_not_claim_success_without_evidence",
+        "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+        "regeneration_token": "regen-20260325-bl035-001"
+      }
+    }
+  },
+  "result": {
+    "task_id": "CRITIC-20260325-279",
+    "worker": "critic",
+    "status": "success",
+    "summary": "Reviewed the inbox runner and paired delegate together as an end-to-end readonly smoke path. The wrapper is well aligned to the evidence-backed contract: it resolves paths portably, performs honest preflight handling, avoids success claims based only on exit code, requires canonical delegate JSON evidence, supports sidecar reporting, and preserves partial outcomes for dry-run and zero-input cases. The delegate provides batch isolation, OCR fallback options, sidecar/stdout reporting, and per-file result modeling. However, the pair has material contract mismatches that prevent a full pass: the delegate reports zero discovered PDFs as status=failed while the wrapper expects zero-input as an honest partial scenario; the delegate marks overall status=success whenever there are no failed files, even if some files are partial; and the wrapper’s canonical success check depends on an output XLSX existing but the delegate report itself does not attest to successful Excel write beyond status, making the success evidence slightly asymmetric. Verdict: needs_revision.",
+    "artifacts": [
+      {
+        "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+        "type": "review"
+      }
+    ],
+    "timestamp": "2026-03-25T04:23:05.855830Z",
+    "duration_ms": 30476,
+    "notes": [
+      "Used supplied artifact snapshots as review evidence.",
+      "Reviewed wrapper and delegate together rather than narrowing to a single file."
+    ],
+    "metadata": {
+      "task_id": "CRITIC-20260325-279",
+      "worker": "critic",
+      "verdict": "needs_revision",
+      "reviewed_artifacts": [
+        "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "artifacts/scripts/pdf_to_excel_ocr.py"
+      ]
+    }
+  }
+}

--- a/runtime_archives/bl035/runtime/automation-output.json
+++ b/runtime_archives/bl035/runtime/automation-output.json
@@ -1,0 +1,27 @@
+{
+  "task_id": "AUTO-20260325-858",
+  "worker": "automation",
+  "status": "success",
+  "summary": "Generated one runnable wrapper script artifact that prefers the reviewed repository delegate, preserves parameter-driven paths, uses explicit delegate timeout, parses delegate JSON from stdout and optional --report-json sidecar, keeps dry-run/zero-PDF outcomes as partial, and emits structured reviewable summaries.",
+  "artifacts": [
+    {
+      "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+      "type": "script"
+    }
+  ],
+  "timestamp": "2026-03-25T04:22:34.971092Z",
+  "duration_ms": 82923,
+  "notes": [
+    "Produced exactly one script artifact as requested.",
+    "The wrapper is deterministic and local-only, with no unsupported external dependency claims.",
+    "The wrapper resolves the reviewed base delegate relative to repository/script location instead of Path.cwd().",
+    "Success requires canonical delegate evidence via status/total_files/status_counter/dry_run rather than exit code plus file existence alone."
+  ],
+  "metadata": {
+    "task_id": "AUTO-20260325-858",
+    "worker": "automation",
+    "task_type": "generate_script",
+    "source_origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+    "expected_output_path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py"
+  }
+}

--- a/runtime_archives/bl035/runtime/automation-runtime.attempt-1.log
+++ b/runtime_archives/bl035/runtime/automation-runtime.attempt-1.log
@@ -1,0 +1,19 @@
+task_id: AUTO-20260325-858
+worker: automation
+attempt: 1
+container_name: argus-automation-auto-20260325-858
+worker_image: argus-worker:latest
+started_at: 2026-03-25T04:21:11.798701Z
+finished_at: 2026-03-25T04:22:35.135250Z
+exit_code: 0
+timed_out: False
+wait_error: 
+
+=== stdout ===
+[2026-03-25T04:21:12.048502Z] [automation] [INFO] Worker started using endpoint https://fast.vpsairobot.com/v1/chat/completions (timeout=120s, attempts=3)
+[2026-03-25T04:22:34.970639Z] [automation] [INFO] Artifact written: artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
+[2026-03-25T04:22:34.971671Z] [automation] [INFO] Task completed AUTO-20260325-858 with status success
+[2026-03-25T04:22:34.972862Z] [automation] [INFO] Worker exiting from /app/workspaces/automation/AUTO-20260325-858
+
+=== stderr ===
+

--- a/runtime_archives/bl035/runtime/critic-output.json
+++ b/runtime_archives/bl035/runtime/critic-output.json
@@ -1,0 +1,27 @@
+{
+  "task_id": "CRITIC-20260325-279",
+  "worker": "critic",
+  "status": "success",
+  "summary": "Reviewed the inbox runner and paired delegate together as an end-to-end readonly smoke path. The wrapper is well aligned to the evidence-backed contract: it resolves paths portably, performs honest preflight handling, avoids success claims based only on exit code, requires canonical delegate JSON evidence, supports sidecar reporting, and preserves partial outcomes for dry-run and zero-input cases. The delegate provides batch isolation, OCR fallback options, sidecar/stdout reporting, and per-file result modeling. However, the pair has material contract mismatches that prevent a full pass: the delegate reports zero discovered PDFs as status=failed while the wrapper expects zero-input as an honest partial scenario; the delegate marks overall status=success whenever there are no failed files, even if some files are partial; and the wrapper’s canonical success check depends on an output XLSX existing but the delegate report itself does not attest to successful Excel write beyond status, making the success evidence slightly asymmetric. Verdict: needs_revision.",
+  "artifacts": [
+    {
+      "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+      "type": "review"
+    }
+  ],
+  "timestamp": "2026-03-25T04:23:05.855830Z",
+  "duration_ms": 30476,
+  "notes": [
+    "Used supplied artifact snapshots as review evidence.",
+    "Reviewed wrapper and delegate together rather than narrowing to a single file."
+  ],
+  "metadata": {
+    "task_id": "CRITIC-20260325-279",
+    "worker": "critic",
+    "verdict": "needs_revision",
+    "reviewed_artifacts": [
+      "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+      "artifacts/scripts/pdf_to_excel_ocr.py"
+    ]
+  }
+}

--- a/runtime_archives/bl035/runtime/critic-runtime.attempt-1.log
+++ b/runtime_archives/bl035/runtime/critic-runtime.attempt-1.log
@@ -1,0 +1,19 @@
+task_id: CRITIC-20260325-279
+worker: critic
+attempt: 1
+container_name: argus-critic-critic-20260325-279
+worker_image: argus-worker:latest
+started_at: 2026-03-25T04:22:35.173165Z
+finished_at: 2026-03-25T04:23:05.984349Z
+exit_code: 0
+timed_out: False
+wait_error: 
+
+=== stdout ===
+[2026-03-25T04:22:35.380263Z] [critic] [INFO] Worker started using endpoint https://fast.vpsairobot.com/v1/chat/completions (timeout=120s, attempts=3)
+[2026-03-25T04:23:05.855357Z] [critic] [INFO] Artifact written: artifacts/reviews/pdf_to_excel_ocr_inbox_review.md
+[2026-03-25T04:23:05.856396Z] [critic] [INFO] Task completed CRITIC-20260325-279 with status success
+[2026-03-25T04:23:05.857620Z] [critic] [INFO] Worker exiting from /app/workspaces/critic/CRITIC-20260325-279
+
+=== stderr ===
+

--- a/runtime_archives/bl035/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8.json
+++ b/runtime_archives/bl035/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8.json
@@ -1,0 +1,393 @@
+{
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8",
+  "created_at": "2026-03-25T04:20:27.814523Z",
+  "approved": true,
+  "source": {
+    "kind": "local_inbox",
+    "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+    "received_at": "2026-03-25T04:20:27.813413Z",
+    "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl035-001.json",
+    "regeneration_token": "regen-20260325-bl035-001"
+  },
+  "external_input": {
+    "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+    "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+    "labels": [
+      "best_effort",
+      "evidence_backed",
+      "readonly",
+      "reviewable",
+      "trello"
+    ],
+    "metadata": {
+      "source_system": "trello",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "card_short_id": 7,
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "date_last_activity": "2026-03-24T08:35:56.234Z",
+      "readonly_mapped_at": "2026-03-25T04:19:16.331224Z",
+      "contract_profile": "best_effort_evidence_backed",
+      "ocr_claim_policy": "do_not_claim_success_without_evidence",
+      "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+      "regeneration_token": "regen-20260325-bl035-001"
+    },
+    "request_type": "pdf_to_excel_ocr",
+    "input": {
+      "input_dir": "~/Desktop/pdf样本",
+      "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+      "ocr": "auto",
+      "dry_run": false
+    }
+  },
+  "task_summary": {
+    "automation": {
+      "task_id": "AUTO-20260325-858",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+      "expected_outputs": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ]
+    },
+    "critic": {
+      "task_id": "CRITIC-20260325-279",
+      "worker": "critic",
+      "task_type": "review_artifact",
+      "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+      "expected_outputs": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ]
+    }
+  },
+  "internal_tasks": {
+    "automation": {
+      "task_id": "AUTO-20260325-858",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+      "inputs": {
+        "params": {
+          "input_dir": "~/Desktop/pdf样本",
+          "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+          "ocr": "auto",
+          "dry_run": false,
+          "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+          "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+          "description": "Purpose: | Controlled Trello live preview smoke for openclaw-team. | Expected behavior: | - read-only Trello ingest | - preview creation smoke only | - no business execution claim | - no Trello writeback expected in this step | Traceability: | - backlog: BL-20260324-014 | - blocker context: BL-20260324-015 | - created_by: Oscarling | - created_at: 2026-03-24 Asia/Shanghai | Note: | This card is only for governed smoke verification and should remain open until the smoke is finished.",
+          "labels": [
+            "best_effort",
+            "evidence_backed",
+            "readonly",
+            "reviewable",
+            "trello"
+          ],
+          "preferred_wrapper_script": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "preferred_base_script": "artifacts/scripts/pdf_to_excel_ocr.py",
+          "reference_docs": [
+            "artifacts/docs/pdf_to_excel_ocr_usage.md",
+            "artifacts/reviews/pdf_to_excel_ocr_review.md"
+          ],
+          "contract_hints": {
+            "output_format_fidelity": "If output_xlsx ends with .xlsx, produce a real XLSX workbook container or fail honestly before writing mismatched text/XML/CSV content to a .xlsx path.",
+            "path_portability": "Use the provided input_dir parameter as runtime input. Do not hardcode a user-home or absolute input path when params already declare the path.",
+            "traceability": "Preserve meaningful description context from the external input; do not collapse it to a heading fragment such as Purpose:.",
+            "reuse_preference": "Prefer reusing artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py as the wrapper baseline and artifacts/scripts/pdf_to_excel_ocr.py as the reviewed delegate when compatible, so workbook semantics and contract behavior stay aligned with repository evidence.",
+            "outcome_status_model": "Use the reviewable status model success/partial/failed. Dry-run requests or zero-PDF discovery should resolve to partial rather than claiming success without an output artifact.",
+            "delegate_resolution": "If preferred_base_script is relative, resolve it from the repository or script location instead of Path.cwd() so behavior stays portable across shells and CI.",
+            "reviewed_delegate_contract": "For readonly reviewable preview flows, delegate only to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py or fail honestly instead of broadening behavior through an arbitrary helper.",
+            "delegate_success_evidence": "Do not treat zero exit code plus output-file existence as sufficient wrapper success evidence on their own. Prefer a structured delegate report that confirms a real success outcome with at least one processed input and no failed-file counterexamples before the wrapper claims success.",
+            "delegate_timeout": "Bound delegate subprocess execution with an explicit timeout and report timeout as an honest failed/partial outcome instead of allowing smoke automation to hang indefinitely.",
+            "runtime_summary": "The generated script should emit a structured summary of what it produced so later review can inspect behavior without guessing.",
+            "delegate_report_schema": "Treat delegate JSON report fields status/total_files/status_counter/dry_run as the canonical evidence contract. Do not require undeclared processed_files/succeeded_files/failed_files counters.",
+            "delegate_report_handoff": "When the delegate prints a JSON report to stdout, parse that JSON directly instead of relying only on sidecar-report file path discovery.",
+            "delegate_report_flag_contract": "If wrapper passes a sidecar report path to the reviewed delegate, use the reviewed delegate CLI flag --report-json (or another explicitly supported alias). Do not invent undeclared flags such as --report-file.",
+            "dry_run_semantics": "If wrapper dry-run short-circuits before delegate execution, keep execution.delegated=false and report partial honestly. If wrapper does delegate under dry-run, pass through --dry-run explicitly.",
+            "pdf_discovery_consistency": "Keep wrapper preflight PDF discovery semantics aligned with the reviewed delegate (for example recursive vs non-recursive), so wrapper evidence and delegated execution count the same candidate set."
+          }
+        }
+      },
+      "expected_outputs": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ],
+      "constraints": [
+        "Follow the local inbox normalized request",
+        "Do not claim unsupported runtime dependencies",
+        "Keep output deterministic and executable",
+        "Produce only the expected script artifact",
+        "Prefer honest, reviewable intermediate behavior over unsupported OCR claims",
+        "If the requested output path ends with .xlsx, do not write non-XLSX text/XML/CSV content to that path.",
+        "Do not hardcode an input directory when the task params already provide input_dir.",
+        "Preserve meaningful traceability from the incoming description instead of collapsing it to a heading fragment.",
+        "Prefer wrapping or adapting artifacts/scripts/pdf_to_excel_ocr.py when that existing repo script already matches the requested behavior.",
+        "When artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py already exists, prefer updating that reviewed wrapper baseline instead of rewriting a new control flow from scratch.",
+        "If dry_run is true or no PDFs are discovered, report a reviewable partial outcome instead of claiming success without an XLSX artifact.",
+        "Resolve relative delegate script paths from the repository or script location, not from Path.cwd().",
+        "For readonly reviewable preview flows, only delegate to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py unless failing honestly.",
+        "Do not claim wrapper success from exit code plus output existence alone when the reviewed delegate report does not provide strong enough success evidence.",
+        "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
+        "When delegate emits JSON to stdout, parse that report directly instead of depending only on sidecar report-file discovery.",
+        "When wrapper passes a sidecar report path to the reviewed delegate, use --report-json exactly unless the reviewed delegate explicitly supports another alias.",
+        "If wrapper supports dry-run short-circuit semantics, keep execution.delegated=false and preserve partial status honestly.",
+        "Keep wrapper PDF discovery semantics aligned with reviewed delegate discovery semantics to avoid preflight/execution evidence drift.",
+        "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely."
+      ],
+      "priority": "medium",
+      "source": {
+        "kind": "local_inbox",
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl035-001.json",
+        "received_at": "2026-03-25T04:20:27.813413Z",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "regeneration_token": "regen-20260325-bl035-001"
+      },
+      "acceptance_criteria": [
+        "Produce the expected script artifact at expected_outputs[0].path",
+        "Script behavior remains runnable, deterministic, and reviewable",
+        "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
+        "Artifact behavior remains parameter-driven for input_dir and output_xlsx rather than hardcoding unrelated local defaults.",
+        "Dry-run or zero-input behavior is represented as a reviewable partial outcome instead of artifact-production success.",
+        "Relative preferred_base_script resolution remains portable and does not depend on Path.cwd().",
+        "Wrapper success requires stronger delegate evidence than zero exit code plus a non-empty output file alone.",
+        "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
+        "Delegate report handoff can consume JSON printed to stdout without relying exclusively on report sidecar file discovery.",
+        "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",
+        "Dry-run semantics remain explicit: short-circuit stays partial with no delegated execution, or delegated dry-run is passed through honestly.",
+        "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
+        "Delegate execution is bounded by an explicit timeout and reports timeout honestly."
+      ],
+      "metadata": {
+        "integration_phase": "8B",
+        "pipeline": "inbox->adapter->manager->automation->critic",
+        "request_type": "pdf_to_excel_ocr",
+        "payload_hash": "103723900dc85c4a28b75178ffb0c01d55bbba1d864efb89c62c3da065fb3d24",
+        "regeneration_token": "regen-20260325-bl035-001",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "external_metadata": {
+          "source_system": "trello",
+          "card_id": "69c24cd3c1a2359ddd7a1bf8",
+          "card_short_id": 7,
+          "board_id": "69be462743bfa0038ca10f7a",
+          "list_id": "69be462743bfa0038ca10f8f",
+          "date_last_activity": "2026-03-24T08:35:56.234Z",
+          "readonly_mapped_at": "2026-03-25T04:19:16.331224Z",
+          "contract_profile": "best_effort_evidence_backed",
+          "ocr_claim_policy": "do_not_claim_success_without_evidence",
+          "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+          "regeneration_token": "regen-20260325-bl035-001"
+        },
+        "automation_contract_profile": "narrow_script_artifact_with_repo_reuse_and_reviewable_runner_contract"
+      }
+    },
+    "critic": {
+      "task_id": "CRITIC-20260325-279",
+      "worker": "critic",
+      "task_type": "review_artifact",
+      "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+      "inputs": {
+        "artifacts": [
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "type": "script"
+          },
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+            "type": "script"
+          }
+        ],
+        "params": {
+          "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+          "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+          "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+          "labels": [
+            "best_effort",
+            "evidence_backed",
+            "readonly",
+            "reviewable",
+            "trello"
+          ],
+          "review_scope": {
+            "primary_artifact": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "paired_artifacts": [
+              "artifacts/scripts/pdf_to_excel_ocr.py"
+            ],
+            "goal": "Audit the wrapper and the reviewed delegate together so the review evidence can speak to the end-to-end readonly smoke path."
+          }
+        }
+      },
+      "expected_outputs": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ],
+      "constraints": [
+        "Review must be grounded in produced automation artifact",
+        "When both wrapper and reviewed delegate snapshots are supplied, evaluate them as one end-to-end readonly pair instead of ignoring the delegate evidence.",
+        "Do not invent missing artifact content",
+        "Return a clear verdict: pass, fail, or needs_revision",
+        "Include metadata.verdict in output",
+        "Generate review artifact markdown for expected_outputs[0].path"
+      ],
+      "priority": "medium",
+      "source": {
+        "kind": "local_inbox",
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl035-001.json",
+        "received_at": "2026-03-25T04:20:27.813413Z",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "regeneration_token": "regen-20260325-bl035-001"
+      },
+      "acceptance_criteria": [
+        "Produce a review artifact with explicit verdict (pass/fail/needs_revision)"
+      ],
+      "metadata": {
+        "integration_phase": "8B",
+        "pipeline": "inbox->adapter->manager->automation->critic",
+        "request_type": "pdf_to_excel_ocr",
+        "payload_hash": "103723900dc85c4a28b75178ffb0c01d55bbba1d864efb89c62c3da065fb3d24",
+        "regeneration_token": "regen-20260325-bl035-001",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "external_metadata": {
+          "source_system": "trello",
+          "card_id": "69c24cd3c1a2359ddd7a1bf8",
+          "card_short_id": 7,
+          "board_id": "69be462743bfa0038ca10f7a",
+          "list_id": "69be462743bfa0038ca10f8f",
+          "date_last_activity": "2026-03-24T08:35:56.234Z",
+          "readonly_mapped_at": "2026-03-25T04:19:16.331224Z",
+          "contract_profile": "best_effort_evidence_backed",
+          "ocr_claim_policy": "do_not_claim_success_without_evidence",
+          "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+          "regeneration_token": "regen-20260325-bl035-001"
+        }
+      }
+    }
+  },
+  "expected_artifacts": [
+    "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+    "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py"
+  ],
+  "dedupe_keys": [
+    "origin_regeneration:trello:69c24cd3c1a2359ddd7a1bf8:regen-20260325-bl035-001",
+    "hash:103723900dc85c4a28b75178ffb0c01d55bbba1d864efb89c62c3da065fb3d24"
+  ],
+  "risk_warnings": [],
+  "execution": {
+    "status": "rejected",
+    "executed": true,
+    "attempts": 2,
+    "executed_at": "2026-03-25T04:23:06.022096Z",
+    "decision_reason": "critic_verdict=needs_revision"
+  },
+  "approval": {
+    "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8.json",
+    "approved_by": "Oscarling",
+    "approved_at": "2026-03-25T04:20:34Z",
+    "note": "BL-20260325-035 governed validation execute only; no Git finalization; no Trello Done."
+  },
+  "last_execution": {
+    "decision": "rejected",
+    "decision_reason": "critic_verdict=needs_revision",
+    "automation_result": {
+      "task_id": "AUTO-20260325-858",
+      "worker": "automation",
+      "status": "success",
+      "summary": "Generated one runnable wrapper script artifact that prefers the reviewed repository delegate, preserves parameter-driven paths, uses explicit delegate timeout, parses delegate JSON from stdout and optional --report-json sidecar, keeps dry-run/zero-PDF outcomes as partial, and emits structured reviewable summaries.",
+      "artifacts": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ],
+      "timestamp": "2026-03-25T04:22:34.971092Z",
+      "duration_ms": 82923,
+      "notes": [
+        "Produced exactly one script artifact as requested.",
+        "The wrapper is deterministic and local-only, with no unsupported external dependency claims.",
+        "The wrapper resolves the reviewed base delegate relative to repository/script location instead of Path.cwd().",
+        "Success requires canonical delegate evidence via status/total_files/status_counter/dry_run rather than exit code plus file existence alone."
+      ],
+      "metadata": {
+        "task_id": "AUTO-20260325-858",
+        "worker": "automation",
+        "task_type": "generate_script",
+        "source_origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "expected_output_path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py"
+      }
+    },
+    "critic_result": {
+      "task_id": "CRITIC-20260325-279",
+      "worker": "critic",
+      "status": "success",
+      "summary": "Reviewed the inbox runner and paired delegate together as an end-to-end readonly smoke path. The wrapper is well aligned to the evidence-backed contract: it resolves paths portably, performs honest preflight handling, avoids success claims based only on exit code, requires canonical delegate JSON evidence, supports sidecar reporting, and preserves partial outcomes for dry-run and zero-input cases. The delegate provides batch isolation, OCR fallback options, sidecar/stdout reporting, and per-file result modeling. However, the pair has material contract mismatches that prevent a full pass: the delegate reports zero discovered PDFs as status=failed while the wrapper expects zero-input as an honest partial scenario; the delegate marks overall status=success whenever there are no failed files, even if some files are partial; and the wrapper’s canonical success check depends on an output XLSX existing but the delegate report itself does not attest to successful Excel write beyond status, making the success evidence slightly asymmetric. Verdict: needs_revision.",
+      "artifacts": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ],
+      "timestamp": "2026-03-25T04:23:05.855830Z",
+      "duration_ms": 30476,
+      "notes": [
+        "Used supplied artifact snapshots as review evidence.",
+        "Reviewed wrapper and delegate together rather than narrowing to a single file."
+      ],
+      "metadata": {
+        "task_id": "CRITIC-20260325-279",
+        "worker": "critic",
+        "verdict": "needs_revision",
+        "reviewed_artifacts": [
+          "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "artifacts/scripts/pdf_to_excel_ocr.py"
+        ]
+      }
+    },
+    "critic_verdict": "needs_revision"
+  }
+}

--- a/runtime_archives/bl035/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8.result.json
+++ b/runtime_archives/bl035/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8.result.json
@@ -1,0 +1,9 @@
+{
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8",
+  "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8.json",
+  "executed_at": "2026-03-25T04:23:06.022886Z",
+  "status": "rejected",
+  "decision_reason": "critic_verdict=needs_revision",
+  "critic_verdict": "needs_revision",
+  "test_mode": "off"
+}

--- a/runtime_archives/bl035/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl035-001.json
+++ b/runtime_archives/bl035/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl035-001.json
@@ -1,0 +1,41 @@
+{
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "metadata": {
+    "source_system": "trello",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "card_short_id": 7,
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "date_last_activity": "2026-03-24T08:35:56.234Z",
+    "readonly_mapped_at": "2026-03-25T04:19:16.331224Z",
+    "contract_profile": "best_effort_evidence_backed",
+    "ocr_claim_policy": "do_not_claim_success_without_evidence",
+    "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+    "regeneration_token": "regen-20260325-bl035-001"
+  },
+  "source": {
+    "provider": "trello",
+    "mode": "readonly",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "regeneration_token": "regen-20260325-bl035-001"
+  },
+  "request_type": "pdf_to_excel_ocr",
+  "input": {
+    "input_dir": "~/Desktop/pdf样本",
+    "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+    "ocr": "auto",
+    "dry_run": false
+  },
+  "regeneration_token": "regen-20260325-bl035-001"
+}

--- a/runtime_archives/bl035/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl035-001.json.result.json
+++ b/runtime_archives/bl035/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl035-001.json.result.json
@@ -1,0 +1,23 @@
+{
+  "ingested_at": "2026-03-25T04:20:27.814923Z",
+  "status": "processed",
+  "decision": "preview_created_pending_approval",
+  "decision_reason": "preview_created; waiting_for_explicit_approval",
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "payload_hash": "103723900dc85c4a28b75178ffb0c01d55bbba1d864efb89c62c3da065fb3d24",
+  "dedupe_keys": [
+    "origin_regeneration:trello:69c24cd3c1a2359ddd7a1bf8:regen-20260325-bl035-001",
+    "hash:103723900dc85c4a28b75178ffb0c01d55bbba1d864efb89c62c3da065fb3d24"
+  ],
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8",
+  "preview_file": "/Users/lingguozhong/openclaw-team/preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8.json",
+  "regeneration_token": "regen-20260325-bl035-001"
+}

--- a/runtime_archives/bl035/tmp/bl035_execute_once_elevated.json
+++ b/runtime_archives/bl035/tmp/bl035_execute_once_elevated.json
@@ -1,0 +1,18 @@
+{
+  "status": "done",
+  "processed": 0,
+  "rejected": 1,
+  "skipped": 0,
+  "test_mode": "off",
+  "allow_replay": true,
+  "results": [
+    {
+      "status": "rejected",
+      "decision_reason": "critic_verdict=needs_revision",
+      "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8",
+      "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8.json",
+      "result_sidecar": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8.result.json",
+      "critic_verdict": "needs_revision"
+    }
+  ]
+}

--- a/runtime_archives/bl035/tmp/bl035_execute_once_sandbox.json
+++ b/runtime_archives/bl035/tmp/bl035_execute_once_sandbox.json
@@ -1,0 +1,18 @@
+{
+  "status": "done",
+  "processed": 0,
+  "rejected": 1,
+  "skipped": 0,
+  "test_mode": "off",
+  "allow_replay": false,
+  "results": [
+    {
+      "status": "rejected",
+      "decision_reason": "Failed to initialize docker client from environment. Ensure Docker access is available or pass docker_client explicitly.",
+      "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8",
+      "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8.json",
+      "result_sidecar": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8.result.json",
+      "critic_verdict": "needs_revision"
+    }
+  ]
+}

--- a/runtime_archives/bl035/tmp/bl035_ingest_once.json
+++ b/runtime_archives/bl035/tmp/bl035_ingest_once.json
@@ -1,0 +1,21 @@
+{
+  "status": "done",
+  "processed": 1,
+  "rejected": 0,
+  "duplicate_skipped": 0,
+  "preview_created": 1,
+  "inbox_claimed": 1,
+  "processing_recovered": 0,
+  "test_mode": "success",
+  "results": [
+    {
+      "status": "processed",
+      "decision": "preview_created_pending_approval",
+      "decision_reason": "preview_created; waiting_for_explicit_approval",
+      "file": "/Users/lingguozhong/openclaw-team/processed/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl035-001.json",
+      "result_sidecar": "/Users/lingguozhong/openclaw-team/processed/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl035-001.json.result.json",
+      "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8",
+      "preview_file": "/Users/lingguozhong/openclaw-team/preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-103723900dc8.json"
+    }
+  ]
+}

--- a/runtime_archives/bl035/tmp/bl035_live_mapped_preview.json
+++ b/runtime_archives/bl035/tmp/bl035_live_mapped_preview.json
@@ -1,0 +1,38 @@
+{
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "metadata": {
+    "source_system": "trello",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "card_short_id": 7,
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "date_last_activity": "2026-03-24T08:35:56.234Z",
+    "readonly_mapped_at": "2026-03-25T04:19:16.331224Z",
+    "contract_profile": "best_effort_evidence_backed",
+    "ocr_claim_policy": "do_not_claim_success_without_evidence",
+    "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable"
+  },
+  "source": {
+    "provider": "trello",
+    "mode": "readonly",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f"
+  },
+  "request_type": "pdf_to_excel_ocr",
+  "input": {
+    "input_dir": "~/Desktop/pdf样本",
+    "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+    "ocr": "auto",
+    "dry_run": false
+  }
+}

--- a/runtime_archives/bl035/tmp/bl035_smoke_result.json
+++ b/runtime_archives/bl035/tmp/bl035_smoke_result.json
@@ -1,0 +1,90 @@
+{
+  "status": "done",
+  "fixture": "/Users/lingguozhong/openclaw-team/adapters/samples/trello_card_fixture.json",
+  "mapped_output": "/private/tmp/bl035_mapped.json",
+  "required_env": {
+    "credentials": [
+      "TRELLO_API_KEY",
+      "TRELLO_API_TOKEN"
+    ],
+    "credentials_aliases": [
+      "TRELLO_KEY",
+      "TRELLO_TOKEN"
+    ],
+    "credentials_priority": [
+      "TRELLO_API_KEY/TRELLO_API_TOKEN",
+      "TRELLO_KEY/TRELLO_TOKEN"
+    ],
+    "scope": [
+      "TRELLO_BOARD_ID",
+      "TRELLO_LIST_ID"
+    ],
+    "scope_rule": [
+      "TRELLO_BOARD_ID or TRELLO_LIST_ID (either one)"
+    ]
+  },
+  "smoke_read": {
+    "status": "pass",
+    "read_count": 1,
+    "scope": {
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": null
+    },
+    "scope_kind": "board",
+    "mapped_preview": {
+      "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+      "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+      "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "metadata": {
+        "source_system": "trello",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "card_short_id": 7,
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "date_last_activity": "2026-03-24T08:35:56.234Z",
+        "readonly_mapped_at": "2026-03-25T04:19:16.331224Z",
+        "contract_profile": "best_effort_evidence_backed",
+        "ocr_claim_policy": "do_not_claim_success_without_evidence",
+        "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable"
+      },
+      "source": {
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f"
+      },
+      "request_type": "pdf_to_excel_ocr",
+      "input": {
+        "input_dir": "~/Desktop/pdf样本",
+        "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+        "ocr": "auto",
+        "dry_run": false
+      }
+    },
+    "auth_env": {
+      "selected_names": {
+        "key": "TRELLO_API_KEY",
+        "token": "TRELLO_API_TOKEN"
+      },
+      "priority": "TRELLO_API_* first, fallback to TRELLO_*",
+      "presence": {
+        "TRELLO_API_KEY": "set",
+        "TRELLO_KEY": "set",
+        "TRELLO_API_TOKEN": "set",
+        "TRELLO_TOKEN": "set",
+        "TRELLO_BOARD_ID": "set",
+        "TRELLO_LIST_ID": "missing"
+      }
+    },
+    "note": "Read-only GET only. No write operations performed."
+  },
+  "mode": "trello_readonly_prep"
+}


### PR DESCRIPTION
## Summary\n- activate and complete BL-20260325-035 governed validation against a fresh same-origin candidate\n- archive full runtime evidence under runtime_archives/bl035 and restore tracked runtime-overwritten artifacts before commit\n- document outcome in POST_CRITIC_SNAPSHOT_HARDENING_VALIDATION_REPORT.md\n- mark BL-035 done with evidence and add BL-20260325-036 as the next blocker\n\n## Validation\n- python3 scripts/backlog_lint.py\n- python3 scripts/backlog_sync.py\n- bash scripts/premerge_check.sh\n- git diff --check\n\nCloses #63