### PR TITLE
fix: harden automation transport reliability for BL-038

### DIFF
--- a/AUTOMATION_ENDPOINT_SSL_RELIABILITY_HARDENING_REPORT.md
+++ b/AUTOMATION_ENDPOINT_SSL_RELIABILITY_HARDENING_REPORT.md
@@ -1,0 +1,108 @@
+# Automation Endpoint SSL Reliability Hardening Report
+
+## Objective
+
+Complete `BL-20260325-038` by hardening automation LLM transport handling for
+runtime endpoint instability observed in `BL-20260325-037`, specifically TLS EOF
+class failures.
+
+## Scope
+
+In scope:
+
+- automation LLM call transport error classification hardening
+- deterministic retry logging and terminal error diagnostics
+- optional fallback endpoint rotation support
+- focused regression coverage
+
+Out of scope:
+
+- fresh governed live Trello validation run
+- changing external endpoint provider infrastructure
+- git finalization / Trello Done writeback
+
+## Changes
+
+### 1) Added deterministic transport error classification
+
+Updated `dispatcher/worker_runtime.py`:
+
+- added `classify_llm_call_error()` to classify retry failures into stable
+  classes, including:
+  - `tls_eof`
+  - `timeout`
+  - `dns_resolution`
+  - `connection_reset`
+  - `connection_refused`
+  - `remote_closed`
+  - `http_<status>`
+  - `unknown`
+- mapped HTTP classes to retryability by code:
+  - retryable: `408/409/425/429/500/502/503/504`
+- kept unknown errors retryable to preserve existing operational resilience
+
+### 2) Hardened call path logging and terminal error clarity
+
+Updated `call_llm()` in `dispatcher/worker_runtime.py`:
+
+- per-attempt warning now logs:
+  - attempt index (`n/total`)
+  - endpoint
+  - classified error class
+  - retryable flag
+- retry log now includes next endpoint and delay seconds
+- terminal failure now raises structured runtime error containing:
+  - exhausted attempts
+  - error class
+  - endpoint
+  - retryable state
+- added `Connection: close` header to reduce stale-connection sensitivity
+
+### 3) Added optional fallback endpoint rotation
+
+Updated `dispatcher/worker_runtime.py`:
+
+- added fallback URL sources:
+  - `ARGUS_LLM_FALLBACK_CHAT_URLS` (comma-separated full chat URLs)
+  - `ARGUS_LLM_FALLBACK_API_BASES` (comma-separated API bases, normalized to
+    `/chat/completions`)
+- call attempts rotate deterministically across candidate endpoints
+
+Updated `skills/delegate_task.py`:
+
+- propagated fallback env into worker container runtime:
+  - `ARGUS_LLM_FALLBACK_CHAT_URLS`
+  - `ARGUS_LLM_FALLBACK_API_BASES`
+
+### 4) Added focused SSL EOF reliability regressions
+
+Expanded `tests/test_argus_hardening.py` with:
+
+- `test_call_llm_rotates_to_fallback_chat_url_after_retryable_tls_eof`
+  - verifies first-attempt TLS EOF on primary endpoint rotates to fallback and
+    succeeds
+- `test_call_llm_raises_classified_tls_error_after_exhaustion`
+  - verifies exhausted retries raise deterministic classified terminal error
+    containing `class=tls_eof` and attempt counters
+
+## Verification
+
+Passed on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_argus_hardening.py`
+- `python3 -m unittest -v tests/test_backlog_sync.py`
+
+## Conclusion
+
+`BL-20260325-038` can be treated as complete as a source-side blocker-hardening
+phase.
+
+Automation transport handling now has stronger reliability semantics through:
+
+- deterministic error classification
+- endpoint-aware retry diagnostics
+- configurable fallback endpoint rotation
+
+Next required step: run a fresh same-origin governed validation to verify
+whether this transport hardening allows runtime to reach artifact generation and
+critic review without the prior TLS EOF blocker.

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -690,8 +690,8 @@ Allowed enum values:
 ### BL-20260325-038
 - title: Harden automation endpoint transport reliability after BL-20260325-037 SSL EOF blocker
 - type: blocker
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-037
@@ -699,7 +699,24 @@ Allowed enum values:
 - done_when: Automation LLM call path handles endpoint transport instability with deterministic retry/error classification hardening (or endpoint/TLS configuration hardening), focused tests cover the new behavior, and one blocker report records the implemented mitigation
 - source: `POST_SEMANTIC_CONTRACT_ALIGNMENT_VALIDATION_REPORT.md` on 2026-03-25 records automation transport failure as the active blocker that prevented semantic runtime validation closure
 - link: /Users/lingguozhong/openclaw-team/AUTOMATION_ENDPOINT_SSL_RELIABILITY_HARDENING_REPORT.md
-- issue: deferred:phase=next until BL-20260325-037 lands on main
+- issue: https://github.com/Oscarling/openclaw-team/issues/69
+- evidence: `AUTOMATION_ENDPOINT_SSL_RELIABILITY_HARDENING_REPORT.md` records source-side hardening in `dispatcher/worker_runtime.py` and `skills/delegate_task.py` for deterministic transport error classification, endpoint-aware retry diagnostics, and optional fallback endpoint rotation (`ARGUS_LLM_FALLBACK_CHAT_URLS` / `ARGUS_LLM_FALLBACK_API_BASES`), with focused regression coverage in `tests/test_argus_hardening.py`
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-039
+- title: Validate BL-20260325-038 automation transport hardening on a fresh same-origin governed candidate
+- type: mainline
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-038
+- start_when: `BL-20260325-038` is merged so a fresh same-origin governed run can verify whether transport hardening clears SSL EOF-driven early automation failure
+- done_when: One governed validation creates a fresh same-origin preview candidate after BL-20260325-038, runs one explicit approval plus one real execute, and records whether runtime now reaches artifact generation and critic dispatch without transport-side SSL EOF blocker
+- source: `AUTOMATION_ENDPOINT_SSL_RELIABILITY_HARDENING_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation rather than assuming transport hardening success without live evidence
+- link: /Users/lingguozhong/openclaw-team/POST_AUTOMATION_SSL_RELIABILITY_VALIDATION_REPORT.md
+- issue: deferred:phase=next until BL-20260325-038 lands on main
 - evidence: -
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -1509,6 +1509,64 @@ Verification snapshot on 2026-03-25:
   - `runtime_archives/bl037/state/`
   - `runtime_archives/bl037/tmp/`
 
