### PR TITLE
docs: close BL-039 governed validation and archive runtime evidence

### DIFF
--- a/POST_AUTOMATION_SSL_RELIABILITY_VALIDATION_REPORT.md
+++ b/POST_AUTOMATION_SSL_RELIABILITY_VALIDATION_REPORT.md
@@ -1,0 +1,179 @@
+# Post-Automation SSL Reliability Validation Report
+
+## Objective
+
+Validate `BL-20260325-038` on one fresh same-origin governed candidate by
+running:
+
+- one live Trello read-only smoke
+- one explicit same-origin regeneration
+- one preview creation
+- one explicit approval
+- one real execute (`test_mode=off`)
+
+This phase objective is validation truth, not forcing a `pass` verdict.
+
+## Scope
+
+In scope:
+
+- one governed run against origin `trello:69c24cd3c1a2359ddd7a1bf8`
+- one regeneration token and one fresh preview candidate
+- runtime evidence capture for automation and critic outcomes
+- explicit recording of whether `BL-20260325-038` clears SSL EOF-driven early
+  automation failure under real execute
+
+Out of scope:
+
+- source-code hardening inside this validation phase
+- git finalization and Trello Done writeback
+- additional live reruns beyond this one governed candidate
+
+## Pre-Run Checks
+
+- branch: `phase9b/validate-bl039-automation-transport`
+- Trello env loaded from `/tmp/trello_env.sh`:
+  - `TRELLO_API_KEY` set
+  - `TRELLO_API_TOKEN` set
+  - `TRELLO_BOARD_ID` set
+- OpenAI runtime values available from:
+  - `secrets/openai_api_key.txt`
+  - `secrets/openai_api_base.txt`
+  - `secrets/openai_model_name.txt`
+- governed execute requires Docker worker access:
+  - first sandboxed execute attempt is captured as environment evidence
+  - elevated replay is used to complete governed runtime validation intent
+
+## Run Summary
+
+Target origin:
+
+- `trello:69c24cd3c1a2359ddd7a1bf8`
+
+Regeneration token:
+
+- `regen-20260325-bl039-001`
+
+### 1) Live Trello read-only smoke
+
+First sandboxed read:
+
+- blocked by DNS / sandbox network policy
+- error: `ConnectionError` / `NameResolutionError`
+
+Elevated rerun:
+
+- `status = pass`
+- `read_count = 1`
+- archive snapshots:
+  - `runtime_archives/bl039/tmp/bl039_smoke_result.json`
+  - `runtime_archives/bl039/tmp/bl039_live_mapped_preview.json`
+
+### 2) Regenerated payload and preview ingest
+
+- generated inbox payload from live `smoke_read.mapped_preview` with token
+  `regen-20260325-bl039-001`
+- ingest result sidecar:
+  - `processed/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl039-001.json.result.json`
+- ingest decision:
+  - `status = processed`
+  - `decision = preview_created_pending_approval`
+  - `preview_id = preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8`
+
+### 3) Preview candidate
+
+Generated preview:
+
+- `preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8`
+- preview file:
+  - `preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8.json`
+
+Pre-execute state:
+
+- `approved = false`
+- `execution.status = pending_approval`
+- `execution.attempts = 0`
+- `source.regeneration_token = regen-20260325-bl039-001`
+
+### 4) Explicit approval
+
+- approval file:
+  - `approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8.json`
+
+### 5) Real execute (`test_mode=off`)
+
+First sandboxed execute:
+
+- rejected before worker dispatch
+- reason:
+  `Failed to initialize docker client from environment. Ensure Docker access is available or pass docker_client explicitly.`
+- archive snapshot:
+  - `runtime_archives/bl039/tmp/bl039_execute_once_sandbox.json`
+
+Elevated replay execute (`--allow-replay`):
+
+- final result sidecar:
+  - `approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8.result.json`
+- `status = rejected`
+- `decision_reason = critic_verdict=needs_revision`
+
+Worker outcomes:
+
+- automation:
+  - task `AUTO-20260325-860`
+  - `status = success`
+  - artifact: `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`
+- critic:
+  - task `CRITIC-20260325-280`
+  - `status = success`
+  - verdict: `needs_revision`
+  - artifact: `artifacts/reviews/pdf_to_excel_ocr_inbox_review.md`
+
+Final preview execution state:
+
+- `approved = true`
+- `execution.status = rejected`
+- `execution.executed = true`
+- `execution.attempts = 2`
+
+## Critical Findings
+
+This validation confirms the prior transport blocker was cleared in this run:
+
+- automation no longer failed early with SSL EOF transport error
+- runtime progressed through automation artifact generation and critic review
+
+Current blocker shifted to generated wrapper review findings:
+
+- critic reports success-evidence handling risk in generated wrapper semantics
+  (wrapper may overstate `success` on delegate aggregate success without
+  sufficiently enforcing output-write attestation contract)
+
+Inference from this run:
+
+- `BL-20260325-038` transport hardening achieved its intended runtime objective
+  for this validation path.
+- end-to-end pass is now blocked by wrapper evidence-contract semantics in the
+  generated runtime artifact, not by transport instability.
+
+## Validation Conclusion
+
+`BL-20260325-039` is complete as a governed validation phase.
+
+It answers the intended question after `BL-20260325-038`: SSL EOF-driven early
+automation failure did not recur in this run, and execution reached critic
+review. Remaining failure cause moved forward to a different blocker class
+(generated wrapper evidence-contract consistency).
+
+Next required phase: harden source-side/runtime contract guidance for generated
+wrapper success-evidence semantics, then rerun fresh governed validation.
+
+## Archive Preservation
+
+To preserve runtime evidence and avoid loss from tracked artifact overwrite, this
+phase archived outputs under:
+
+- `runtime_archives/bl039/artifacts/`
+- `runtime_archives/bl039/runtime/`
+- `runtime_archives/bl039/state/`
+- `runtime_archives/bl039/tmp/`

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -707,8 +707,8 @@ Allowed enum values:
 ### BL-20260325-039
 - title: Validate BL-20260325-038 automation transport hardening on a fresh same-origin governed candidate
 - type: mainline
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-038
@@ -716,7 +716,24 @@ Allowed enum values:
 - done_when: One governed validation creates a fresh same-origin preview candidate after BL-20260325-038, runs one explicit approval plus one real execute, and records whether runtime now reaches artifact generation and critic dispatch without transport-side SSL EOF blocker
 - source: `AUTOMATION_ENDPOINT_SSL_RELIABILITY_HARDENING_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation rather than assuming transport hardening success without live evidence
 - link: /Users/lingguozhong/openclaw-team/POST_AUTOMATION_SSL_RELIABILITY_VALIDATION_REPORT.md
-- issue: deferred:phase=next until BL-20260325-038 lands on main
+- issue: https://github.com/Oscarling/openclaw-team/issues/71
+- evidence: `POST_AUTOMATION_SSL_RELIABILITY_VALIDATION_REPORT.md` records one fresh same-origin governed run (`regen-20260325-bl039-001`) to preview `preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8` with explicit approval and one elevated real execute replay; automation (`AUTO-20260325-860`) and critic (`CRITIC-20260325-280`) both completed, SSL EOF early-failure blocker did not recur, and dominant blocker shifted to generated wrapper success-evidence semantics
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-040
+- title: Harden generated wrapper success-evidence contract after BL-20260325-039 runtime findings
+- type: blocker
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-039
+- start_when: `BL-20260325-039` has completed and confirmed transport reliability blocker is cleared but runtime critic still returns `needs_revision` on generated wrapper success-evidence handling semantics
+- done_when: Source-side/runtime contract hardening ensures generated wrapper success semantics cannot overclaim without explicit delegate output-write attestation consistency, focused tests cover the targeted semantics, and one blocker report records the hardening outcome
+- source: `POST_AUTOMATION_SSL_RELIABILITY_VALIDATION_REPORT.md` on 2026-03-25 records that runtime progressed to critic review and shifted blocker to wrapper evidence-contract semantics
+- link: /Users/lingguozhong/openclaw-team/WRAPPER_SUCCESS_EVIDENCE_CONTRACT_HARDENING_REPORT.md
+- issue: deferred:phase=next until BL-20260325-039 lands on main
 - evidence: -
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -1567,6 +1567,72 @@ Verification snapshot on 2026-03-25:
 - `python3 scripts/backlog_sync.py` passed with `BL-20260325-038` mirrored to
   issue `#69`
 
+### 47. Fresh Governed Validation After BL-038 Transport Hardening
+
+User objective:
+
+- continue from `BL-20260325-038` with one fresh same-origin governed runtime
+  validation
+- verify whether transport hardening clears SSL EOF-driven early automation
+  failure under real execute
+- preserve runtime evidence and keep workflow-gated delivery
+
+Main work areas:
+
+- activated `BL-20260325-039` and mirrored it to GitHub issue `#71`
+- ran live Trello read-only smoke for origin
+  `trello:69c24cd3c1a2359ddd7a1bf8`
+  - first sandboxed call blocked by DNS policy
+  - elevated rerun passed with `read_count=1`
+- generated one regeneration token:
+  - `regen-20260325-bl039-001`
+- created inbox payload from `smoke_read.mapped_preview`, ingested once, and
+  created fresh preview:
+  - `preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8`
+- wrote explicit approval and ran real execute in `test_mode=off`
+  - first sandboxed execute blocked before dispatch due Docker client access
+  - elevated replay (`--allow-replay`) reached full automation + critic flow
+- archived runtime outputs under `runtime_archives/bl039/` before restoring
+  tracked `artifacts/` baselines
+- recorded next blocker phase as `BL-20260325-040`
+
+Primary output:
+
+- [POST_AUTOMATION_SSL_RELIABILITY_VALIDATION_REPORT.md](/Users/lingguozhong/openclaw-team/POST_AUTOMATION_SSL_RELIABILITY_VALIDATION_REPORT.md)
+
+Key result:
+
+- `BL-20260325-039` completed as a governed validation phase
+- prior transport blocker did not recur:
+  - automation task `AUTO-20260325-860` succeeded
+  - critic task `CRITIC-20260325-280` executed normally
+- final decision remained `critic_verdict=needs_revision`, but dominant blocker
+  shifted to generated wrapper success-evidence semantics instead of transport
+  instability
+- backlog updates from this phase:
+  - `BL-20260325-039` marked done with evidence
+  - new blocker `BL-20260325-040` added for wrapper success-evidence contract
+    hardening
+
+Verification snapshot on 2026-03-25:
+
+- smoke (elevated) returned `status=pass` with `read_count=1`
+- `python3 skills/ingest_tasks.py --once` returned:
+  - `processed = 1`
+  - `preview_created = 1`
+- sandboxed execute returned Docker-client initialization rejection
+- elevated replay execute returned:
+  - `status = rejected`
+  - `decision_reason = critic_verdict=needs_revision`
+- worker outcomes:
+  - automation `AUTO-20260325-860`: `success`
+  - critic `CRITIC-20260325-280`: `success` with verdict `needs_revision`
+- runtime archive preserved under:
+  - `runtime_archives/bl039/artifacts/`
+  - `runtime_archives/bl039/runtime/`
+  - `runtime_archives/bl039/state/`
+  - `runtime_archives/bl039/tmp/`
+
 ### 31. Post-Timeout Governed Validation On Fresh Same-Origin Candidate
 
 User objective:

--- a/runtime_archives/bl039/artifacts/pdf_to_excel_ocr_inbox_review.md
+++ b/runtime_archives/bl039/artifacts/pdf_to_excel_ocr_inbox_review.md
@@ -1,0 +1,95 @@
+# Review: pdf_to_excel_ocr_inbox_runner.py
+
+## Scope
+
+Reviewed the following artifacts together as a single readonly smoke execution pair:
+
+- `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`
+- `artifacts/scripts/pdf_to_excel_ocr.py`
+
+Review focus:
+
+- end-to-end readonly wrapper/delegate behavior
+- evidence-backed success/partial/failed reporting
+- alignment with the stated smoke contract
+- determinism and reviewability of local-artifact execution
+
+## Findings
+
+### Positive findings
+
+1. **Readonly delegation pattern is clear and bounded**
+   - The wrapper only resolves and invokes the reviewed local delegate script.
+   - No Trello writeback or external mutation behavior appears in either artifact.
+   - The wrapper uses a bounded subprocess timeout (`--delegate-timeout`), which is appropriate for smoke execution control.
+
+2. **Good structured reporting for reviewability**
+   - The wrapper emits a structured JSON summary with request, traceability, discovery, execution, delegate report, logs, and notes.
+   - The delegate emits structured JSON to stdout and optionally to a sidecar path via `--report-json`.
+   - Dry-run and zero-PDF cases are handled as `partial`, which matches a conservative evidence-backed posture.
+
+3. **Discovery and per-file isolation are sensible**
+   - Both wrapper and delegate perform recursive PDF discovery.
+   - Delegate processing isolates failures per file and aggregates status without aborting the whole batch.
+
+4. **Delegate avoids unsupported OCR claims**
+   - OCR runtime dependencies are detected and surfaced.
+   - OCR failure is reported explicitly in per-file results.
+   - The delegate reports `partial` when extraction is incomplete rather than overstating success.
+
+5. **Wrapper avoids writing mismatched fake XLSX content**
+   - The wrapper itself does not synthesize non-XLSX payloads into the target path.
+   - Output writing responsibility remains with the delegate.
+
+### Issues requiring revision
+
+1. **Wrapper success classification is weaker than its own contract suggests**
+   - In `evidence_status_from_delegate`, if the delegate report has `status == "success"` and no failed/error-like counts in `status_counter`, the wrapper returns `success`.
+   - It does **not** additionally verify delegate evidence such as:
+     - `excel_written == true`
+     - `output_exists == true`
+     - `output_size_bytes > 0`
+   - This is important because the wrapper header explicitly claims "stronger success evidence from delegate JSON report fields", but current logic does not enforce those output-evidence fields.
+   - Result: the wrapper may classify a run as `success` based only on aggregate delegate status, even if output evidence is absent or inconsistent.
+
+2. **Wrapper execution summary checks local output existence but does not use it to gate success**
+   - `build_summary()` captures `output_exists` and `output_size`, which is useful.
+   - However, these values do not affect `final_status` when delegate JSON is present.
+   - This means observable local evidence is collected but not used to protect the success verdict.
+
+3. **Delegate can report aggregate success before write phase, but wrapper trusts final report too broadly**
+   - The delegate initially sets aggregate status from file-level results, then attempts Excel writing.
+   - It does downgrade to `failed` on write exception, which is good.
+   - Still, because the wrapper is intended to be the reviewable inbox layer, it should independently verify the delegate's reported output evidence rather than trusting `status` alone.
+
+### Minor observations
+
+- The wrapper appends a note if `--output-xlsx` does not end with `.xlsx`, but does not fail fast. This is acceptable for a best-effort wrapper, though stricter validation could be justified.
+- The wrapper contains an unreachable `if args.dry_run:` inside the delegate command assembly because dry-run is short-circuited earlier; harmless but unnecessary.
+- The delegate imports optional dependencies defensively and degrades reasonably.
+
+## Verdict
+
+**needs_revision**
+
+## Rationale
+
+The pair is close to acceptable for a readonly, reviewable smoke path and demonstrates strong conservative design in several areas: structured reporting, bounded execution, local-only delegation, explicit dry-run/partial handling, and no inflated OCR claims.
+
+However, the wrapper's central evidence-handling responsibility is not fully met. It claims stronger success evidence based on delegate JSON, yet its actual success decision does not require proof that a real Excel artifact was written. Because the smoke contract explicitly says not to claim success without evidence, this is a material review issue.
+
+### Recommended revision
+
+Tighten wrapper success logic so `success` requires all of the following when delegate JSON is present:
+
+- delegate report `status == "success"`
+- `total_files > 0`
+- no failed/error/timeout counts in `status_counter`
+- `excel_written == true`
+- `output_exists == true`
+- `output_size_bytes > 0`
+- ideally, local wrapper-side `output_xlsx.exists()` and nonzero size agree with delegate evidence
+
+If those conditions are not met, downgrade to `partial` or `failed` with an explicit note.
+
+With that adjustment, this wrapper/delegate pair would be much better aligned with the stated evidence-backed readonly smoke contract.

