### PR TITLE
fix: harden semantic contract alignment for BL-036

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -656,8 +656,8 @@ Allowed enum values:
 ### BL-20260325-036
 - title: Harden wrapper/delegate semantic contract alignment after BL-20260325-035 runtime findings
 - type: blocker
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-035
@@ -665,7 +665,24 @@ Allowed enum values:
 - done_when: Delegate/wrapper contract is aligned on zero-input semantics and aggregate status truthfulness, delegate report includes explicit output-write evidence fields required for reviewability, focused tests cover the new semantics, and one hardening report records the outcome
 - source: `POST_CRITIC_SNAPSHOT_HARDENING_VALIDATION_REPORT.md` on 2026-03-25 records `needs_revision` due semantic contract drift instead of snapshot truncation
 - link: /Users/lingguozhong/openclaw-team/SEMANTIC_CONTRACT_ALIGNMENT_HARDENING_REPORT.md
-- issue: deferred:phase=next until BL-20260325-035 lands on main
+- issue: https://github.com/Oscarling/openclaw-team/issues/65
+- evidence: `SEMANTIC_CONTRACT_ALIGNMENT_HARDENING_REPORT.md` records source-side hardening in `artifacts/scripts/pdf_to_excel_ocr.py` and `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py` to align zero-input partial semantics, aggregate status truthfulness, and explicit output-write attestation (`excel_written`, `output_exists`, `output_size_bytes`), with focused regressions in `tests/test_pdf_to_excel_ocr_delegate.py`
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-037
+- title: Validate BL-20260325-036 semantic contract hardening on a fresh same-origin governed candidate
+- type: mainline
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-036
+- start_when: `BL-20260325-036` is merged so a fresh same-origin governed run can verify whether semantic contract hardening clears the remaining `needs_revision` blocker cluster under real execute
+- done_when: One governed validation creates a fresh same-origin preview candidate after BL-20260325-036, runs one explicit approval plus one real execute, and records whether runtime critic outcome now clears semantic contract mismatches found in BL-20260325-035
+- source: `SEMANTIC_CONTRACT_ALIGNMENT_HARDENING_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation rather than assuming semantic hardening success without live evidence
+- link: /Users/lingguozhong/openclaw-team/POST_SEMANTIC_CONTRACT_ALIGNMENT_VALIDATION_REPORT.md
+- issue: deferred:phase=next until BL-20260325-036 lands on main
 - evidence: -
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -1388,6 +1388,63 @@ Verification snapshot on 2026-03-25:
   - `runtime_archives/bl035/state/`
   - `runtime_archives/bl035/tmp/`
 
+### 44. Source-Side Semantic Contract Alignment After BL-035
+
+User objective:
+
+- continue directly after `BL-20260325-035` without mixing a new live governed
+  run into the same phase
+- close the semantic mismatch cluster identified by critic:
+  - zero-input status semantics
+  - aggregate status truthfulness for partial outcomes
+  - explicit delegate output-write attestation fields
+- keep changes minimal, source-side, and test-backed
+
+Main work areas:
+
+- activated `BL-20260325-036` and mirrored it to GitHub issue `#65`
+- updated `artifacts/scripts/pdf_to_excel_ocr.py`:
+  - no-PDF branch now reports reviewable `partial` instead of hard `failed`
+  - no-PDF path now includes canonical output evidence defaults:
+    - `excel_written=false`
+    - `output_exists=false`
+    - `output_size_bytes=0`
+  - aggregate status now reports `success` only when:
+    - `failed == 0`
+    - `partial == 0`
+  - canonical report now emits output-write evidence fields across paths
+- updated `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`:
+  - strengthened success gate to require delegate attestation:
+    - no partial file outcomes
+    - `excel_written=true`
+    - `output_exists=true`
+    - `output_size_bytes > 0`
+- expanded `tests/test_pdf_to_excel_ocr_delegate.py` with focused semantic
+  regressions and output-evidence assertions
+- recorded next fresh governed validation phase as `BL-20260325-037`
+
+Primary output:
+
+- [SEMANTIC_CONTRACT_ALIGNMENT_HARDENING_REPORT.md](/Users/lingguozhong/openclaw-team/SEMANTIC_CONTRACT_ALIGNMENT_HARDENING_REPORT.md)
+
+Key result:
+
+- `BL-20260325-036` completed as a source-side hardening phase
+- delegate/wrapper semantic contract is now tighter on:
+  - zero-input reviewable partial semantics
+  - aggregate status truthfulness when partial files exist
+  - explicit output-write evidence in delegate canonical report
+- runtime closure is intentionally deferred to governed validation phase
+  `BL-20260325-037`
+
+Verification snapshot on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_delegate.py` passed
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py` passed
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed with `BL-20260325-036` mirrored to
+  issue `#65`
+
 ### 31. Post-Timeout Governed Validation On Fresh Same-Origin Candidate
 
 User objective:

--- a/SEMANTIC_CONTRACT_ALIGNMENT_HARDENING_REPORT.md
+++ b/SEMANTIC_CONTRACT_ALIGNMENT_HARDENING_REPORT.md
@@ -1,0 +1,110 @@
+# Semantic Contract Alignment Hardening Report
+
+## Objective
+
+Complete `BL-20260325-036` by resolving the semantic contract mismatches
+identified in `BL-20260325-035` between:
+
+- wrapper success/partial semantics
+- delegate aggregate status semantics
+- delegate canonical output-write evidence fields
+
+## Scope
+
+In scope:
+
+- delegate zero-input semantics hardening
+- delegate aggregate status truthfulness hardening
+- delegate output-write evidence enrichment
+- wrapper success-evidence gate tightening to consume enriched delegate evidence
+- focused regression coverage
+
+Out of scope:
+
+- fresh governed live Trello validation run
+- prompt-policy redesign for automation/critic
+- git finalization / Trello Done writeback
+
+## Changes
+
+### 1) Delegate zero-input semantics aligned to reviewable partial
+
+Updated `artifacts/scripts/pdf_to_excel_ocr.py`:
+
+- changed no-PDF branch from hard failure to reviewable partial report
+- no-PDF report now includes explicit canonical fields:
+  - `total_files = 0`
+  - `status_counter = {}`
+  - `excel_written = false`
+  - `output_exists = false`
+  - `output_size_bytes = 0`
+- no-PDF exit code changed from `2` to `0` (completed with honest partial)
+
+This removes the prior hard-failure semantic drift versus wrapper’s declared
+zero-input handling policy.
+
+### 2) Delegate aggregate status now respects partial outcomes
+
+Updated delegate aggregate status computation:
+
+- previous logic:
+  - `success` whenever `failed == 0`
+- new logic:
+  - `success` only when both `failed == 0` and `partial == 0`
+  - otherwise `partial`
+
+This prevents overclaiming success when partial file outcomes are present.
+
+### 3) Delegate report now attests output-write evidence explicitly
+
+Updated delegate canonical report fields:
+
+- `excel_written`
+- `output_exists`
+- `output_size_bytes`
+
+These are emitted consistently across dry-run, no-input, success, and
+write-failure paths.
+
+### 4) Wrapper success-evidence gate strengthened
+
+Updated `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`:
+
+- `has_strong_delegate_success_evidence()` now additionally requires:
+  - no partial file outcomes in `status_counter`
+  - `excel_written = true`
+  - `output_exists = true`
+  - `output_size_bytes > 0`
+
+This makes wrapper-level success claims rely on explicit delegate write
+attestation rather than status text alone.
+
+### 5) Focused regressions added for BL-036 semantics
+
+Expanded `tests/test_pdf_to_excel_ocr_delegate.py` with coverage for:
+
+- no-PDF path returns reviewable partial (not hard failure)
+- aggregate status stays `partial` when any file is partial
+- success reports include explicit output-write evidence fields
+- dry-run and write-failure paths emit explicit output evidence defaults
+
+## Verification
+
+Passed on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_delegate.py`
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py`
+
+## Conclusion
+
+`BL-20260325-036` can be treated as complete as a source-side hardening phase.
+
+The wrapper/delegate semantic contract is now materially tighter on:
+
+- zero-input partial semantics
+- aggregate status truthfulness
+- output-write evidence attestation
+
+Next required step: run a fresh same-origin governed validation to confirm these
+semantic hardenings remove the new runtime blocker cluster observed in
+`BL-20260325-035`.