+### 46. Automation Transport Reliability Hardening After BL-037
+
+User objective:
+
+- continue after `BL-20260325-037` without mixing a new live validation into
+  the same phase
+- harden automation transport behavior for TLS EOF failures observed at runtime
+- make retry outcomes and terminal failures deterministic and diagnosable
+- keep the change minimal and test-backed
+
+Main work areas:
+
+- activated `BL-20260325-038` and mirrored it to GitHub issue `#69`
+- updated `dispatcher/worker_runtime.py`:
+  - added deterministic transport error classification for retry decisions and
+    diagnostics
+  - enriched retry logs with:
+    - attempt counters
+    - endpoint
+    - error class
+    - retryable flag
+  - terminal failures now raise structured exhaustion errors with class and
+    endpoint context
+  - added deterministic endpoint rotation across candidate chat endpoints
+  - added `Connection: close` request header to reduce stale-connection
+    sensitivity
+  - added env-supported fallback endpoint inputs:
+    - `ARGUS_LLM_FALLBACK_CHAT_URLS`
+    - `ARGUS_LLM_FALLBACK_API_BASES`
+- updated `skills/delegate_task.py` to pass fallback endpoint env into worker
+  containers
+- expanded `tests/test_argus_hardening.py` with focused regressions:
+  - TLS EOF on primary endpoint rotates to fallback and succeeds
+  - exhausted TLS EOF retries emit classified terminal error
+- recorded next governed validation phase as `BL-20260325-039`
+
+Primary output:
+
+- [AUTOMATION_ENDPOINT_SSL_RELIABILITY_HARDENING_REPORT.md](/Users/lingguozhong/openclaw-team/AUTOMATION_ENDPOINT_SSL_RELIABILITY_HARDENING_REPORT.md)
+
+Key result:
+
+- `BL-20260325-038` completed as a source-side blocker-hardening phase
+- automation transport path now provides deterministic classification and
+  endpoint-aware retry diagnostics
+- optional fallback endpoint rotation is now available without code changes
+  (via env configuration)
+- runtime closure is intentionally deferred to governed validation phase
+  `BL-20260325-039`
+
+Verification snapshot on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_argus_hardening.py` passed
+- `python3 -m unittest -v tests/test_backlog_sync.py` passed
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed with `BL-20260325-038` mirrored to
+  issue `#69`
+
 ### 31. Post-Timeout Governed Validation On Fresh Same-Origin Candidate
 
 User objective:

--- a/dispatcher/worker_runtime.py
+++ b/dispatcher/worker_runtime.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 import time
+import urllib.error
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
@@ -142,6 +143,30 @@ def llm_max_retries():
         DEFAULT_LLM_MAX_RETRIES,
         minimum=1,
     )
+
+
+def llm_fallback_chat_urls():
+    raw = first_env("ARGUS_LLM_FALLBACK_CHAT_URLS")
+    if not raw:
+        return []
+    urls = []
+    for item in raw.split(","):
+        value = item.strip()
+        if value:
+            urls.append(value)
+    return urls
+
+
+def llm_fallback_api_bases():
+    raw = first_env("ARGUS_LLM_FALLBACK_API_BASES")
+    if not raw:
+        return []
+    bases = []
+    for item in raw.split(","):
+        value = item.strip()
+        if value:
+            bases.append(value)
+    return bases
 
 
 # ==========================================