--- a/runtime_archives/bl039/artifacts/pdf_to_excel_ocr_inbox_runner.py
+++ b/runtime_archives/bl039/artifacts/pdf_to_excel_ocr_inbox_runner.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""Local inbox-style wrapper for reviewed PDF->Excel OCR delegate.
+
+This helper prefers delegating to the reviewed repository script
+`artifacts/scripts/pdf_to_excel_ocr.py` and emits a structured JSON summary
+suitable for reviewable smoke execution.
+
+Contract highlights implemented here:
+- parameter-driven `input_dir` and `output_xlsx`
+- portable relative delegate resolution from repository/script location
+- bounded delegate subprocess timeout
+- partial outcome for dry-run or zero discovered PDFs
+- stronger success evidence from delegate JSON report fields
+- parse delegate JSON from stdout and/or `--report-json` sidecar
+- no mismatched non-XLSX content written to `.xlsx` outputs by this wrapper
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_DELEGATE_REL = "artifacts/scripts/pdf_to_excel_ocr.py"
+DEFAULT_TIMEOUT_SECONDS = 900
+
+
+@dataclass
+class DiscoveryResult:
+    total_pdfs: int
+    files: List[Path]
+
+
+def expand_path(value: str) -> Path:
+    return Path(os.path.expandvars(os.path.expanduser(value))).resolve()
+
+
+def resolve_repo_relative(path_str: str) -> Path:
+    candidate = Path(path_str)
+    if candidate.is_absolute():
+        return candidate
+    return (REPO_ROOT / candidate).resolve()
+
+
+def discover_pdfs(input_dir: Path) -> DiscoveryResult:
+    # Use recursive discovery to stay aligned with common delegate behavior for folder-based processing.
+    files = sorted(p for p in input_dir.rglob("*.pdf") if p.is_file())
+    return DiscoveryResult(total_pdfs=len(files), files=files)
+
+
+def extract_json_object_from_text(text: str) -> Optional[Dict[str, Any]]:
+    if not text:
+        return None
+    stripped = text.strip()
+    if not stripped:
+        return None
+
+    # First try whole payload.
+    try:
+        obj = json.loads(stripped)
+        if isinstance(obj, dict):
+            return obj
+    except Exception:
+        pass
+
+    # Fallback: scan lines from bottom to top for a JSON object.
+    for line in reversed([ln.strip() for ln in stripped.splitlines() if ln.strip()]):
+        if not (line.startswith("{") and line.endswith("}")):
+            continue
+        try:
+            obj = json.loads(line)
+            if isinstance(obj, dict):
+                return obj
+        except Exception:
+            continue
+    return None
+
+
+def load_json_file(path: Path) -> Optional[Dict[str, Any]]:
+    try:
+        if path.is_file():
+            return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    return None
+
+
+def evidence_status_from_delegate(report: Dict[str, Any]) -> str:
+    status = str(report.get("status", "")).strip().lower()
+    total_files = report.get("total_files")
+    status_counter = report.get("status_counter") or {}
+    dry_run = bool(report.get("dry_run", False))
+
+    try:
+        total = int(total_files)
+    except Exception:
+        total = 0
+
+    if dry_run:
+        return "partial"
+    if total <= 0:
+        return "partial"
+
+    if status == "success":
+        failed = 0
+        if isinstance(status_counter, dict):
+            try:
+                failed = sum(
+                    int(v)
+                    for k, v in status_counter.items()
+                    if str(k).strip().lower() in {"failed", "error", "errors", "timeout"}
+                )
+            except Exception:
+                failed = 0
+        return "success" if failed == 0 else "partial"
+
+    if status in {"partial", "failed"}:
+        return status
+
+    return "partial"
+
+
+def build_summary(
+    *,
+    status: str,
+    input_dir: Path,
+    output_xlsx: Path,
+    params: argparse.Namespace,
+    discovery: DiscoveryResult,
+    delegate_path: Path,
+    delegated: bool,
+    delegate_report: Optional[Dict[str, Any]],
+    delegate_exit_code: Optional[int],
+    stdout_text: str,
+    stderr_text: str,
+    extra_notes: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    return {
+        "status": status,
+        "request": {
+            "origin_id": params.origin_id,
+            "title": params.title,
+            "description": params.description,
+            "labels": params.labels,
+            "ocr": params.ocr,
+            "dry_run": params.dry_run,
+            "input_dir": str(input_dir),
+            "output_xlsx": str(output_xlsx),
+        },
+        "traceability": {
+            "wrapper_script": str(Path(__file__).resolve()),
+            "delegate_script": str(delegate_path),
+        },
+        "discovery": {
+            "input_dir": str(input_dir),
+            "total_pdfs": discovery.total_pdfs,
+            "sample_files": [str(p) for p in discovery.files[:10]],
+            "recursive": True,
+        },
+        "execution": {
+            "delegated": delegated,
+            "delegate_exit_code": delegate_exit_code,
+            "timeout_seconds": params.delegate_timeout,
+            "output_exists": output_xlsx.exists(),
+            "output_size": output_xlsx.stat().st_size if output_xlsx.exists() else 0,
+        },
+        "delegate_report": delegate_report,
+        "logs": {
+            "stdout_tail": stdout_text[-4000:],
+            "stderr_tail": stderr_text[-4000:],
+        },
+        "notes": extra_notes or [],
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Reviewable inbox runner for PDF-to-Excel OCR delegate")
+    parser.add_argument("--input-dir", required=True, help="Directory containing PDF files")
+    parser.add_argument("--output-xlsx", required=True, help="Target XLSX output path")
+    parser.add_argument("--ocr", default="auto", help="OCR mode to pass through when supported")
+    parser.add_argument("--dry-run", action="store_true", help="Reviewable dry-run; returns partial")
+    parser.add_argument("--origin-id", default="", help="Source origin id for traceability")
+    parser.add_argument("--title", default="", help="Request title")
+    parser.add_argument("--description", default="", help="Request description")
+    parser.add_argument("--labels", nargs="*", default=[], help="Traceability labels")
+    parser.add_argument(
+        "--preferred-base-script",
+        default=DEFAULT_DELEGATE_REL,
+        help="Preferred reviewed delegate script path",
+    )
+    parser.add_argument(
+        "--delegate-timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help="Explicit subprocess timeout in seconds",
+    )
+    parser.add_argument(
+        "--summary-json",
+        default="",
+        help="Optional path to write wrapper structured summary JSON",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    input_dir = expand_path(args.input_dir)
+    output_xlsx = expand_path(args.output_xlsx)
+    delegate_path = resolve_repo_relative(args.preferred_base_script)
+
+    notes: List[str] = []
+
+    if output_xlsx.suffix.lower() != ".xlsx":
+        notes.append("Requested output path is not .xlsx; wrapper expects real XLSX target semantics.")
+
+    if not input_dir.exists() or not input_dir.is_dir():
+        summary = build_summary(
+            status="failed",
+            input_dir=input_dir,
+            output_xlsx=output_xlsx,
+            params=args,
+            discovery=DiscoveryResult(total_pdfs=0, files=[]),
+            delegate_path=delegate_path,
+            delegated=False,
+            delegate_report=None,
+            delegate_exit_code=None,
+            stdout_text="",
+            stderr_text="Input directory does not exist or is not a directory.",
+            extra_notes=notes + ["Input directory validation failed."],
+        )
+        payload = json.dumps(summary, ensure_ascii=False, indent=2)
+        if args.summary_json:
+            summary_path = expand_path(args.summary_json)
+            summary_path.parent.mkdir(parents=True, exist_ok=True)
+            summary_path.write_text(payload, encoding="utf-8")
+        print(payload)
+        return 2
+
+    discovery = discover_pdfs(input_dir)
+
+    if args.dry_run:
+        summary = build_summary(
+            status="partial",
+            input_dir=input_dir,
+            output_xlsx=output_xlsx,
+            params=args,
+            discovery=discovery,
+            delegate_path=delegate_path,
+            delegated=False,
+            delegate_report=None,
+            delegate_exit_code=None,
+            stdout_text="",
+            stderr_text="",
+            extra_notes=notes + ["Dry-run short-circuit: delegate not executed."],
+        )
+        payload = json.dumps(summary, ensure_ascii=False, indent=2)
+        if args.summary_json:
+            summary_path = expand_path(args.summary_json)
+            summary_path.parent.mkdir(parents=True, exist_ok=True)
+            summary_path.write_text(payload, encoding="utf-8")
+        print(payload)
+        return 0
+
+    if discovery.total_pdfs == 0:
+        summary = build_summary(
+            status="partial",
+            input_dir=input_dir,
+            output_xlsx=output_xlsx,
+            params=args,
+            discovery=discovery,
+            delegate_path=delegate_path,
+            delegated=False,
+            delegate_report=None,
+            delegate_exit_code=None,
+            stdout_text="",
+            stderr_text="",
+            extra_notes=notes + ["No PDF files discovered; nothing delegated."],
+        )
+        payload = json.dumps(summary, ensure_ascii=False, indent=2)
+        if args.summary_json:
+            summary_path = expand_path(args.summary_json)
+            summary_path.parent.mkdir(parents=True, exist_ok=True)
+            summary_path.write_text(payload, encoding="utf-8")
+        print(payload)
+        return 0
+
+    if not delegate_path.is_file():
+        summary = build_summary(
+            status="failed",
+            input_dir=input_dir,
+            output_xlsx=output_xlsx,
+            params=args,
+            discovery=discovery,
+            delegate_path=delegate_path,
+            delegated=False,
+            delegate_report=None,
+            delegate_exit_code=None,
+            stdout_text="",
+            stderr_text="Reviewed delegate script not found.",
+            extra_notes=notes + ["Readonly reviewable flow only delegates to reviewed repository script."],
+        )
+        payload = json.dumps(summary, ensure_ascii=False, indent=2)
+        if args.summary_json:
+            summary_path = expand_path(args.summary_json)
+            summary_path.parent.mkdir(parents=True, exist_ok=True)
+            summary_path.write_text(payload, encoding="utf-8")
+        print(payload)
+        return 2
+
+    output_xlsx.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="pdf_to_excel_runner_") as tmpdir:
+        report_path = Path(tmpdir) / "delegate_report.json"
+        cmd = [
+            sys.executable,
+            str(delegate_path),
+            "--input-dir",
+            str(input_dir),
+            "--output-xlsx",
+            str(output_xlsx),
+            "--ocr",
+            str(args.ocr),
+            "--report-json",
+            str(report_path),
+        ]
+        if args.dry_run:
+            cmd.append("--dry-run")
+
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=args.delegate_timeout,
+                cwd=str(REPO_ROOT),
+                check=False,
+            )
+            stdout_text = proc.stdout or ""
+            stderr_text = proc.stderr or ""
+            delegate_report = extract_json_object_from_text(stdout_text) or load_json_file(report_path)
+            final_status = "failed"
+            if delegate_report is not None:
+                final_status = evidence_status_from_delegate(delegate_report)
+            elif proc.returncode == 0:
+                notes.append("Delegate exited zero but did not provide canonical JSON evidence; wrapper does not upgrade to success.")
+                final_status = "partial" if output_xlsx.exists() else "failed"
+
+            summary = build_summary(
+                status=final_status,
+                input_dir=input_dir,
+                output_xlsx=output_xlsx,
+                params=args,
+                discovery=discovery,
+                delegate_path=delegate_path,
+                delegated=True,
+                delegate_report=delegate_report,
+                delegate_exit_code=proc.returncode,
+                stdout_text=stdout_text,
+                stderr_text=stderr_text,
+                extra_notes=notes,
+            )
+            payload = json.dumps(summary, ensure_ascii=False, indent=2)
+            if args.summary_json:
+                summary_path = expand_path(args.summary_json)
+                summary_path.parent.mkdir(parents=True, exist_ok=True)
+                summary_path.write_text(payload, encoding="utf-8")
+            print(payload)
+            return 0 if final_status in {"success", "partial"} else 2
+
+        except subprocess.TimeoutExpired as exc:
+            stdout_text = exc.stdout or ""
+            stderr_text = exc.stderr or ""
+            summary = build_summary(
+                status="failed",
+                input_dir=input_dir,
+                output_xlsx=output_xlsx,
+                params=args,
+                discovery=discovery,
+                delegate_path=delegate_path,
+                delegated=True,
+                delegate_report=None,
+                delegate_exit_code=None,
+                stdout_text=stdout_text if isinstance(stdout_text, str) else "",
+                stderr_text=(stderr_text if isinstance(stderr_text, str) else "") + "\nDelegate timed out.",
+                extra_notes=notes + ["Delegate subprocess timed out before producing reviewable completion evidence."],
+            )
+            payload = json.dumps(summary, ensure_ascii=False, indent=2)
+            if args.summary_json:
+                summary_path = expand_path(args.summary_json)
+                summary_path.parent.mkdir(parents=True, exist_ok=True)
+                summary_path.write_text(payload, encoding="utf-8")
+            print(payload)
+            return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runtime_archives/bl039/runtime/AUTO-20260325-860.json
+++ b/runtime_archives/bl039/runtime/AUTO-20260325-860.json
@@ -1,0 +1,192 @@
+{
+  "task_id": "AUTO-20260325-860",
+  "worker": "automation",
+  "status": "success",
+  "created_at": "2026-03-25T04:55:03.109310Z",
+  "updated_at": "2026-03-25T04:56:13.327288Z",
+  "retries": 0,
+  "max_retries": 0,
+  "attempts": [
+    {
+      "attempt": 1,
+      "status": "success",
+      "retryable": false,
+      "error": null,
+      "runtime_log": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-860/runtime.attempt-1.log",
+      "exit_code": 0,
+      "timed_out": false,
+      "wait_error": null,
+      "output_path": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-860/output.json",
+      "started_at": "2026-03-25T04:55:03.111259Z",
+      "finished_at": "2026-03-25T04:56:13.301976Z"
+    }
+  ],
+  "task_dir": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-860",
+  "payload": {
+    "task_id": "AUTO-20260325-860",
+    "worker": "automation",
+    "task_type": "generate_script",
+    "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+    "inputs": {
+      "params": {
+        "input_dir": "~/Desktop/pdf样本",
+        "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+        "ocr": "auto",
+        "dry_run": false,
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "description": "Purpose: | Controlled Trello live preview smoke for openclaw-team. | Expected behavior: | - read-only Trello ingest | - preview creation smoke only | - no business execution claim | - no Trello writeback expected in this step | Traceability: | - backlog: BL-20260324-014 | - blocker context: BL-20260324-015 | - created_by: Oscarling | - created_at: 2026-03-24 Asia/Shanghai | Note: | This card is only for governed smoke verification and should remain open until the smoke is finished.",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "preferred_wrapper_script": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "preferred_base_script": "artifacts/scripts/pdf_to_excel_ocr.py",
+        "reference_docs": [
+          "artifacts/docs/pdf_to_excel_ocr_usage.md",
+          "artifacts/reviews/pdf_to_excel_ocr_review.md"
+        ],
+        "contract_hints": {
+          "output_format_fidelity": "If output_xlsx ends with .xlsx, produce a real XLSX workbook container or fail honestly before writing mismatched text/XML/CSV content to a .xlsx path.",
+          "path_portability": "Use the provided input_dir parameter as runtime input. Do not hardcode a user-home or absolute input path when params already declare the path.",
+          "traceability": "Preserve meaningful description context from the external input; do not collapse it to a heading fragment such as Purpose:.",
+          "reuse_preference": "Prefer reusing artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py as the wrapper baseline and artifacts/scripts/pdf_to_excel_ocr.py as the reviewed delegate when compatible, so workbook semantics and contract behavior stay aligned with repository evidence.",
+          "outcome_status_model": "Use the reviewable status model success/partial/failed. Dry-run requests or zero-PDF discovery should resolve to partial rather than claiming success without an output artifact.",
+          "delegate_resolution": "If preferred_base_script is relative, resolve it from the repository or script location instead of Path.cwd() so behavior stays portable across shells and CI.",
+          "reviewed_delegate_contract": "For readonly reviewable preview flows, delegate only to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py or fail honestly instead of broadening behavior through an arbitrary helper.",
+          "delegate_success_evidence": "Do not treat zero exit code plus output-file existence as sufficient wrapper success evidence on their own. Prefer a structured delegate report that confirms a real success outcome with at least one processed input and no failed-file counterexamples before the wrapper claims success.",
+          "delegate_timeout": "Bound delegate subprocess execution with an explicit timeout and report timeout as an honest failed/partial outcome instead of allowing smoke automation to hang indefinitely.",
+          "runtime_summary": "The generated script should emit a structured summary of what it produced so later review can inspect behavior without guessing.",
+          "delegate_report_schema": "Treat delegate JSON report fields status/total_files/status_counter/dry_run as the canonical evidence contract. Do not require undeclared processed_files/succeeded_files/failed_files counters.",
+          "delegate_report_handoff": "When the delegate prints a JSON report to stdout, parse that JSON directly instead of relying only on sidecar-report file path discovery.",
+          "delegate_report_flag_contract": "If wrapper passes a sidecar report path to the reviewed delegate, use the reviewed delegate CLI flag --report-json (or another explicitly supported alias). Do not invent undeclared flags such as --report-file.",
+          "dry_run_semantics": "If wrapper dry-run short-circuits before delegate execution, keep execution.delegated=false and report partial honestly. If wrapper does delegate under dry-run, pass through --dry-run explicitly.",
+          "pdf_discovery_consistency": "Keep wrapper preflight PDF discovery semantics aligned with the reviewed delegate (for example recursive vs non-recursive), so wrapper evidence and delegated execution count the same candidate set."
+        }
+      }
+    },
+    "expected_outputs": [
+      {
+        "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "type": "script"
+      }
+    ],
+    "constraints": [
+      "Follow the local inbox normalized request",
+      "Do not claim unsupported runtime dependencies",
+      "Keep output deterministic and executable",
+      "Produce only the expected script artifact",
+      "Prefer honest, reviewable intermediate behavior over unsupported OCR claims",
+      "If the requested output path ends with .xlsx, do not write non-XLSX text/XML/CSV content to that path.",
+      "Do not hardcode an input directory when the task params already provide input_dir.",
+      "Preserve meaningful traceability from the incoming description instead of collapsing it to a heading fragment.",
+      "Prefer wrapping or adapting artifacts/scripts/pdf_to_excel_ocr.py when that existing repo script already matches the requested behavior.",
+      "When artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py already exists, prefer updating that reviewed wrapper baseline instead of rewriting a new control flow from scratch.",
+      "If dry_run is true or no PDFs are discovered, report a reviewable partial outcome instead of claiming success without an XLSX artifact.",
+      "Resolve relative delegate script paths from the repository or script location, not from Path.cwd().",
+      "For readonly reviewable preview flows, only delegate to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py unless failing honestly.",
+      "Do not claim wrapper success from exit code plus output existence alone when the reviewed delegate report does not provide strong enough success evidence.",
+      "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
+      "When delegate emits JSON to stdout, parse that report directly instead of depending only on sidecar report-file discovery.",
+      "When wrapper passes a sidecar report path to the reviewed delegate, use --report-json exactly unless the reviewed delegate explicitly supports another alias.",
+      "If wrapper supports dry-run short-circuit semantics, keep execution.delegated=false and preserve partial status honestly.",
+      "Keep wrapper PDF discovery semantics aligned with reviewed delegate discovery semantics to avoid preflight/execution evidence drift.",
+      "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely."
+    ],
+    "priority": "medium",
+    "source": {
+      "kind": "local_inbox",
+      "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+      "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl039-001.json",
+      "received_at": "2026-03-25T04:54:19.933558Z",
+      "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "provider": "trello",
+      "mode": "readonly",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "regeneration_token": "regen-20260325-bl039-001"
+    },
+    "acceptance_criteria": [
+      "Produce the expected script artifact at expected_outputs[0].path",
+      "Script behavior remains runnable, deterministic, and reviewable",
+      "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
+      "Artifact behavior remains parameter-driven for input_dir and output_xlsx rather than hardcoding unrelated local defaults.",
+      "Dry-run or zero-input behavior is represented as a reviewable partial outcome instead of artifact-production success.",
+      "Relative preferred_base_script resolution remains portable and does not depend on Path.cwd().",
+      "Wrapper success requires stronger delegate evidence than zero exit code plus a non-empty output file alone.",
+      "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
+      "Delegate report handoff can consume JSON printed to stdout without relying exclusively on report sidecar file discovery.",
+      "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",
+      "Dry-run semantics remain explicit: short-circuit stays partial with no delegated execution, or delegated dry-run is passed through honestly.",
+      "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
+      "Delegate execution is bounded by an explicit timeout and reports timeout honestly."
+    ],
+    "metadata": {
+      "integration_phase": "8B",
+      "pipeline": "inbox->adapter->manager->automation->critic",
+      "request_type": "pdf_to_excel_ocr",
+      "payload_hash": "055bd74afff89e46f2397c3f7a855c6dba4fc2cf7471cf3923f7aa8bb46d27ba",
+      "regeneration_token": "regen-20260325-bl039-001",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "external_metadata": {
+        "source_system": "trello",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "card_short_id": 7,
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "date_last_activity": "2026-03-24T08:35:56.234Z",
+        "readonly_mapped_at": "2026-03-25T04:54:11.471876Z",
+        "contract_profile": "best_effort_evidence_backed",
+        "ocr_claim_policy": "do_not_claim_success_without_evidence",
+        "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+        "regeneration_token": "regen-20260325-bl039-001"
+      },
+      "automation_contract_profile": "narrow_script_artifact_with_repo_reuse_and_reviewable_runner_contract"
+    }
+  },
+  "result": {
+    "task_id": "AUTO-20260325-860",
+    "worker": "automation",
+    "status": "success",
+    "summary": "Generated the requested single runnable helper script artifact as a reviewed-wrapper-style inbox runner that preserves parameter-driven behavior, resolves the reviewed delegate portably, enforces timeout-bounded delegation, parses delegate JSON from stdout and/or --report-json sidecar, keeps zero-input/dry-run outcomes reviewably partial, and avoids claiming success without strong delegate evidence.",
+    "artifacts": [
+      {
+        "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "type": "script"
+      }
+    ],
+    "timestamp": "2026-03-25T04:56:13.142928Z",
+    "duration_ms": 69802,
+    "notes": [
+      "The artifact is a single Python script only, per contract.",
+      "It is designed to wrap the reviewed delegate artifacts/scripts/pdf_to_excel_ocr.py rather than re-implement PDF extraction/conversion.",
+      "It preserves traceability context from the incoming request in its structured summary output.",
+      "It does not hardcode the provided input directory; input_dir and output_xlsx are runtime parameters.",
+      "It treats dry-run and zero-PDF discovery as partial outcomes and uses explicit delegate timeout handling."
+    ],
+    "metadata": {
+      "task_id": "AUTO-20260325-860",
+      "worker": "automation",
+      "created_files": [
+        "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py"
+      ]
+    }
+  }
+}