--- a/artifacts/scripts/pdf_to_excel_ocr.py
+++ b/artifacts/scripts/pdf_to_excel_ocr.py
@@ -268,12 +268,21 @@ def main() -> int:
     if not pdf_files:
         emit_report(
             {
-                "status": "failed",
-                "error": f"No PDF files found under {input_dir}",
+                "status": "partial",
+                "input_dir": str(input_dir),
+                "output_xlsx": str(output_xlsx),
+                "ocr_mode": args.ocr,
+                "total_files": 0,
+                "status_counter": {},
+                "dry_run": bool(args.dry_run),
+                "excel_written": False,
+                "output_exists": False,
+                "output_size_bytes": 0,
+                "notes": [f"No PDF files found under {input_dir}"],
             },
             args.report_json,
         )
-        return 2
+        return 0
 
     ocr_runtime, missing = detect_ocr_runtime_status()
     results: list[FileResult] = []
@@ -306,8 +315,15 @@ def main() -> int:
     for item in results:
         status_counter[item.status] = status_counter.get(item.status, 0) + 1
 
+    failed_count = status_counter.get("failed", 0)
+    partial_count = status_counter.get("partial", 0)
+    if failed_count == 0 and partial_count == 0:
+        aggregate_status = "success"
+    else:
+        aggregate_status = "partial"
+
     report = {
-        "status": "success" if status_counter.get("failed", 0) == 0 else "partial",
+        "status": aggregate_status,
         "input_dir": str(input_dir),
         "output_xlsx": str(output_xlsx),
         "ocr_mode": args.ocr,
@@ -316,6 +332,9 @@ def main() -> int:
         "total_files": len(results),
         "status_counter": status_counter,
         "dry_run": bool(args.dry_run),
+        "excel_written": False,
+        "output_exists": False,
+        "output_size_bytes": 0,
     }
 
     if args.dry_run:
@@ -324,11 +343,19 @@ def main() -> int:
 
     try:
         write_excel(results, output_xlsx)
+        report["output_exists"] = output_xlsx.exists() and output_xlsx.is_file()
+        if report["output_exists"]:
+            report["output_size_bytes"] = int(output_xlsx.stat().st_size)
+        report["excel_written"] = bool(report["output_exists"] and report["output_size_bytes"] > 0)
         emit_report(report, args.report_json)
         return 0
     except Exception as e:
         report["status"] = "failed"
         report["error"] = str(e)
+        report["output_exists"] = output_xlsx.exists() and output_xlsx.is_file()
+        if report["output_exists"]:
+            report["output_size_bytes"] = int(output_xlsx.stat().st_size)
+        report["excel_written"] = bool(report["output_exists"] and report["output_size_bytes"] > 0)
         emit_report(report, args.report_json)
         return 3
 

--- a/artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
+++ b/artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
@@ -105,9 +105,22 @@ def has_strong_delegate_success_evidence(delegate_report: dict[str, Any] | None)
         failed_count = status_counter.get("failed", 0)
         if isinstance(failed_count, int) and failed_count > 0:
             return False, "Delegate report still records failed file outcomes."
+        partial_count = status_counter.get("partial", 0)
+        if isinstance(partial_count, int) and partial_count > 0:
+            return False, "Delegate report still records partial file outcomes."
 
     if bool(delegate_report.get("dry_run", False)):
         return False, "Delegate reported dry-run mode, so wrapper success would overclaim execution."
+
+    if delegate_report.get("excel_written") is not True:
+        return False, "Delegate report did not attest excel_written=true."
+
+    if delegate_report.get("output_exists") is not True:
+        return False, "Delegate report did not attest output_exists=true."
+
+    output_size_bytes = delegate_report.get("output_size_bytes")
+    if not isinstance(output_size_bytes, int) or output_size_bytes < 1:
+        return False, "Delegate report did not attest a non-empty output_size_bytes value."
 
     return True, None
 

--- a/tests/test_pdf_to_excel_ocr_delegate.py
+++ b/tests/test_pdf_to_excel_ocr_delegate.py
@@ -85,6 +85,9 @@ class PdfToExcelOcrDelegateTests(unittest.TestCase):
         self.assertEqual(sidecar_payload["status"], "success")
         self.assertEqual(sidecar_payload["total_files"], 1)
         self.assertEqual(sidecar_payload["dry_run"], True)