@@ -309,12 +334,56 @@ def load_test_mode_payload(task, worker):
     return build_test_mode_payload(task, worker, scenario or "success")
 
 
+def llm_candidate_chat_urls(llm_settings):
+    candidates = [llm_settings["chat_url"]]
+    candidates.extend(llm_fallback_chat_urls())
+    candidates.extend(normalize_chat_endpoint(base) for base in llm_fallback_api_bases())
+    deduped = []
+    seen = set()
+    for url in candidates:
+        if url in seen:
+            continue
+        seen.add(url)
+        deduped.append(url)
+    return deduped
+
+
+def classify_llm_call_error(error):
+    status_code = None
+    error_text = str(error or "")
+    if isinstance(error, urllib.error.URLError) and getattr(error, "reason", None) is not None:
+        error_text = f"{error_text} | reason={error.reason}"
+    if isinstance(error, urllib.error.HTTPError):
+        status_code = int(error.code)
+
+    lowered = error_text.lower()
+    if "unexpected_eof_while_reading" in lowered or "eof occurred in violation of protocol" in lowered:
+        return "tls_eof", True
+    if "timed out" in lowered:
+        return "timeout", True
+    if "name or service not known" in lowered or "name resolution" in lowered or "temporary failure in name resolution" in lowered:
+        return "dns_resolution", True
+    if "connection reset" in lowered:
+        return "connection_reset", True
+    if "connection refused" in lowered:
+        return "connection_refused", True
+    if "remote end closed connection" in lowered:
+        return "remote_closed", True
+    if status_code is not None:
+        retryable_codes = {408, 409, 425, 429, 500, 502, 503, 504}
+        return f"http_{status_code}", status_code in retryable_codes
+    if isinstance(error, TimeoutError):
+        return "timeout", True
+    return "unknown", True
+
+
 # ==========================================
 # LLM Call with retry
 # ==========================================
 def call_llm(system_prompt, user_prompt, worker, llm_settings):
     timeout_seconds = llm_timeout_seconds()
     max_attempts = llm_max_retries()