--- a/runtime_archives/bl039/runtime/CRITIC-20260325-280.json
+++ b/runtime_archives/bl039/runtime/CRITIC-20260325-280.json
@@ -1,0 +1,196 @@
+{
+  "task_id": "CRITIC-20260325-280",
+  "worker": "critic",
+  "status": "success",
+  "created_at": "2026-03-25T04:56:13.333903Z",
+  "updated_at": "2026-03-25T04:56:42.929582Z",
+  "retries": 0,
+  "max_retries": 0,
+  "attempts": [
+    {
+      "attempt": 1,
+      "status": "success",
+      "retryable": false,
+      "error": null,
+      "runtime_log": "/Users/lingguozhong/openclaw-team/workspaces/critic/CRITIC-20260325-280/runtime.attempt-1.log",
+      "exit_code": 0,
+      "timed_out": false,
+      "wait_error": null,
+      "output_path": "/Users/lingguozhong/openclaw-team/workspaces/critic/CRITIC-20260325-280/output.json",
+      "started_at": "2026-03-25T04:56:13.337190Z",
+      "finished_at": "2026-03-25T04:56:42.898012Z"
+    }
+  ],
+  "task_dir": "/Users/lingguozhong/openclaw-team/workspaces/critic/CRITIC-20260325-280",
+  "payload": {
+    "task_id": "CRITIC-20260325-280",
+    "worker": "critic",
+    "task_type": "review_artifact",
+    "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+    "inputs": {
+      "artifacts": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        },
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+          "type": "script"
+        }
+      ],
+      "params": {
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "review_scope": {
+          "primary_artifact": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "paired_artifacts": [
+            "artifacts/scripts/pdf_to_excel_ocr.py"
+          ],
+          "goal": "Audit the wrapper and the reviewed delegate together so the review evidence can speak to the end-to-end readonly smoke path."
+        },
+        "artifact_snapshots": [
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "available": true,
+            "content": "#!/usr/bin/env python3\n\"\"\"Local inbox-style wrapper for reviewed PDF->Excel OCR delegate.\n\nThis helper prefers delegating to the reviewed repository script\n`artifacts/scripts/pdf_to_excel_ocr.py` and emits a structured JSON summary\nsuitable for reviewable smoke execution.\n\nContract highlights implemented here:\n- parameter-driven `input_dir` and `output_xlsx`\n- portable relative delegate resolution from repository/script location\n- bounded delegate subprocess timeout\n- partial outcome for dry-run or zero discovered PDFs\n- stronger success evidence from delegate JSON report fields\n- parse delegate JSON from stdout and/or `--report-json` sidecar\n- no mismatched non-XLSX content written to `.xlsx` outputs by this wrapper\n\"\"\"\n\nfrom __future__ import annotations\n\nimport argparse\nimport json\nimport os\nimport subprocess\nimport sys\nimport tempfile\nfrom dataclasses import dataclass\nfrom pathlib import Path\nfrom typing import Any, Dict, List, Optional\n\nREPO_ROOT = Path(__file__).resolve().parents[2]\nDEFAULT_DELEGATE_REL = \"artifacts/scripts/pdf_to_excel_ocr.py\"\nDEFAULT_TIMEOUT_SECONDS = 900\n\n\n@dataclass\nclass DiscoveryResult:\n    total_pdfs: int\n    files: List[Path]\n\n\ndef expand_path(value: str) -> Path:\n    return Path(os.path.expandvars(os.path.expanduser(value))).resolve()\n\n\ndef resolve_repo_relative(path_str: str) -> Path:\n    candidate = Path(path_str)\n    if candidate.is_absolute():\n        return candidate\n    return (REPO_ROOT / candidate).resolve()\n\n\ndef discover_pdfs(input_dir: Path) -> DiscoveryResult:\n    # Use recursive discovery to stay aligned with common delegate behavior for folder-based processing.\n    files = sorted(p for p in input_dir.rglob(\"*.pdf\") if p.is_file())\n    return DiscoveryResult(total_pdfs=len(files), files=files)\n\n\ndef extract_json_object_from_text(text: str) -> Optional[Dict[str, Any]]:\n    if not text:\n        return None\n    stripped = text.strip()\n    if not stripped:\n        return None\n\n    # First try whole payload.\n    try:\n        obj = json.loads(stripped)\n        if isinstance(obj, dict):\n            return obj\n    except Exception:\n        pass\n\n    # Fallback: scan lines from bottom to top for a JSON object.\n    for line in reversed([ln.strip() for ln in stripped.splitlines() if ln.strip()]):\n        if not (line.startswith(\"{\") and line.endswith(\"}\")):\n            continue\n        try:\n            obj = json.loads(line)\n            if isinstance(obj, dict):\n                return obj\n        except Exception:\n            continue\n    return None\n\n\ndef load_json_file(path: Path) -> Optional[Dict[str, Any]]:\n    try:\n        if path.is_file():\n            return json.loads(path.read_text(encoding=\"utf-8\"))\n    except Exception:\n        return None\n    return None\n\n\ndef evidence_status_from_delegate(report: Dict[str, Any]) -> str:\n    status = str(report.get(\"status\", \"\")).strip().lower()\n    total_files = report.get(\"total_files\")\n    status_counter = report.get(\"status_counter\") or {}\n    dry_run = bool(report.get(\"dry_run\", False))\n\n    try:\n        total = int(total_files)\n    except Exception:\n        total = 0\n\n    if dry_run:\n        return \"partial\"\n    if total <= 0:\n        return \"partial\"\n\n    if status == \"success\":\n        failed = 0\n        if isinstance(status_counter, dict):\n            try:\n                failed = sum(\n                    int(v)\n                    for k, v in status_counter.items()\n                    if str(k).strip().lower() in {\"failed\", \"error\", \"errors\", \"timeout\"}\n                )\n            except Exception:\n                failed = 0\n        return \"success\" if failed == 0 else \"partial\"\n\n    if status in {\"partial\", \"failed\"}:\n        return status\n\n    return \"partial\"\n\n\ndef build_summary(\n    *,\n    status: str,\n    input_dir: Path,\n    output_xlsx: Path,\n    params: argparse.Namespace,\n    discovery: DiscoveryResult,\n    delegate_path: Path,\n    delegated: bool,\n    delegate_report: Optional[Dict[str, Any]],\n    delegate_exit_code: Optional[int],\n    stdout_text: str,\n    stderr_text: str,\n    extra_notes: Optional[List[str]] = None,\n) -> Dict[str, Any]:\n    return {\n        \"status\": status,\n        \"request\": {\n            \"origin_id\": params.origin_id,\n            \"title\": params.title,\n            \"description\": params.description,\n            \"labels\": params.labels,\n            \"ocr\": params.ocr,\n            \"dry_run\": params.dry_run,\n            \"input_dir\": str(input_dir),\n            \"output_xlsx\": str(output_xlsx),\n        },\n        \"traceability\": {\n            \"wrapper_script\": str(Path(__file__).resolve()),\n            \"delegate_script\": str(delegate_path),\n        },\n        \"discovery\": {\n            \"input_dir\": str(input_dir),\n            \"total_pdfs\": discovery.total_pdfs,\n            \"sample_files\": [str(p) for p in discovery.files[:10]],\n            \"recursive\": True,\n        },\n        \"execution\": {\n            \"delegated\": delegated,\n            \"delegate_exit_code\": delegate_exit_code,\n            \"timeout_seconds\": params.delegate_timeout,\n            \"output_exists\": output_xlsx.exists(),\n            \"output_size\": output_xlsx.stat().st_size if output_xlsx.exists() else 0,\n        },\n        \"delegate_report\": delegate_report,\n        \"logs\": {\n            \"stdout_tail\": stdout_text[-4000:],\n            \"stderr_tail\": stderr_text[-4000:],\n        },\n        \"notes\": extra_notes or [],\n    }\n\n\ndef parse_args() -> argparse.Namespace:\n    parser = argparse.ArgumentParser(description=\"Reviewable inbox runner for PDF-to-Excel OCR delegate\")\n    parser.add_argument(\"--input-dir\", required=True, help=\"Directory containing PDF files\")\n    parser.add_argument(\"--output-xlsx\", required=True, help=\"Target XLSX output path\")\n    parser.add_argument(\"--ocr\", default=\"auto\", help=\"OCR mode to pass through when supported\")\n    parser.add_argument(\"--dry-run\", action=\"store_true\", help=\"Reviewable dry-run; returns partial\")\n    parser.add_argument(\"--origin-id\", default=\"\", help=\"Source origin id for traceability\")\n    parser.add_argument(\"--title\", default=\"\", help=\"Request title\")\n    parser.add_argument(\"--description\", default=\"\", help=\"Request description\")\n    parser.add_argument(\"--labels\", nargs=\"*\", default=[], help=\"Traceability labels\")\n    parser.add_argument(\n        \"--preferred-base-script\",\n        default=DEFAULT_DELEGATE_REL,\n        help=\"Preferred reviewed delegate script path\",\n    )\n    parser.add_argument(\n        \"--delegate-timeout\",\n        type=int,\n        default=DEFAULT_TIMEOUT_SECONDS,\n        help=\"Explicit subprocess timeout in seconds\",\n    )\n    parser.add_argument(\n        \"--summary-json\",\n        default=\"\",\n        help=\"Optional path to write wrapper structured summary JSON\",\n    )\n    return parser.parse_args()\n\n\ndef main() -> int:\n    args = parse_args()\n\n    input_dir = expand_path(args.input_dir)\n    output_xlsx = expand_path(args.output_xlsx)\n    delegate_path = resolve_repo_relative(args.preferred_base_script)\n\n    notes: List[str] = []\n\n    if output_xlsx.suffix.lower() != \".xlsx\":\n        notes.append(\"Requested output path is not .xlsx; wrapper expects real XLSX target semantics.\")\n\n    if not input_dir.exists() or not input_dir.is_dir():\n        summary = build_summary(\n            status=\"failed\",\n            input_dir=input_dir,\n            output_xlsx=output_xlsx,\n            params=args,\n            discovery=DiscoveryResult(total_pdfs=0, files=[]),\n            delegate_path=delegate_path,\n            delegated=False,\n            delegate_report=None,\n            delegate_exit_code=None,\n            stdout_text=\"\",\n            stderr_text=\"Input directory does not exist or is not a directory.\",\n            extra_notes=notes + [\"Input directory validation failed.\"],\n        )\n        payload = json.dumps(summary, ensure_ascii=False, indent=2)\n        if args.summary_json:\n            summary_path = expand_path(args.summary_json)\n            summary_path.parent.mkdir(parents=True, exist_ok=True)\n            summary_path.write_text(payload, encoding=\"utf-8\")\n        print(payload)\n        return 2\n\n    discovery = discover_pdfs(input_dir)\n\n    if args.dry_run:\n        summary = build_summary(\n            status=\"partial\",\n            input_dir=input_dir,\n            output_xlsx=output_xlsx,\n            params=args,\n            discovery=discovery,\n            delegate_path=delegate_path,\n            delegated=False,\n            delegate_report=None,\n            delegate_exit_code=None,\n            stdout_text=\"\",\n            stderr_text=\"\",\n            extra_notes=notes + [\"Dry-run short-circuit: delegate not executed.\"],\n        )\n        payload = json.dumps(summary, ensure_ascii=False, indent=2)\n        if args.summary_json:\n            summary_path = expand_path(args.summary_json)\n            summary_path.parent.mkdir(parents=True, exist_ok=True)\n            summary_path.write_text(payload, encoding=\"utf-8\")\n        print(payload)\n        return 0\n\n    if discovery.total_pdfs == 0:\n        summary = build_summary(\n            status=\"partial\",\n            input_dir=input_dir,\n            output_xlsx=output_xlsx,\n            params=args,\n            discovery=discovery,\n            delegate_path=delegate_path,\n            delegated=False,\n            delegate_report=None,\n            delegate_exit_code=None,\n            stdout_text=\"\",\n            stderr_text=\"\",\n            extra_notes=notes + [\"No PDF files discovered; nothing delegated.\"],\n        )\n        payload = json.dumps(summary, ensure_ascii=False, indent=2)\n        if args.summary_json:\n            summary_path = expand_path(args.summary_json)\n            summary_path.parent.mkdir(parents=True, exist_ok=True)\n            summary_path.write_text(payload, encoding=\"utf-8\")\n        print(payload)\n        return 0\n\n    if not delegate_path.is_file():\n        summary = build_summary(\n            status=\"failed\",\n            input_dir=input_dir,\n            output_xlsx=output_xlsx,\n            params=args,\n            discovery=discovery,\n            delegate_path=delegate_path,\n            delegated=False,\n            delegate_report=None,\n            delegate_exit_code=None,\n            stdout_text=\"\",\n            stderr_text=\"Reviewed delegate script not found.\",\n            extra_notes=notes + [\"Readonly reviewable flow only delegates to reviewed repository script.\"],\n        )\n        payload = json.dumps(summary, ensure_ascii=False, indent=2)\n        if args.summary_json:\n            summary_path = expand_path(args.summary_json)\n            summary_path.parent.mkdir(parents=True, exist_ok=True)\n            summary_path.write_text(payload, encoding=\"utf-8\")\n        print(payload)\n        return 2\n\n    output_xlsx.parent.mkdir(parents=True, exist_ok=True)\n\n    with tempfile.TemporaryDirectory(prefix=\"pdf_to_excel_runner_\") as tmpdir:\n        report_path = Path(tmpdir) / \"delegate_report.json\"\n        cmd = [\n            sys.executable,\n            str(delegate_path),\n            \"--input-dir\",\n            str(input_dir),\n            \"--output-xlsx\",\n            str(output_xlsx),\n            \"--ocr\",\n            str(args.ocr),\n            \"--report-json\",\n            str(report_path),\n        ]\n        if args.dry_run:\n            cmd.append(\"--dry-run\")\n\n        try:\n            proc = subprocess.run(\n                cmd,\n                capture_output=True,\n                text=True,\n                timeout=args.delegate_timeout,\n                cwd=str(REPO_ROOT),\n                check=False,\n            )\n            stdout_text = proc.stdout or \"\"\n            stderr_text = proc.stderr or \"\"\n            delegate_report = extract_json_object_from_text(stdout_text) or load_json_file(report_path)\n            final_status = \"failed\"\n            if delegate_report is not None:\n                final_status = evidence_status_from_delegate(delegate_report)\n            elif proc.returncode == 0:\n                notes.append(\"Delegate exited zero but did not provide canonical JSON evidence; wrapper does not upgrade to success.\")\n                final_status = \"partial\" if output_xlsx.exists() else \"failed\"\n\n            summary = build_summary(\n                status=final_status,\n                input_dir=input_dir,\n                output_xlsx=output_xlsx,\n                params=args,\n                discovery=discovery,\n                delegate_path=delegate_path,\n                delegated=True,\n                delegate_report=delegate_report,\n                delegate_exit_code=proc.returncode,\n                stdout_text=stdout_text,\n                stderr_text=stderr_text,\n                extra_notes=notes,\n            )\n            payload = json.dumps(summary, ensure_ascii=False, indent=2)\n            if args.summary_json:\n                summary_path = expand_path(args.summary_json)\n                summary_path.parent.mkdir(parents=True, exist_ok=True)\n                summary_path.write_text(payload, encoding=\"utf-8\")\n            print(payload)\n            return 0 if final_status in {\"success\", \"partial\"} else 2\n\n        except subprocess.TimeoutExpired as exc:\n            stdout_text = exc.stdout or \"\"\n            stderr_text = exc.stderr or \"\"\n            summary = build_summary(\n                status=\"failed\",\n                input_dir=input_dir,\n                output_xlsx=output_xlsx,\n                params=args,\n                discovery=discovery,\n                delegate_path=delegate_path,\n                delegated=True,\n                delegate_report=None,\n                delegate_exit_code=None,\n                stdout_text=stdout_text if isinstance(stdout_text, str) else \"\",\n                stderr_text=(stderr_text if isinstance(stderr_text, str) else \"\") + \"\\nDelegate timed out.\",\n                extra_notes=notes + [\"Delegate subprocess timed out before producing reviewable completion evidence.\"],\n            )\n            payload = json.dumps(summary, ensure_ascii=False, indent=2)\n            if args.summary_json:\n                summary_path = expand_path(args.summary_json)\n                summary_path.parent.mkdir(parents=True, exist_ok=True)\n                summary_path.write_text(payload, encoding=\"utf-8\")\n            print(payload)\n            return 2\n\n\nif __name__ == \"__main__\":\n    raise SystemExit(main())\n",
+            "truncated": false
+          },
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+            "available": true,
+            "content": "#!/usr/bin/env python3\n\"\"\"\nBatch PDF -> Excel extractor with optional OCR fallback.\n\nDesign goals:\n- Batch processing with per-file isolation (single file failure must not stop the batch)\n- OCR mode: auto | on | off\n- Chinese-friendly OCR defaults (chi_sim+eng)\n- Dry-run support for pilot validation when dependencies are unavailable\n\"\"\"\n\nfrom __future__ import annotations\n\nimport argparse\nimport json\nimport shutil\nimport sys\nfrom dataclasses import asdict, dataclass\nfrom pathlib import Path\nfrom typing import Any\n\n\ntry:\n    from pypdf import PdfReader  # type: ignore\nexcept Exception:\n    PdfReader = None\n\ntry:\n    import pandas as pd  # type: ignore\nexcept Exception:\n    pd = None\n\ntry:\n    import pytesseract  # type: ignore\nexcept Exception:\n    pytesseract = None\n\ntry:\n    from pdf2image import convert_from_path  # type: ignore\nexcept Exception:\n    convert_from_path = None\n\n\n@dataclass\nclass FileResult:\n    file_name: str\n    file_path: str\n    status: str\n    extract_method: str\n    page_count: int\n    text_chars: int\n    text_preview: str\n    warnings: str\n    error: str\n\n\ndef parse_args() -> argparse.Namespace:\n    parser = argparse.ArgumentParser(description=\"Batch PDF to Excel extractor with OCR fallback.\")\n    parser.add_argument(\"--input-dir\", required=True, help=\"Directory containing PDF files.\")\n    parser.add_argument(\"--output-xlsx\", required=True, help=\"Output Excel path.\")\n    parser.add_argument(\n        \"--ocr\",\n        choices=(\"auto\", \"on\", \"off\"),\n        default=\"auto\",\n        help=\"OCR mode. auto=use OCR when plain text extraction is weak.\",\n    )\n    parser.add_argument(\n        \"--dry-run\",\n        action=\"store_true\",\n        help=\"Do not write Excel file. Print execution summary only.\",\n    )\n    parser.add_argument(\n        \"--ocr-lang\",\n        default=\"chi_sim+eng\",\n        help=\"OCR language pack for pytesseract, default supports Chinese + English.\",\n    )\n    parser.add_argument(\n        \"--auto-ocr-min-chars\",\n        type=int,\n        default=50,\n        help=\"In auto mode, run OCR when extracted text chars < this threshold.\",\n    )\n    parser.add_argument(\n        \"--report-json\",\n        default=\"\",\n        help=\"Optional sidecar path for writing the same JSON report emitted to stdout.\",\n    )\n    return parser.parse_args()\n\n\ndef discover_pdfs(input_dir: Path) -> list[Path]:\n    if not input_dir.exists():\n        raise FileNotFoundError(f\"Input directory does not exist: {input_dir}\")\n    if not input_dir.is_dir():\n        raise NotADirectoryError(f\"Input path is not a directory: {input_dir}\")\n    files = sorted([p for p in input_dir.rglob(\"*\") if p.is_file() and p.suffix.lower() == \".pdf\"])\n    return files\n\n\ndef detect_ocr_runtime_status() -> tuple[str, list[str]]:\n    missing: list[str] = []\n    present: list[str] = []\n\n    if pytesseract is None:\n        missing.append(\"python module pytesseract\")\n    else:\n        present.append(\"python module pytesseract\")\n    if convert_from_path is None:\n        missing.append(\"python module pdf2image\")\n    else:\n        present.append(\"python module pdf2image\")\n    if shutil.which(\"tesseract\") is None:\n        missing.append(\"binary tesseract\")\n    else:\n        present.append(\"binary tesseract\")\n    if shutil.which(\"pdftoppm\") is None:\n        missing.append(\"binary pdftoppm (poppler)\")\n    else:\n        present.append(\"binary pdftoppm (poppler)\")\n\n    if not missing:\n        return \"available\", []\n    if present:\n        return \"partial\", missing\n    return \"blocked\", missing\n\n\ndef extract_text_pypdf(pdf_path: Path) -> tuple[str, int]:\n    if PdfReader is None:\n        raise RuntimeError(\"pypdf not installed\")\n    reader = PdfReader(str(pdf_path))\n    page_texts: list[str] = []\n    for page in reader.pages:\n        text = page.extract_text() or \"\"\n        page_texts.append(text)\n    return \"\\n\".join(page_texts), len(reader.pages)\n\n\ndef extract_text_ocr(pdf_path: Path, ocr_lang: str) -> str:\n    if pytesseract is None:\n        raise RuntimeError(\"pytesseract not installed\")\n    if convert_from_path is None:\n        raise RuntimeError(\"pdf2image not installed\")\n    if shutil.which(\"tesseract\") is None:\n        raise RuntimeError(\"tesseract binary not found\")\n    if shutil.which(\"pdftoppm\") is None:\n        raise RuntimeError(\"pdftoppm binary not found (install poppler)\")\n\n    images = convert_from_path(str(pdf_path), dpi=220)\n    chunks: list[str] = []\n    for image in images:\n        chunks.append(pytesseract.image_to_string(image, lang=ocr_lang))\n    return \"\\n\".join(chunks)\n\n\ndef compact_preview(text: str, limit: int = 160) -> str:\n    single_line = \" \".join(text.split())\n    if len(single_line) <= limit:\n        return single_line\n    return single_line[: limit - 3] + \"...\"\n\n\ndef process_one_pdf(\n    pdf_path: Path,\n    ocr_mode: str,\n    ocr_lang: str,\n    auto_ocr_min_chars: int,\n) -> FileResult:\n    warnings: list[str] = []\n    errors: list[str] = []\n    method = \"none\"\n    text = \"\"\n    page_count = 0\n\n    try:\n        text, page_count = extract_text_pypdf(pdf_path)\n        method = \"text\"\n    except Exception as e:\n        warnings.append(f\"text extraction unavailable: {e}\")\n\n    needs_ocr = False\n    if ocr_mode == \"on\":\n        needs_ocr = True\n    elif ocr_mode == \"auto\" and len(text.strip()) < auto_ocr_min_chars:\n        needs_ocr = True\n\n    if needs_ocr:\n        try:\n            ocr_text = extract_text_ocr(pdf_path, ocr_lang).strip()\n            if ocr_text:\n                if text.strip():\n                    text = f\"{text.strip()}\\n\\n[OCR Fallback]\\n{ocr_text}\"\n                    method = \"text+ocr\"\n                else:\n                    text = ocr_text\n                    method = \"ocr\"\n            else:\n                warnings.append(\"OCR returned empty text\")\n        except Exception as e:\n            errors.append(f\"OCR failed: {e}\")\n\n    if not text.strip():\n        if errors:\n            status = \"failed\"\n        else:\n            status = \"partial\"\n            warnings.append(\"No extractable text captured\")\n    else:\n        status = \"success\"\n\n    return FileResult(\n        file_name=pdf_path.name,\n        file_path=str(pdf_path),\n        status=status,\n        extract_method=method,\n        page_count=page_count,\n        text_chars=len(text),\n        text_preview=compact_preview(text),\n        warnings=\" | \".join(warnings),\n        error=\" | \".join(errors),\n    )\n\n\ndef write_excel(results: list[FileResult], output_xlsx: Path) -> None:\n    if pd is None:\n        raise RuntimeError(\"pandas is required to write Excel output\")\n    output_xlsx.parent.mkdir(parents=True, exist_ok=True)\n\n    rows = [asdict(r) for r in results]\n    detail_df = pd.DataFrame(rows)\n\n    summary_rows: list[dict[str, Any]] = []\n    by_status = detail_df.groupby(\"status\").size().to_dict()\n    by_method = detail_df.groupby(\"extract_method\").size().to_dict()\n    for key, value in sorted(by_status.items()):\n        summary_rows.append({\"metric\": \"status_count\", \"name\": key, \"value\": int(value)})\n    for key, value in sorted(by_method.items()):\n        summary_rows.append({\"metric\": \"method_count\", \"name\": key, \"value\": int(value)})\n    summary_rows.append({\"metric\": \"total_files\", \"name\": \"all\", \"value\": int(len(results))})\n    summary_df = pd.DataFrame(summary_rows)\n\n    with pd.ExcelWriter(output_xlsx) as writer:\n        summary_df.to_excel(writer, sheet_name=\"summary\", index=False)\n        detail_df.to_excel(writer, sheet_name=\"files\", index=False)\n\n\ndef emit_report(report: dict[str, Any], report_json: str) -> None:\n    rendered = json.dumps(report, ensure_ascii=False, indent=2)\n    print(rendered)\n    if not report_json:\n        return\n    out_path = Path(report_json).expanduser().resolve()\n    out_path.parent.mkdir(parents=True, exist_ok=True)\n    out_path.write_text(rendered + \"\\n\", encoding=\"utf-8\")\n\n\ndef main() -> int:\n    args = parse_args()\n    input_dir = Path(args.input_dir).expanduser().resolve()\n    output_xlsx = Path(args.output_xlsx).expanduser().resolve()\n\n    try:\n        pdf_files = discover_pdfs(input_dir)\n    except Exception as e:\n        emit_report({\"status\": \"failed\", \"error\": str(e)}, args.report_json)\n        return 2\n\n    if not pdf_files:\n        emit_report(\n            {\n                \"status\": \"partial\",\n                \"input_dir\": str(input_dir),\n                \"output_xlsx\": str(output_xlsx),\n                \"ocr_mode\": args.ocr,\n                \"total_files\": 0,\n                \"status_counter\": {},\n                \"dry_run\": bool(args.dry_run),\n                \"excel_written\": False,\n                \"output_exists\": False,\n                \"output_size_bytes\": 0,\n                \"notes\": [f\"No PDF files found under {input_dir}\"],\n            },\n            args.report_json,\n        )\n        return 0\n\n    ocr_runtime, missing = detect_ocr_runtime_status()\n    results: list[FileResult] = []\n    for pdf in pdf_files:\n        try:\n            results.append(\n                process_one_pdf(\n                    pdf,\n                    ocr_mode=args.ocr,\n                    ocr_lang=args.ocr_lang,\n                    auto_ocr_min_chars=args.auto_ocr_min_chars,\n                )\n            )\n        except Exception as e:\n            results.append(\n                FileResult(\n                    file_name=pdf.name,\n                    file_path=str(pdf),\n                    status=\"failed\",\n                    extract_method=\"none\",\n                    page_count=0,\n                    text_chars=0,\n                    text_preview=\"\",\n                    warnings=\"\",\n                    error=f\"Unhandled processing exception: {e}\",\n                )\n            )\n\n    status_counter: dict[str, int] = {}\n    for item in results:\n        status_counter[item.status] = status_counter.get(item.status, 0) + 1\n\n    failed_count = status_counter.get(\"failed\", 0)\n    partial_count = status_counter.get(\"partial\", 0)\n    if failed_count == 0 and partial_count == 0:\n        aggregate_status = \"success\"\n    else:\n        aggregate_status = \"partial\"\n\n    report = {\n        \"status\": aggregate_status,\n        \"input_dir\": str(input_dir),\n        \"output_xlsx\": str(output_xlsx),\n        \"ocr_mode\": args.ocr,\n        \"ocr_runtime_status\": ocr_runtime,\n        \"ocr_missing_dependencies\": missing,\n        \"total_files\": len(results),\n        \"status_counter\": status_counter,\n        \"dry_run\": bool(args.dry_run),\n        \"excel_written\": False,\n        \"output_exists\": False,\n        \"output_size_bytes\": 0,\n    }\n\n    if args.dry_run:\n        emit_report(report, args.report_json)\n        return 0\n\n    try:\n        write_excel(results, output_xlsx)\n        report[\"output_exists\"] = output_xlsx.exists() and output_xlsx.is_file()\n        if report[\"output_exists\"]:\n            report[\"output_size_bytes\"] = int(output_xlsx.stat().st_size)\n        report[\"excel_written\"] = bool(report[\"output_exists\"] and report[\"output_size_bytes\"] > 0)\n        emit_report(report, args.report_json)\n        return 0\n    except Exception as e:\n        report[\"status\"] = \"failed\"\n        report[\"error\"] = str(e)\n        report[\"output_exists\"] = output_xlsx.exists() and output_xlsx.is_file()\n        if report[\"output_exists\"]:\n            report[\"output_size_bytes\"] = int(output_xlsx.stat().st_size)\n        report[\"excel_written\"] = bool(report[\"output_exists\"] and report[\"output_size_bytes\"] > 0)\n        emit_report(report, args.report_json)\n        return 3\n\n\nif __name__ == \"__main__\":\n    raise SystemExit(main())\n",
+            "truncated": false
+          }
+        ],
+        "review_contract": {
+          "required_status": [
+            "success",
+            "partial",
+            "failed"
+          ],
+          "required_verdict_values": [
+            "fail",
+            "needs_revision",
+            "pass"
+          ],
+          "required_metadata_key": "verdict",
+          "must_write_review_artifact_to": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "artifact_policy": "Always include either `file_contents` for the review artifact path or `artifacts` referencing that exact path.",
+          "fallback_policy": "If evidence is insufficient, return `status=partial`, include explicit `errors`, still generate review artifact content, and set verdict=needs_revision."
+        },
+        "review_template": {
+          "title": "Review: <artifact name>",
+          "sections": [
+            "Scope",
+            "Findings",
+            "Verdict",
+            "Rationale"
+          ],
+          "verdict_required": true
+        }
+      }
+    },
+    "expected_outputs": [
+      {
+        "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+        "type": "review"
+      }
+    ],
+    "constraints": [
+      "Review must be grounded in produced automation artifact",
+      "When both wrapper and reviewed delegate snapshots are supplied, evaluate them as one end-to-end readonly pair instead of ignoring the delegate evidence.",
+      "Do not invent missing artifact content",
+      "Return a clear verdict: pass, fail, or needs_revision",
+      "Include metadata.verdict in output",
+      "Generate review artifact markdown for expected_outputs[0].path",
+      "Use artifact_snapshots when provided; avoid claiming access problems if snapshot content exists.",
+      "When both the generated wrapper and reviewed delegate snapshots are provided, review them together rather than silently narrowing scope to one file.",
+      "Return metadata.verdict with one of: pass, fail, needs_revision.",
+      "Always generate review artifact content for expected_outputs[0].path.",
+      "If evidence is insufficient, use partial + errors + verdict=needs_revision, but still output review artifact."
+    ],
+    "priority": "medium",
+    "source": {
+      "kind": "local_inbox",
+      "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+      "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl039-001.json",
+      "received_at": "2026-03-25T04:54:19.933558Z",
+      "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "provider": "trello",
+      "mode": "readonly",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "regeneration_token": "regen-20260325-bl039-001"
+    },
+    "acceptance_criteria": [
+      "Produce a review artifact with explicit verdict (pass/fail/needs_revision)"
+    ],
+    "metadata": {
+      "integration_phase": "8B",
+      "pipeline": "inbox->adapter->manager->automation->critic",
+      "request_type": "pdf_to_excel_ocr",
+      "payload_hash": "055bd74afff89e46f2397c3f7a855c6dba4fc2cf7471cf3923f7aa8bb46d27ba",
+      "regeneration_token": "regen-20260325-bl039-001",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "external_metadata": {
+        "source_system": "trello",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "card_short_id": 7,
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "date_last_activity": "2026-03-24T08:35:56.234Z",
+        "readonly_mapped_at": "2026-03-25T04:54:11.471876Z",
+        "contract_profile": "best_effort_evidence_backed",
+        "ocr_claim_policy": "do_not_claim_success_without_evidence",
+        "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+        "regeneration_token": "regen-20260325-bl039-001"
+      }
+    }
+  },
+  "result": {
+    "task_id": "CRITIC-20260325-280",
+    "worker": "critic",
+    "status": "success",
+    "summary": "Reviewed the inbox runner and paired delegate together as an end-to-end readonly smoke path. The wrapper is generally well-structured, preserves readonly delegation, emits reviewable JSON summaries, and avoids overstating success without delegate evidence. The delegate supports batch PDF discovery, per-file isolation, OCR fallback, dry-run reporting, and structured JSON output. However, there is a material evidence-handling issue in the wrapper: when the delegate reports aggregate status=\"success\", the wrapper may still mark final_status=\"success\" without verifying that an Excel artifact was actually written or that delegate report fields such as excel_written/output_exists/output_size_bytes support the claim. This weakens the stated contract of stronger success evidence and could permit unsupported success classification if the delegate emits inconsistent JSON. Verdict: needs_revision.",
+    "artifacts": [
+      {
+        "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+        "type": "review"
+      }
+    ],
+    "timestamp": "2026-03-25T04:56:42.758607Z",
+    "duration_ms": 29215,
+    "notes": [
+      "Review was grounded on the supplied artifact snapshots for both scripts.",
+      "Scope was evaluated jointly for wrapper plus delegate, per instruction.",
+      "Primary concern is success-evidence validation rather than readonly or structural safety."
+    ],
+    "metadata": {
+      "task_id": "CRITIC-20260325-280",
+      "worker": "critic",
+      "verdict": "needs_revision"
+    }
+  }
+}