+        self.assertEqual(sidecar_payload["excel_written"], False)
+        self.assertEqual(sidecar_payload["output_exists"], False)
+        self.assertEqual(sidecar_payload["output_size_bytes"], 0)
 
     def test_report_json_is_written_on_write_failure(self) -> None:
         with mock.patch.object(self.delegate, "discover_pdfs", return_value=[self.fake_pdf]), mock.patch.object(
@@ -97,6 +100,60 @@ class PdfToExcelOcrDelegateTests(unittest.TestCase):
         self.assertEqual(stdout_payload, sidecar_payload)
         self.assertEqual(sidecar_payload["status"], "failed")
         self.assertIn("xlsx write failed", str(sidecar_payload.get("error")))
+        self.assertEqual(sidecar_payload["excel_written"], False)
+
+    def test_no_pdf_reports_partial_and_does_not_fail(self) -> None:
+        with mock.patch.object(self.delegate, "discover_pdfs", return_value=[]):
+            exit_code, stdout_payload, sidecar_payload = self._invoke_main()
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stdout_payload, sidecar_payload)
+        self.assertEqual(sidecar_payload["status"], "partial")
+        self.assertEqual(sidecar_payload["total_files"], 0)
+        self.assertEqual(sidecar_payload["status_counter"], {})
+        self.assertEqual(sidecar_payload["excel_written"], False)
+        self.assertEqual(sidecar_payload["output_exists"], False)
+        self.assertEqual(sidecar_payload["output_size_bytes"], 0)
+
+    def test_aggregate_status_is_partial_when_any_partial_file_exists(self) -> None:
+        def _fake_write_excel(_results, output_xlsx: Path) -> None:
+            output_xlsx.parent.mkdir(parents=True, exist_ok=True)
+            output_xlsx.write_bytes(b"xlsx-bytes")
+
+        with mock.patch.object(self.delegate, "discover_pdfs", return_value=[self.fake_pdf, self.fake_pdf]), mock.patch.object(
+            self.delegate,
+            "process_one_pdf",
+            side_effect=[self._mock_file_result(status="success"), self._mock_file_result(status="partial")],
+        ), mock.patch.object(self.delegate, "write_excel", side_effect=_fake_write_excel):
+            exit_code, stdout_payload, sidecar_payload = self._invoke_main()
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stdout_payload, sidecar_payload)
+        self.assertEqual(sidecar_payload["status"], "partial")
+        self.assertEqual(sidecar_payload["status_counter"]["success"], 1)
+        self.assertEqual(sidecar_payload["status_counter"]["partial"], 1)
+        self.assertEqual(sidecar_payload["excel_written"], True)
+        self.assertEqual(sidecar_payload["output_exists"], True)
+        self.assertGreater(sidecar_payload["output_size_bytes"], 0)
+
+    def test_success_report_includes_output_write_evidence(self) -> None:
+        def _fake_write_excel(_results, output_xlsx: Path) -> None:
+            output_xlsx.parent.mkdir(parents=True, exist_ok=True)
+            output_xlsx.write_bytes(b"xlsx-bytes")
+
+        with mock.patch.object(self.delegate, "discover_pdfs", return_value=[self.fake_pdf]), mock.patch.object(
+            self.delegate, "process_one_pdf", return_value=self._mock_file_result(status="success")
+        ), mock.patch.object(self.delegate, "write_excel", side_effect=_fake_write_excel):
+            exit_code, stdout_payload, sidecar_payload = self._invoke_main()
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(stdout_payload, sidecar_payload)
+        self.assertEqual(sidecar_payload["status"], "success")
+        self.assertEqual(sidecar_payload["total_files"], 1)
+        self.assertEqual(sidecar_payload["status_counter"]["success"], 1)
+        self.assertEqual(sidecar_payload["excel_written"], True)
+        self.assertEqual(sidecar_payload["output_exists"], True)
+        self.assertGreater(sidecar_payload["output_size_bytes"], 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary\n- align delegate zero-input behavior to reviewable partial semantics\n- harden delegate aggregate status logic so partial file outcomes cannot be overreported as success\n- add explicit delegate output-write attestation fields (excel_written/output_exists/output_size_bytes)\n- strengthen wrapper success gate to require those attestation fields and zero partial outcomes\n- expand delegate regressions and close BL-036 with follow-up BL-037 validation phase in backlog\n\n## Validation\n- python3 -m unittest -v tests/test_pdf_to_excel_ocr_delegate.py\n- python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py\n- python3 scripts/backlog_lint.py\n- python3 scripts/backlog_sync.py\n- bash scripts/premerge_check.sh\n- git diff --check\n\nCloses #65