+    chat_urls = llm_candidate_chat_urls(llm_settings)
     payload = {
         "model": llm_settings["model_name"],
         "messages": [
@@ -327,11 +396,13 @@ def call_llm(system_prompt, user_prompt, worker, llm_settings):
         "Content-Type": "application/json",
         "Authorization": f"Bearer {llm_settings['api_key']}",
         "User-Agent": HTTP_USER_AGENT,
+        "Connection": "close",
     }
     for attempt in range(max_attempts):
+        chat_url = chat_urls[attempt % len(chat_urls)]
         try:
             req = urllib.request.Request(
-                llm_settings["chat_url"],
+                chat_url,
                 data=json.dumps(payload).encode("utf-8"),
                 headers=headers,
                 method="POST",
@@ -345,10 +416,26 @@ def call_llm(system_prompt, user_prompt, worker, llm_settings):
             content = choices[0].get("message", {}).get("content", "")
             return content
         except Exception as e:
-            log(worker, "WARN", f"LLM call failed attempt {attempt + 1}: {e}")
-            if attempt == max_attempts - 1:
-                raise
-            time.sleep(2 ** attempt)
+            error_class, retryable = classify_llm_call_error(e)
+            log(
+                worker,
+                "WARN",
+                (
+                    f"LLM call failed attempt {attempt + 1}/{max_attempts} "
+                    f"(endpoint={chat_url}, class={error_class}, retryable={retryable}): {e}"
+                ),
+            )
+            if attempt == max_attempts - 1 or not retryable:
+                raise RuntimeError(
+                    (
+                        f"LLM call exhausted (attempts={attempt + 1}/{max_attempts}, "
+                        f"class={error_class}, endpoint={chat_url}, retryable={retryable}): {e}"
+                    )
+                ) from e
+            delay_seconds = 2 ** attempt
+            next_url = chat_urls[(attempt + 1) % len(chat_urls)]
+            log(worker, "INFO", f"Retrying LLM call in {delay_seconds}s (next_endpoint={next_url})")
+            time.sleep(delay_seconds)
     return ""
 
 

--- a/skills/delegate_task.py
+++ b/skills/delegate_task.py
@@ -285,6 +285,8 @@ def build_worker_env(worker):
     )
     env["ARGUS_LLM_TIMEOUT_SECONDS"] = first_env("ARGUS_LLM_TIMEOUT_SECONDS")
     env["ARGUS_LLM_MAX_RETRIES"] = first_env("ARGUS_LLM_MAX_RETRIES")
+    env["ARGUS_LLM_FALLBACK_CHAT_URLS"] = first_env("ARGUS_LLM_FALLBACK_CHAT_URLS")
+    env["ARGUS_LLM_FALLBACK_API_BASES"] = first_env("ARGUS_LLM_FALLBACK_API_BASES")
     return {key: value for key, value in env.items() if value is not None}
 
 

--- a/tests/test_argus_hardening.py
+++ b/tests/test_argus_hardening.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 import tempfile
 import unittest
+import urllib.error
 from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 from typing import Any
@@ -482,6 +483,98 @@ class ArgusHardeningTests(unittest.TestCase):
         self.assertEqual(calls, [7, 7])
         self.assertEqual(attempts["count"], 2)
         self.assertEqual(json.loads(content)["status"], "success")
+
+    def test_call_llm_rotates_to_fallback_chat_url_after_retryable_tls_eof(self) -> None:
+        calls: list[tuple[str, int]] = []
+
+        class FakeResponse:
+            def __enter__(self) -> "FakeResponse":
+                return self
+
+            def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+                return False
+
+            def read(self) -> bytes:
+                payload = {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": json.dumps({"status": "success", "summary": "ok"})
+                            }
+                        }
+                    ]
+                }
+                return json.dumps(payload).encode("utf-8")
+
+        class FallbackOpener:
+            def open(self, req: Any, timeout: int | None = None) -> FakeResponse:
+                calls.append((req.full_url, timeout or 0))
+                if "primary.invalid" in req.full_url:
+                    raise urllib.error.URLError("[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol")
+                return FakeResponse()
+
+        with mock.patch.object(worker_runtime, "NO_PROXY_OPENER", FallbackOpener()):
+            with mock.patch.object(worker_runtime.time, "sleep", return_value=None):
+                with mock.patch.dict(
+                    os.environ,
+                    {
+                        "ARGUS_LLM_MAX_RETRIES": "2",
+                        "ARGUS_LLM_FALLBACK_CHAT_URLS": "https://fallback.invalid/v1/chat/completions",
+                    },
+                    clear=False,
+                ):
+                    content = worker_runtime.call_llm(
+                        "system",
+                        "user",
+                        "automation",
+                        {
+                            "api_key": "key",
+                            "api_base": "https://primary.invalid/v1",
+                            "chat_url": "https://primary.invalid/v1/chat/completions",
+                            "model_name": "demo-model",
+                        },
+                    )
+
+        self.assertEqual(
+            [url for url, _timeout in calls],
+            [
+                "https://primary.invalid/v1/chat/completions",
+                "https://fallback.invalid/v1/chat/completions",
+            ],
+        )
+        self.assertEqual([timeout for _url, timeout in calls], [120, 120])
+        self.assertEqual(json.loads(content)["status"], "success")
+
+    def test_call_llm_raises_classified_tls_error_after_exhaustion(self) -> None:
+        class AlwaysFailOpener:
+            def open(self, req: Any, timeout: int | None = None) -> Any:  # noqa: ARG002
+                raise urllib.error.URLError(
+                    "[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol"
+                )
+
+        with mock.patch.object(worker_runtime, "NO_PROXY_OPENER", AlwaysFailOpener()):
+            with mock.patch.object(worker_runtime.time, "sleep", return_value=None):
+                with mock.patch.dict(
+                    os.environ,
+                    {"ARGUS_LLM_MAX_RETRIES": "2"},
+                    clear=False,
+                ):
+                    with self.assertRaises(RuntimeError) as ctx:
+                        worker_runtime.call_llm(
+                            "system",
+                            "user",
+                            "automation",
+                            {
+                                "api_key": "key",
+                                "api_base": "https://primary.invalid/v1",
+                                "chat_url": "https://primary.invalid/v1/chat/completions",
+                                "model_name": "demo-model",
+                            },
+                        )
+
+        message = str(ctx.exception)
+        self.assertIn("class=tls_eof", message)
+        self.assertIn("attempts=2/2", message)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary\n- add deterministic LLM transport error classification in worker runtime (including tls_eof)\n- harden retry diagnostics with endpoint, class, retryability, and structured exhaustion errors\n- support optional fallback endpoint rotation via ARGUS_LLM_FALLBACK_CHAT_URLS and ARGUS_LLM_FALLBACK_API_BASES\n- pass fallback env vars through delegate_task worker environment\n- add focused argus hardening regressions for TLS EOF exhaustion and fallback rotation\n- close BL-038 in backlog/worklog and record follow-up governed validation as BL-039\n\n## Validation\n- python3 -m unittest -v tests/test_argus_hardening.py\n- python3 -m unittest -v tests/test_backlog_sync.py\n- python3 scripts/backlog_lint.py\n- python3 scripts/backlog_sync.py\n- bash scripts/premerge_check.sh\n- git diff --check\n\nCloses #69