--- a/runtime_archives/bl039/runtime/automation-output.json
+++ b/runtime_archives/bl039/runtime/automation-output.json
@@ -1,0 +1,28 @@
+{
+  "task_id": "AUTO-20260325-860",
+  "worker": "automation",
+  "status": "success",
+  "summary": "Generated the requested single runnable helper script artifact as a reviewed-wrapper-style inbox runner that preserves parameter-driven behavior, resolves the reviewed delegate portably, enforces timeout-bounded delegation, parses delegate JSON from stdout and/or --report-json sidecar, keeps zero-input/dry-run outcomes reviewably partial, and avoids claiming success without strong delegate evidence.",
+  "artifacts": [
+    {
+      "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+      "type": "script"
+    }
+  ],
+  "timestamp": "2026-03-25T04:56:13.142928Z",
+  "duration_ms": 69802,
+  "notes": [
+    "The artifact is a single Python script only, per contract.",
+    "It is designed to wrap the reviewed delegate artifacts/scripts/pdf_to_excel_ocr.py rather than re-implement PDF extraction/conversion.",
+    "It preserves traceability context from the incoming request in its structured summary output.",
+    "It does not hardcode the provided input directory; input_dir and output_xlsx are runtime parameters.",
+    "It treats dry-run and zero-PDF discovery as partial outcomes and uses explicit delegate timeout handling."
+  ],
+  "metadata": {
+    "task_id": "AUTO-20260325-860",
+    "worker": "automation",
+    "created_files": [
+      "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py"
+    ]
+  }
+}

--- a/runtime_archives/bl039/runtime/automation-runtime.attempt-1.log
+++ b/runtime_archives/bl039/runtime/automation-runtime.attempt-1.log
@@ -1,0 +1,19 @@
+task_id: AUTO-20260325-860
+worker: automation
+attempt: 1
+container_name: argus-automation-auto-20260325-860
+worker_image: argus-worker:latest
+started_at: 2026-03-25T04:55:03.111259Z
+finished_at: 2026-03-25T04:56:13.301976Z
+exit_code: 0
+timed_out: False
+wait_error: 
+
+=== stdout ===
+[2026-03-25T04:55:03.342749Z] [automation] [INFO] Worker started using endpoint https://fast.vpsairobot.com/v1/chat/completions (timeout=120s, attempts=3)
+[2026-03-25T04:56:13.142300Z] [automation] [INFO] Artifact written: artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
+[2026-03-25T04:56:13.143414Z] [automation] [INFO] Task completed AUTO-20260325-860 with status success
+[2026-03-25T04:56:13.144314Z] [automation] [INFO] Worker exiting from /app/workspaces/automation/AUTO-20260325-860
+
+=== stderr ===
+

--- a/runtime_archives/bl039/runtime/critic-output.json
+++ b/runtime_archives/bl039/runtime/critic-output.json
@@ -1,0 +1,24 @@
+{
+  "task_id": "CRITIC-20260325-280",
+  "worker": "critic",
+  "status": "success",
+  "summary": "Reviewed the inbox runner and paired delegate together as an end-to-end readonly smoke path. The wrapper is generally well-structured, preserves readonly delegation, emits reviewable JSON summaries, and avoids overstating success without delegate evidence. The delegate supports batch PDF discovery, per-file isolation, OCR fallback, dry-run reporting, and structured JSON output. However, there is a material evidence-handling issue in the wrapper: when the delegate reports aggregate status=\"success\", the wrapper may still mark final_status=\"success\" without verifying that an Excel artifact was actually written or that delegate report fields such as excel_written/output_exists/output_size_bytes support the claim. This weakens the stated contract of stronger success evidence and could permit unsupported success classification if the delegate emits inconsistent JSON. Verdict: needs_revision.",
+  "artifacts": [
+    {
+      "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+      "type": "review"
+    }
+  ],
+  "timestamp": "2026-03-25T04:56:42.758607Z",
+  "duration_ms": 29215,
+  "notes": [
+    "Review was grounded on the supplied artifact snapshots for both scripts.",
+    "Scope was evaluated jointly for wrapper plus delegate, per instruction.",
+    "Primary concern is success-evidence validation rather than readonly or structural safety."
+  ],
+  "metadata": {
+    "task_id": "CRITIC-20260325-280",
+    "worker": "critic",
+    "verdict": "needs_revision"
+  }
+}

--- a/runtime_archives/bl039/runtime/critic-runtime.attempt-1.log
+++ b/runtime_archives/bl039/runtime/critic-runtime.attempt-1.log
@@ -1,0 +1,19 @@
+task_id: CRITIC-20260325-280
+worker: critic
+attempt: 1
+container_name: argus-critic-critic-20260325-280
+worker_image: argus-worker:latest
+started_at: 2026-03-25T04:56:13.337190Z
+finished_at: 2026-03-25T04:56:42.898012Z
+exit_code: 0
+timed_out: False
+wait_error: 
+
+=== stdout ===
+[2026-03-25T04:56:13.543599Z] [critic] [INFO] Worker started using endpoint https://fast.vpsairobot.com/v1/chat/completions (timeout=120s, attempts=3)
+[2026-03-25T04:56:42.758124Z] [critic] [INFO] Artifact written: artifacts/reviews/pdf_to_excel_ocr_inbox_review.md
+[2026-03-25T04:56:42.759032Z] [critic] [INFO] Task completed CRITIC-20260325-280 with status success
+[2026-03-25T04:56:42.759868Z] [critic] [INFO] Worker exiting from /app/workspaces/critic/CRITIC-20260325-280
+
+=== stderr ===
+

--- a/runtime_archives/bl039/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8.json
+++ b/runtime_archives/bl039/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8.json
@@ -1,0 +1,391 @@
+{
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8",
+  "created_at": "2026-03-25T04:54:19.934084Z",
+  "approved": true,
+  "source": {
+    "kind": "local_inbox",
+    "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+    "received_at": "2026-03-25T04:54:19.933558Z",
+    "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl039-001.json",
+    "regeneration_token": "regen-20260325-bl039-001"
+  },
+  "external_input": {
+    "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+    "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+    "labels": [
+      "best_effort",
+      "evidence_backed",
+      "readonly",
+      "reviewable",
+      "trello"
+    ],
+    "metadata": {
+      "source_system": "trello",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "card_short_id": 7,
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "date_last_activity": "2026-03-24T08:35:56.234Z",
+      "readonly_mapped_at": "2026-03-25T04:54:11.471876Z",
+      "contract_profile": "best_effort_evidence_backed",
+      "ocr_claim_policy": "do_not_claim_success_without_evidence",
+      "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+      "regeneration_token": "regen-20260325-bl039-001"
+    },
+    "request_type": "pdf_to_excel_ocr",
+    "input": {
+      "input_dir": "~/Desktop/pdf样本",
+      "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+      "ocr": "auto",
+      "dry_run": false
+    }
+  },
+  "task_summary": {
+    "automation": {
+      "task_id": "AUTO-20260325-860",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+      "expected_outputs": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ]
+    },
+    "critic": {
+      "task_id": "CRITIC-20260325-280",
+      "worker": "critic",
+      "task_type": "review_artifact",
+      "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+      "expected_outputs": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ]
+    }
+  },
+  "internal_tasks": {
+    "automation": {
+      "task_id": "AUTO-20260325-860",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+      "inputs": {
+        "params": {
+          "input_dir": "~/Desktop/pdf样本",
+          "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+          "ocr": "auto",
+          "dry_run": false,
+          "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+          "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+          "description": "Purpose: | Controlled Trello live preview smoke for openclaw-team. | Expected behavior: | - read-only Trello ingest | - preview creation smoke only | - no business execution claim | - no Trello writeback expected in this step | Traceability: | - backlog: BL-20260324-014 | - blocker context: BL-20260324-015 | - created_by: Oscarling | - created_at: 2026-03-24 Asia/Shanghai | Note: | This card is only for governed smoke verification and should remain open until the smoke is finished.",
+          "labels": [
+            "best_effort",
+            "evidence_backed",
+            "readonly",
+            "reviewable",
+            "trello"
+          ],
+          "preferred_wrapper_script": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "preferred_base_script": "artifacts/scripts/pdf_to_excel_ocr.py",
+          "reference_docs": [
+            "artifacts/docs/pdf_to_excel_ocr_usage.md",
+            "artifacts/reviews/pdf_to_excel_ocr_review.md"
+          ],
+          "contract_hints": {
+            "output_format_fidelity": "If output_xlsx ends with .xlsx, produce a real XLSX workbook container or fail honestly before writing mismatched text/XML/CSV content to a .xlsx path.",
+            "path_portability": "Use the provided input_dir parameter as runtime input. Do not hardcode a user-home or absolute input path when params already declare the path.",
+            "traceability": "Preserve meaningful description context from the external input; do not collapse it to a heading fragment such as Purpose:.",
+            "reuse_preference": "Prefer reusing artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py as the wrapper baseline and artifacts/scripts/pdf_to_excel_ocr.py as the reviewed delegate when compatible, so workbook semantics and contract behavior stay aligned with repository evidence.",
+            "outcome_status_model": "Use the reviewable status model success/partial/failed. Dry-run requests or zero-PDF discovery should resolve to partial rather than claiming success without an output artifact.",
+            "delegate_resolution": "If preferred_base_script is relative, resolve it from the repository or script location instead of Path.cwd() so behavior stays portable across shells and CI.",
+            "reviewed_delegate_contract": "For readonly reviewable preview flows, delegate only to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py or fail honestly instead of broadening behavior through an arbitrary helper.",
+            "delegate_success_evidence": "Do not treat zero exit code plus output-file existence as sufficient wrapper success evidence on their own. Prefer a structured delegate report that confirms a real success outcome with at least one processed input and no failed-file counterexamples before the wrapper claims success.",
+            "delegate_timeout": "Bound delegate subprocess execution with an explicit timeout and report timeout as an honest failed/partial outcome instead of allowing smoke automation to hang indefinitely.",
+            "runtime_summary": "The generated script should emit a structured summary of what it produced so later review can inspect behavior without guessing.",
+            "delegate_report_schema": "Treat delegate JSON report fields status/total_files/status_counter/dry_run as the canonical evidence contract. Do not require undeclared processed_files/succeeded_files/failed_files counters.",
+            "delegate_report_handoff": "When the delegate prints a JSON report to stdout, parse that JSON directly instead of relying only on sidecar-report file path discovery.",
+            "delegate_report_flag_contract": "If wrapper passes a sidecar report path to the reviewed delegate, use the reviewed delegate CLI flag --report-json (or another explicitly supported alias). Do not invent undeclared flags such as --report-file.",
+            "dry_run_semantics": "If wrapper dry-run short-circuits before delegate execution, keep execution.delegated=false and report partial honestly. If wrapper does delegate under dry-run, pass through --dry-run explicitly.",
+            "pdf_discovery_consistency": "Keep wrapper preflight PDF discovery semantics aligned with the reviewed delegate (for example recursive vs non-recursive), so wrapper evidence and delegated execution count the same candidate set."
+          }
+        }
+      },
+      "expected_outputs": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ],
+      "constraints": [
+        "Follow the local inbox normalized request",
+        "Do not claim unsupported runtime dependencies",
+        "Keep output deterministic and executable",
+        "Produce only the expected script artifact",
+        "Prefer honest, reviewable intermediate behavior over unsupported OCR claims",
+        "If the requested output path ends with .xlsx, do not write non-XLSX text/XML/CSV content to that path.",
+        "Do not hardcode an input directory when the task params already provide input_dir.",
+        "Preserve meaningful traceability from the incoming description instead of collapsing it to a heading fragment.",
+        "Prefer wrapping or adapting artifacts/scripts/pdf_to_excel_ocr.py when that existing repo script already matches the requested behavior.",
+        "When artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py already exists, prefer updating that reviewed wrapper baseline instead of rewriting a new control flow from scratch.",
+        "If dry_run is true or no PDFs are discovered, report a reviewable partial outcome instead of claiming success without an XLSX artifact.",
+        "Resolve relative delegate script paths from the repository or script location, not from Path.cwd().",
+        "For readonly reviewable preview flows, only delegate to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py unless failing honestly.",
+        "Do not claim wrapper success from exit code plus output existence alone when the reviewed delegate report does not provide strong enough success evidence.",
+        "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
+        "When delegate emits JSON to stdout, parse that report directly instead of depending only on sidecar report-file discovery.",
+        "When wrapper passes a sidecar report path to the reviewed delegate, use --report-json exactly unless the reviewed delegate explicitly supports another alias.",
+        "If wrapper supports dry-run short-circuit semantics, keep execution.delegated=false and preserve partial status honestly.",
+        "Keep wrapper PDF discovery semantics aligned with reviewed delegate discovery semantics to avoid preflight/execution evidence drift.",
+        "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely."
+      ],
+      "priority": "medium",
+      "source": {
+        "kind": "local_inbox",
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl039-001.json",
+        "received_at": "2026-03-25T04:54:19.933558Z",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "regeneration_token": "regen-20260325-bl039-001"
+      },
+      "acceptance_criteria": [
+        "Produce the expected script artifact at expected_outputs[0].path",
+        "Script behavior remains runnable, deterministic, and reviewable",
+        "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
+        "Artifact behavior remains parameter-driven for input_dir and output_xlsx rather than hardcoding unrelated local defaults.",
+        "Dry-run or zero-input behavior is represented as a reviewable partial outcome instead of artifact-production success.",
+        "Relative preferred_base_script resolution remains portable and does not depend on Path.cwd().",
+        "Wrapper success requires stronger delegate evidence than zero exit code plus a non-empty output file alone.",
+        "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
+        "Delegate report handoff can consume JSON printed to stdout without relying exclusively on report sidecar file discovery.",
+        "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",
+        "Dry-run semantics remain explicit: short-circuit stays partial with no delegated execution, or delegated dry-run is passed through honestly.",
+        "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
+        "Delegate execution is bounded by an explicit timeout and reports timeout honestly."
+      ],
+      "metadata": {
+        "integration_phase": "8B",
+        "pipeline": "inbox->adapter->manager->automation->critic",
+        "request_type": "pdf_to_excel_ocr",
+        "payload_hash": "055bd74afff89e46f2397c3f7a855c6dba4fc2cf7471cf3923f7aa8bb46d27ba",
+        "regeneration_token": "regen-20260325-bl039-001",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "external_metadata": {
+          "source_system": "trello",
+          "card_id": "69c24cd3c1a2359ddd7a1bf8",
+          "card_short_id": 7,
+          "board_id": "69be462743bfa0038ca10f7a",
+          "list_id": "69be462743bfa0038ca10f8f",
+          "date_last_activity": "2026-03-24T08:35:56.234Z",
+          "readonly_mapped_at": "2026-03-25T04:54:11.471876Z",
+          "contract_profile": "best_effort_evidence_backed",
+          "ocr_claim_policy": "do_not_claim_success_without_evidence",
+          "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+          "regeneration_token": "regen-20260325-bl039-001"
+        },
+        "automation_contract_profile": "narrow_script_artifact_with_repo_reuse_and_reviewable_runner_contract"
+      }
+    },
+    "critic": {
+      "task_id": "CRITIC-20260325-280",
+      "worker": "critic",
+      "task_type": "review_artifact",
+      "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+      "inputs": {
+        "artifacts": [
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "type": "script"
+          },
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+            "type": "script"
+          }
+        ],
+        "params": {
+          "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+          "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+          "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+          "labels": [
+            "best_effort",
+            "evidence_backed",
+            "readonly",
+            "reviewable",
+            "trello"
+          ],
+          "review_scope": {
+            "primary_artifact": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "paired_artifacts": [
+              "artifacts/scripts/pdf_to_excel_ocr.py"
+            ],
+            "goal": "Audit the wrapper and the reviewed delegate together so the review evidence can speak to the end-to-end readonly smoke path."
+          }
+        }
+      },
+      "expected_outputs": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ],
+      "constraints": [
+        "Review must be grounded in produced automation artifact",
+        "When both wrapper and reviewed delegate snapshots are supplied, evaluate them as one end-to-end readonly pair instead of ignoring the delegate evidence.",
+        "Do not invent missing artifact content",
+        "Return a clear verdict: pass, fail, or needs_revision",
+        "Include metadata.verdict in output",
+        "Generate review artifact markdown for expected_outputs[0].path"
+      ],
+      "priority": "medium",
+      "source": {
+        "kind": "local_inbox",
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl039-001.json",
+        "received_at": "2026-03-25T04:54:19.933558Z",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "regeneration_token": "regen-20260325-bl039-001"
+      },
+      "acceptance_criteria": [
+        "Produce a review artifact with explicit verdict (pass/fail/needs_revision)"
+      ],
+      "metadata": {
+        "integration_phase": "8B",
+        "pipeline": "inbox->adapter->manager->automation->critic",
+        "request_type": "pdf_to_excel_ocr",
+        "payload_hash": "055bd74afff89e46f2397c3f7a855c6dba4fc2cf7471cf3923f7aa8bb46d27ba",
+        "regeneration_token": "regen-20260325-bl039-001",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "external_metadata": {
+          "source_system": "trello",
+          "card_id": "69c24cd3c1a2359ddd7a1bf8",
+          "card_short_id": 7,
+          "board_id": "69be462743bfa0038ca10f7a",
+          "list_id": "69be462743bfa0038ca10f8f",
+          "date_last_activity": "2026-03-24T08:35:56.234Z",
+          "readonly_mapped_at": "2026-03-25T04:54:11.471876Z",
+          "contract_profile": "best_effort_evidence_backed",
+          "ocr_claim_policy": "do_not_claim_success_without_evidence",
+          "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+          "regeneration_token": "regen-20260325-bl039-001"
+        }
+      }
+    }
+  },
+  "expected_artifacts": [
+    "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+    "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py"
+  ],
+  "dedupe_keys": [
+    "origin_regeneration:trello:69c24cd3c1a2359ddd7a1bf8:regen-20260325-bl039-001",
+    "hash:055bd74afff89e46f2397c3f7a855c6dba4fc2cf7471cf3923f7aa8bb46d27ba"
+  ],
+  "risk_warnings": [],
+  "execution": {
+    "status": "rejected",
+    "executed": true,
+    "attempts": 2,
+    "executed_at": "2026-03-25T04:56:42.930280Z",
+    "decision_reason": "critic_verdict=needs_revision"
+  },
+  "approval": {
+    "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8.json",
+    "approved_by": "Oscarling",
+    "approved_at": "2026-03-25T04:54:25Z",
+    "note": "BL-20260325-039 governed validation execute only; no Git finalization; no Trello Done."
+  },
+  "last_execution": {
+    "decision": "rejected",
+    "decision_reason": "critic_verdict=needs_revision",
+    "automation_result": {
+      "task_id": "AUTO-20260325-860",
+      "worker": "automation",
+      "status": "success",
+      "summary": "Generated the requested single runnable helper script artifact as a reviewed-wrapper-style inbox runner that preserves parameter-driven behavior, resolves the reviewed delegate portably, enforces timeout-bounded delegation, parses delegate JSON from stdout and/or --report-json sidecar, keeps zero-input/dry-run outcomes reviewably partial, and avoids claiming success without strong delegate evidence.",
+      "artifacts": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ],
+      "timestamp": "2026-03-25T04:56:13.142928Z",
+      "duration_ms": 69802,
+      "notes": [
+        "The artifact is a single Python script only, per contract.",
+        "It is designed to wrap the reviewed delegate artifacts/scripts/pdf_to_excel_ocr.py rather than re-implement PDF extraction/conversion.",
+        "It preserves traceability context from the incoming request in its structured summary output.",
+        "It does not hardcode the provided input directory; input_dir and output_xlsx are runtime parameters.",
+        "It treats dry-run and zero-PDF discovery as partial outcomes and uses explicit delegate timeout handling."
+      ],
+      "metadata": {
+        "task_id": "AUTO-20260325-860",
+        "worker": "automation",
+        "created_files": [
+          "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py"
+        ]
+      }
+    },
+    "critic_result": {
+      "task_id": "CRITIC-20260325-280",
+      "worker": "critic",
+      "status": "success",
+      "summary": "Reviewed the inbox runner and paired delegate together as an end-to-end readonly smoke path. The wrapper is generally well-structured, preserves readonly delegation, emits reviewable JSON summaries, and avoids overstating success without delegate evidence. The delegate supports batch PDF discovery, per-file isolation, OCR fallback, dry-run reporting, and structured JSON output. However, there is a material evidence-handling issue in the wrapper: when the delegate reports aggregate status=\"success\", the wrapper may still mark final_status=\"success\" without verifying that an Excel artifact was actually written or that delegate report fields such as excel_written/output_exists/output_size_bytes support the claim. This weakens the stated contract of stronger success evidence and could permit unsupported success classification if the delegate emits inconsistent JSON. Verdict: needs_revision.",
+      "artifacts": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ],
+      "timestamp": "2026-03-25T04:56:42.758607Z",
+      "duration_ms": 29215,
+      "notes": [
+        "Review was grounded on the supplied artifact snapshots for both scripts.",
+        "Scope was evaluated jointly for wrapper plus delegate, per instruction.",
+        "Primary concern is success-evidence validation rather than readonly or structural safety."
+      ],
+      "metadata": {
+        "task_id": "CRITIC-20260325-280",
+        "worker": "critic",
+        "verdict": "needs_revision"
+      }
+    },
+    "critic_verdict": "needs_revision"
+  }
+}

--- a/runtime_archives/bl039/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8.result.json
+++ b/runtime_archives/bl039/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8.result.json
@@ -1,0 +1,9 @@
+{
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8",
+  "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8.json",
+  "executed_at": "2026-03-25T04:56:42.930885Z",
+  "status": "rejected",
+  "decision_reason": "critic_verdict=needs_revision",
+  "critic_verdict": "needs_revision",
+  "test_mode": "off"
+}

--- a/runtime_archives/bl039/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl039-001.json
+++ b/runtime_archives/bl039/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl039-001.json
@@ -1,0 +1,41 @@
+{
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "metadata": {
+    "source_system": "trello",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "card_short_id": 7,
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "date_last_activity": "2026-03-24T08:35:56.234Z",
+    "readonly_mapped_at": "2026-03-25T04:54:11.471876Z",
+    "contract_profile": "best_effort_evidence_backed",
+    "ocr_claim_policy": "do_not_claim_success_without_evidence",
+    "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+    "regeneration_token": "regen-20260325-bl039-001"
+  },
+  "source": {
+    "provider": "trello",
+    "mode": "readonly",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "regeneration_token": "regen-20260325-bl039-001"
+  },
+  "request_type": "pdf_to_excel_ocr",
+  "input": {
+    "input_dir": "~/Desktop/pdf样本",
+    "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+    "ocr": "auto",
+    "dry_run": false
+  },
+  "regeneration_token": "regen-20260325-bl039-001"
+}

--- a/runtime_archives/bl039/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl039-001.json.result.json
+++ b/runtime_archives/bl039/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl039-001.json.result.json
@@ -1,0 +1,23 @@
+{
+  "ingested_at": "2026-03-25T04:54:19.934436Z",
+  "status": "processed",
+  "decision": "preview_created_pending_approval",
+  "decision_reason": "preview_created; waiting_for_explicit_approval",
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "payload_hash": "055bd74afff89e46f2397c3f7a855c6dba4fc2cf7471cf3923f7aa8bb46d27ba",
+  "dedupe_keys": [
+    "origin_regeneration:trello:69c24cd3c1a2359ddd7a1bf8:regen-20260325-bl039-001",
+    "hash:055bd74afff89e46f2397c3f7a855c6dba4fc2cf7471cf3923f7aa8bb46d27ba"
+  ],
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8",
+  "preview_file": "/Users/lingguozhong/openclaw-team/preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8.json",
+  "regeneration_token": "regen-20260325-bl039-001"
+}

--- a/runtime_archives/bl039/tmp/bl039_execute_once_elevated.json
+++ b/runtime_archives/bl039/tmp/bl039_execute_once_elevated.json
@@ -1,0 +1,18 @@
+{
+  "status": "done",
+  "processed": 0,
+  "rejected": 1,
+  "skipped": 0,
+  "test_mode": "off",
+  "allow_replay": true,
+  "results": [
+    {
+      "status": "rejected",
+      "decision_reason": "critic_verdict=needs_revision",
+      "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8",
+      "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8.json",
+      "result_sidecar": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8.result.json",
+      "critic_verdict": "needs_revision"
+    }
+  ]
+}

--- a/runtime_archives/bl039/tmp/bl039_execute_once_sandbox.json
+++ b/runtime_archives/bl039/tmp/bl039_execute_once_sandbox.json
@@ -1,0 +1,18 @@
+{
+  "status": "done",
+  "processed": 0,
+  "rejected": 1,
+  "skipped": 0,
+  "test_mode": "off",
+  "allow_replay": false,
+  "results": [
+    {
+      "status": "rejected",
+      "decision_reason": "Failed to initialize docker client from environment. Ensure Docker access is available or pass docker_client explicitly.",
+      "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8",
+      "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8.json",
+      "result_sidecar": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8.result.json",
+      "critic_verdict": "needs_revision"
+    }
+  ]
+}

--- a/runtime_archives/bl039/tmp/bl039_ingest_once.json
+++ b/runtime_archives/bl039/tmp/bl039_ingest_once.json
@@ -1,0 +1,21 @@
+{
+  "status": "done",
+  "processed": 1,
+  "rejected": 0,
+  "duplicate_skipped": 0,
+  "preview_created": 1,
+  "inbox_claimed": 1,
+  "processing_recovered": 0,
+  "test_mode": "success",
+  "results": [
+    {
+      "status": "processed",
+      "decision": "preview_created_pending_approval",
+      "decision_reason": "preview_created; waiting_for_explicit_approval",
+      "file": "/Users/lingguozhong/openclaw-team/processed/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl039-001.json",
+      "result_sidecar": "/Users/lingguozhong/openclaw-team/processed/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl039-001.json.result.json",
+      "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8",
+      "preview_file": "/Users/lingguozhong/openclaw-team/preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-055bd74afff8.json"
+    }
+  ]
+}

--- a/runtime_archives/bl039/tmp/bl039_live_mapped_preview.json
+++ b/runtime_archives/bl039/tmp/bl039_live_mapped_preview.json
@@ -1,0 +1,38 @@
+{
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "metadata": {
+    "source_system": "trello",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "card_short_id": 7,
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "date_last_activity": "2026-03-24T08:35:56.234Z",
+    "readonly_mapped_at": "2026-03-25T04:54:11.471876Z",
+    "contract_profile": "best_effort_evidence_backed",
+    "ocr_claim_policy": "do_not_claim_success_without_evidence",
+    "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable"
+  },
+  "source": {
+    "provider": "trello",
+    "mode": "readonly",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f"
+  },
+  "request_type": "pdf_to_excel_ocr",
+  "input": {
+    "input_dir": "~/Desktop/pdf样本",
+    "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+    "ocr": "auto",
+    "dry_run": false
+  }
+}

--- a/runtime_archives/bl039/tmp/bl039_smoke_result.json
+++ b/runtime_archives/bl039/tmp/bl039_smoke_result.json
@@ -1,0 +1,90 @@
+{
+  "status": "done",
+  "fixture": "/Users/lingguozhong/openclaw-team/adapters/samples/trello_card_fixture.json",
+  "mapped_output": "/private/tmp/bl039_mapped.json",
+  "required_env": {
+    "credentials": [
+      "TRELLO_API_KEY",
+      "TRELLO_API_TOKEN"
+    ],
+    "credentials_aliases": [
+      "TRELLO_KEY",
+      "TRELLO_TOKEN"
+    ],
+    "credentials_priority": [
+      "TRELLO_API_KEY/TRELLO_API_TOKEN",
+      "TRELLO_KEY/TRELLO_TOKEN"
+    ],
+    "scope": [
+      "TRELLO_BOARD_ID",
+      "TRELLO_LIST_ID"
+    ],
+    "scope_rule": [
+      "TRELLO_BOARD_ID or TRELLO_LIST_ID (either one)"
+    ]
+  },
+  "smoke_read": {
+    "status": "pass",
+    "read_count": 1,
+    "scope": {
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": null
+    },
+    "scope_kind": "board",
+    "mapped_preview": {
+      "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+      "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+      "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "metadata": {
+        "source_system": "trello",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "card_short_id": 7,
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "date_last_activity": "2026-03-24T08:35:56.234Z",
+        "readonly_mapped_at": "2026-03-25T04:54:11.471876Z",
+        "contract_profile": "best_effort_evidence_backed",
+        "ocr_claim_policy": "do_not_claim_success_without_evidence",
+        "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable"
+      },
+      "source": {
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f"
+      },
+      "request_type": "pdf_to_excel_ocr",
+      "input": {
+        "input_dir": "~/Desktop/pdf样本",
+        "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+        "ocr": "auto",
+        "dry_run": false
+      }
+    },
+    "auth_env": {
+      "selected_names": {
+        "key": "TRELLO_API_KEY",
+        "token": "TRELLO_API_TOKEN"
+      },
+      "priority": "TRELLO_API_* first, fallback to TRELLO_*",
+      "presence": {
+        "TRELLO_API_KEY": "set",
+        "TRELLO_KEY": "set",
+        "TRELLO_API_TOKEN": "set",
+        "TRELLO_TOKEN": "set",
+        "TRELLO_BOARD_ID": "set",
+        "TRELLO_LIST_ID": "missing"
+      }
+    },
+    "note": "Read-only GET only. No write operations performed."
+  },
+  "mode": "trello_readonly_prep"
+}


### PR DESCRIPTION
## Summary\n- activate and complete BL-20260325-039 governed validation against a fresh same-origin candidate\n- capture sandbox blocker and elevated replay evidence for smoke and execute\n- document runtime outcome in POST_AUTOMATION_SSL_RELIABILITY_VALIDATION_REPORT.md\n- archive full runtime evidence under runtime_archives/bl039\n- mark BL-039 done with evidence and add BL-20260325-040 as next blocker\n\n## Validation\n- python3 scripts/backlog_lint.py\n- python3 scripts/backlog_sync.py\n- bash scripts/premerge_check.sh\n- git diff --check\n\nCloses #71