### PR TITLE
docs: close BL-041 governed validation and archive runtime evidence

### DIFF
--- a/POST_WRAPPER_SUCCESS_EVIDENCE_VALIDATION_REPORT.md
+++ b/POST_WRAPPER_SUCCESS_EVIDENCE_VALIDATION_REPORT.md
@@ -1,0 +1,177 @@
+# Post-Wrapper Success-Evidence Validation Report
+
+## Objective
+
+Validate `BL-20260325-040` on one fresh same-origin governed candidate by
+running:
+
+- one live Trello read-only smoke
+- one explicit same-origin regeneration
+- one preview creation
+- one explicit approval
+- one real execute (`test_mode=off`)
+
+This phase objective is validation truth, not forcing a `pass` verdict.
+
+## Scope
+
+In scope:
+
+- one governed run against origin `trello:69c24cd3c1a2359ddd7a1bf8`
+- one regeneration token and one fresh preview candidate
+- runtime evidence capture for automation and critic outcomes
+- explicit recording of whether `BL-20260325-040` clears wrapper
+  success-evidence blocker findings under real execute
+
+Out of scope:
+
+- source-code hardening inside this validation phase
+- git finalization and Trello Done writeback
+- additional live reruns beyond this one governed candidate
+
+## Pre-Run Checks
+
+- branch: `phase9c/validate-bl041-wrapper-success-evidence`
+- Trello env loaded from `/tmp/trello_env.sh`:
+  - `TRELLO_API_KEY` set
+  - `TRELLO_API_TOKEN` set
+  - `TRELLO_BOARD_ID` set
+- OpenAI runtime values available from:
+  - `secrets/openai_api_key.txt`
+  - `secrets/openai_api_base.txt`
+  - `secrets/openai_model_name.txt`
+- governed execute requires Docker worker access:
+  - first sandboxed execute attempt is captured as environment evidence
+  - elevated replay is used to complete governed runtime validation intent
+
+## Run Summary
+
+Target origin:
+
+- `trello:69c24cd3c1a2359ddd7a1bf8`
+
+Regeneration token:
+
+- `regen-20260325-bl041-001`
+
+### 1) Live Trello read-only smoke
+
+First sandboxed read:
+
+- blocked by DNS / sandbox network policy
+- error: `ConnectionError` / `NameResolutionError`
+
+Elevated rerun:
+
+- `status = pass`
+- `read_count = 1`
+- archive snapshots:
+  - `runtime_archives/bl041/tmp/bl041_smoke_result.json`
+  - `runtime_archives/bl041/tmp/bl041_live_mapped_preview.json`
+
+### 2) Regenerated payload and preview ingest
+
+- generated inbox payload from elevated `smoke_read.mapped_preview` with token
+  `regen-20260325-bl041-001`
+- ingest result sidecar:
+  - `processed/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl041-001.json.result.json`
+- ingest decision:
+  - `status = processed`
+  - `decision = preview_created_pending_approval`
+  - `preview_id = preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7`
+
+### 3) Preview candidate
+
+Generated preview:
+
+- `preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7`
+- preview file:
+  - `preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7.json`
+
+Pre-execute state:
+
+- `approved = false`
+- `execution.status = pending_approval`
+- `execution.attempts = 0`
+- `source.regeneration_token = regen-20260325-bl041-001`
+
+### 4) Explicit approval
+
+- approval file:
+  - `approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7.json`
+
+### 5) Real execute (`test_mode=off`)
+
+First sandboxed execute:
+
+- rejected before worker dispatch
+- reason:
+  `Failed to initialize docker client from environment. Ensure Docker access is available or pass docker_client explicitly.`
+- archive snapshot:
+  - `runtime_archives/bl041/tmp/bl041_execute_once_sandbox.json`
+
+Elevated replay execute (`--allow-replay`):
+
+- final result sidecar:
+  - `approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7.result.json`
+- `status = rejected`
+- decision reason includes automation terminal failure:
+  - `AUTO-20260325-861`
+  - `class=http_403`
+  - endpoint `https://fast.vpsairobot.com/v1/chat/completions`
+
+Worker outcomes:
+
+- automation:
+  - task `AUTO-20260325-861`
+  - `status = failed`
+  - no generated script artifacts were produced
+- critic:
+  - task not dispatched (`tasks/CRITIC-20260325-281.json` absent)
+
+Final preview execution state:
+
+- `approved = true`
+- `execution.status = rejected`
+- `execution.executed = true`
+- `execution.attempts = 2`
+
+## Critical Findings
+
+This validation did not reach wrapper-review evaluation.
+
+- `BL-20260325-040` source-side contract hardening propagated into the fresh
+  preview candidate inputs/constraints.
+- real execute replay failed earlier at automation endpoint authorization
+  (`HTTP 403: Forbidden`), so no new runner artifact was generated and critic
+  review was never dispatched.
+
+Inference from this run:
+
+- the runtime question for `BL-20260325-040` remains unclosed in live evidence
+  because execution terminated before wrapper/critic evaluation.
+- the active blocker has shifted to automation endpoint authorization/runtime
+  access (`http_403`) under governed real execute.
+
+## Validation Conclusion
+
+`BL-20260325-041` is complete as a governed validation phase.
+
+It answers the intended question truthfully: this run could not yet validate
+whether BL-040 clears wrapper success-evidence review findings, because runtime
+failed earlier with automation `HTTP 403` and never reached critic artifact
+review.
+
+Next required phase: harden or repair automation endpoint authorization/runtime
+access so a fresh governed run can reach automation artifact generation and
+critic review again.
+
+## Archive Preservation
+
+To preserve runtime evidence and avoid loss from tracked artifact overwrite, this
+phase archived outputs under:
+
+- `runtime_archives/bl041/artifacts/`
+- `runtime_archives/bl041/runtime/`
+- `runtime_archives/bl041/state/`
+- `runtime_archives/bl041/tmp/`

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -741,8 +741,8 @@ Allowed enum values:
 ### BL-20260325-041
 - title: Validate BL-20260325-040 wrapper success-evidence contract hardening on a fresh same-origin governed candidate
 - type: mainline
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-040
@@ -750,7 +750,24 @@ Allowed enum values:
 - done_when: One governed validation creates a fresh same-origin preview candidate after BL-20260325-040, runs one explicit approval plus one real execute, and records whether runtime critic outcome now clears wrapper success-evidence semantics findings from BL-20260325-039
 - source: `WRAPPER_SUCCESS_EVIDENCE_CONTRACT_HARDENING_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation rather than assuming contract hardening success without live evidence
 - link: /Users/lingguozhong/openclaw-team/POST_WRAPPER_SUCCESS_EVIDENCE_VALIDATION_REPORT.md
-- issue: deferred:phase=next until BL-20260325-040 lands on main
+- issue: https://github.com/Oscarling/openclaw-team/issues/75
+- evidence: `POST_WRAPPER_SUCCESS_EVIDENCE_VALIDATION_REPORT.md` records one fresh same-origin governed run (`regen-20260325-bl041-001`) to preview `preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7` with explicit approval and one elevated real execute replay; runtime remained blocked by automation endpoint authorization failure (`AUTO-20260325-861`, class `http_403`, `HTTP 403: Forbidden`) before critic dispatch, so BL-20260325-040 runtime effect remained unverified
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-042
+- title: Harden automation endpoint authorization/runtime access after BL-20260325-041 HTTP 403 blocker
+- type: blocker
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-041
+- start_when: `BL-20260325-041` has completed and confirmed governed replay is blocked by automation endpoint authorization failure (`HTTP 403: Forbidden`) before artifact generation and critic dispatch
+- done_when: Automation LLM path handles or avoids endpoint authorization/runtime-access blockers (credential/endpoint policy hardening with explicit diagnostics and deterministic behavior), focused tests cover the new behavior, and one blocker report records the implemented mitigation
+- source: `POST_WRAPPER_SUCCESS_EVIDENCE_VALIDATION_REPORT.md` on 2026-03-25 records automation failure class `http_403` at `https://fast.vpsairobot.com/v1/chat/completions` as the active blocker that prevented runtime validation closure of BL-20260325-040
+- link: /Users/lingguozhong/openclaw-team/AUTOMATION_ENDPOINT_HTTP403_HARDENING_REPORT.md
+- issue: deferred:phase=next until BL-20260325-041 lands on main
 - evidence: -
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -1682,6 +1682,72 @@ Verification snapshot on 2026-03-25:
 - `python3 scripts/backlog_sync.py` passed with `BL-20260325-040` mirrored to
   issue `#73`
 
+### 49. Fresh Governed Validation After BL-040 Wrapper Success-Evidence Hardening
+
+User objective:
+
+- continue from `BL-20260325-040` with one fresh same-origin governed runtime
+  validation
+- verify whether wrapper success-evidence contract hardening can clear the
+  latest blocker cluster under real execute
+- preserve runtime evidence and keep workflow-gated delivery
+
+Main work areas:
+
+- activated `BL-20260325-041` and mirrored it to GitHub issue `#75`
+- ran live Trello read-only smoke for origin
+  `trello:69c24cd3c1a2359ddd7a1bf8`
+  - first sandboxed call blocked by DNS policy
+  - elevated rerun passed with `read_count=1`
+- generated one regeneration token:
+  - `regen-20260325-bl041-001`
+- created inbox payload from `smoke_read.mapped_preview`, ingested once, and
+  created fresh preview:
+  - `preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7`
+- wrote explicit approval and ran real execute in `test_mode=off`
+  - first sandboxed execute blocked before dispatch due Docker client access
+  - elevated replay (`--allow-replay`) reached automation dispatch but failed
+    with endpoint authorization `HTTP 403: Forbidden` (`class=http_403`)
+- archived runtime outputs under `runtime_archives/bl041/` before restoring
+  tracked baseline state
+- recorded next blocker phase as `BL-20260325-042`
+
+Primary output:
+
+- [POST_WRAPPER_SUCCESS_EVIDENCE_VALIDATION_REPORT.md](/Users/lingguozhong/openclaw-team/POST_WRAPPER_SUCCESS_EVIDENCE_VALIDATION_REPORT.md)
+
+Key result:
+
+- `BL-20260325-041` completed as a governed validation phase
+- `BL-20260325-040` runtime effect remained unverified in this run because
+  automation failed before artifact generation and critic review:
+  - automation task `AUTO-20260325-861`: `failed`
+  - failure class: `http_403`
+  - endpoint: `https://fast.vpsairobot.com/v1/chat/completions`
+  - critic task `CRITIC-20260325-281`: not dispatched
+- dominant blocker shifted to automation endpoint authorization/runtime access,
+  tracked as `BL-20260325-042`
+
+Verification snapshot on 2026-03-25:
+
+- smoke (elevated) returned `status=pass` with `read_count=1`
+- `python3 skills/ingest_tasks.py --once` returned:
+  - `processed = 1`
+  - `preview_created = 1`
+- sandboxed execute returned Docker-client initialization rejection
+- elevated replay execute returned:
+  - `status = rejected`
+  - decision reason includes:
+    `AUTO-20260325-861`, `class=http_403`, `HTTP 403: Forbidden`
+- worker outcomes:
+  - automation `AUTO-20260325-861`: `failed`
+  - critic `CRITIC-20260325-281`: not dispatched
+- runtime archive preserved under:
+  - `runtime_archives/bl041/artifacts/`
+  - `runtime_archives/bl041/runtime/`
+  - `runtime_archives/bl041/state/`
+  - `runtime_archives/bl041/tmp/`
+
 ### 31. Post-Timeout Governed Validation On Fresh Same-Origin Candidate
 
 User objective:

--- a/runtime_archives/bl041/runtime/AUTO-20260325-861.json
+++ b/runtime_archives/bl041/runtime/AUTO-20260325-861.json
@@ -1,0 +1,180 @@
+{
+  "task_id": "AUTO-20260325-861",
+  "worker": "automation",
+  "status": "failed",
+  "created_at": "2026-03-25T05:54:39.382041Z",
+  "updated_at": "2026-03-25T05:54:41.244231Z",
+  "retries": 0,
+  "max_retries": 0,
+  "attempts": [
+    {
+      "attempt": 1,
+      "status": "failed",
+      "retryable": false,
+      "error": "LLM call exhausted (attempts=1/3, class=http_403, endpoint=https://fast.vpsairobot.com/v1/chat/completions, retryable=False): HTTP Error 403: Forbidden",
+      "runtime_log": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-861/runtime.attempt-1.log",
+      "exit_code": 0,
+      "timed_out": false,
+      "wait_error": null,
+      "output_path": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-861/output.json",
+      "started_at": "2026-03-25T05:54:39.384026Z",
+      "finished_at": "2026-03-25T05:54:41.212675Z"
+    }
+  ],
+  "task_dir": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-861",
+  "payload": {
+    "task_id": "AUTO-20260325-861",
+    "worker": "automation",
+    "task_type": "generate_script",
+    "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+    "inputs": {
+      "params": {
+        "input_dir": "~/Desktop/pdf样本",
+        "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+        "ocr": "auto",
+        "dry_run": false,
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "description": "Purpose: | Controlled Trello live preview smoke for openclaw-team. | Expected behavior: | - read-only Trello ingest | - preview creation smoke only | - no business execution claim | - no Trello writeback expected in this step | Traceability: | - backlog: BL-20260324-014 | - blocker context: BL-20260324-015 | - created_by: Oscarling | - created_at: 2026-03-24 Asia/Shanghai | Note: | This card is only for governed smoke verification and should remain open until the smoke is finished.",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "preferred_wrapper_script": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "preferred_base_script": "artifacts/scripts/pdf_to_excel_ocr.py",
+        "reference_docs": [
+          "artifacts/docs/pdf_to_excel_ocr_usage.md",
+          "artifacts/reviews/pdf_to_excel_ocr_review.md"
+        ],
+        "contract_hints": {
+          "output_format_fidelity": "If output_xlsx ends with .xlsx, produce a real XLSX workbook container or fail honestly before writing mismatched text/XML/CSV content to a .xlsx path.",
+          "path_portability": "Use the provided input_dir parameter as runtime input. Do not hardcode a user-home or absolute input path when params already declare the path.",
+          "traceability": "Preserve meaningful description context from the external input; do not collapse it to a heading fragment such as Purpose:.",
+          "reuse_preference": "Prefer reusing artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py as the wrapper baseline and artifacts/scripts/pdf_to_excel_ocr.py as the reviewed delegate when compatible, so workbook semantics and contract behavior stay aligned with repository evidence.",
+          "outcome_status_model": "Use the reviewable status model success/partial/failed. Dry-run requests or zero-PDF discovery should resolve to partial rather than claiming success without an output artifact.",
+          "delegate_resolution": "If preferred_base_script is relative, resolve it from the repository or script location instead of Path.cwd() so behavior stays portable across shells and CI.",
+          "reviewed_delegate_contract": "For readonly reviewable preview flows, delegate only to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py or fail honestly instead of broadening behavior through an arbitrary helper.",
+          "delegate_success_evidence": "Do not treat zero exit code plus output-file existence as sufficient wrapper success evidence on their own. Prefer a structured delegate report that confirms a real success outcome before the wrapper claims success. Require delegate status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, and explicit output attestation fields excel_written=true, output_exists=true, and output_size_bytes>0.",
+          "delegate_timeout": "Bound delegate subprocess execution with an explicit timeout and report timeout as an honest failed/partial outcome instead of allowing smoke automation to hang indefinitely.",
+          "runtime_summary": "The generated script should emit a structured summary of what it produced so later review can inspect behavior without guessing.",
+          "delegate_report_schema": "Treat delegate JSON report fields status/total_files/status_counter/dry_run as the canonical evidence contract. Do not require undeclared processed_files/succeeded_files/failed_files counters.",
+          "delegate_report_handoff": "When the delegate prints a JSON report to stdout, parse that JSON directly instead of relying only on sidecar-report file path discovery.",
+          "delegate_report_flag_contract": "If wrapper passes a sidecar report path to the reviewed delegate, use the reviewed delegate CLI flag --report-json (or another explicitly supported alias). Do not invent undeclared flags such as --report-file.",
+          "dry_run_semantics": "If wrapper dry-run short-circuits before delegate execution, keep execution.delegated=false and report partial honestly. If wrapper does delegate under dry-run, pass through --dry-run explicitly.",
+          "pdf_discovery_consistency": "Keep wrapper preflight PDF discovery semantics aligned with the reviewed delegate (for example recursive vs non-recursive), so wrapper evidence and delegated execution count the same candidate set."
+        }
+      }
+    },
+    "expected_outputs": [
+      {
+        "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "type": "script"
+      }
+    ],
+    "constraints": [
+      "Follow the local inbox normalized request",
+      "Do not claim unsupported runtime dependencies",
+      "Keep output deterministic and executable",
+      "Produce only the expected script artifact",
+      "Prefer honest, reviewable intermediate behavior over unsupported OCR claims",
+      "If the requested output path ends with .xlsx, do not write non-XLSX text/XML/CSV content to that path.",
+      "Do not hardcode an input directory when the task params already provide input_dir.",
+      "Preserve meaningful traceability from the incoming description instead of collapsing it to a heading fragment.",
+      "Prefer wrapping or adapting artifacts/scripts/pdf_to_excel_ocr.py when that existing repo script already matches the requested behavior.",
+      "When artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py already exists, prefer updating that reviewed wrapper baseline instead of rewriting a new control flow from scratch.",
+      "If dry_run is true or no PDFs are discovered, report a reviewable partial outcome instead of claiming success without an XLSX artifact.",
+      "Resolve relative delegate script paths from the repository or script location, not from Path.cwd().",
+      "For readonly reviewable preview flows, only delegate to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py unless failing honestly.",
+      "Do not claim wrapper success from exit code plus output existence alone when the reviewed delegate report does not provide strong enough success evidence.",
+      "When wrapper reports success, enforce delegate evidence gates: status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, excel_written=true, output_exists=true, and output_size_bytes>0.",
+      "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
+      "When delegate emits JSON to stdout, parse that report directly instead of depending only on sidecar report-file discovery.",
+      "When wrapper passes a sidecar report path to the reviewed delegate, use --report-json exactly unless the reviewed delegate explicitly supports another alias.",
+      "If wrapper supports dry-run short-circuit semantics, keep execution.delegated=false and preserve partial status honestly.",
+      "Keep wrapper PDF discovery semantics aligned with reviewed delegate discovery semantics to avoid preflight/execution evidence drift.",
+      "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely."
+    ],
+    "priority": "medium",
+    "source": {
+      "kind": "local_inbox",
+      "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+      "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl041-001.json",
+      "received_at": "2026-03-25T05:53:23.227184Z",
+      "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "provider": "trello",
+      "mode": "readonly",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "regeneration_token": "regen-20260325-bl041-001"
+    },
+    "acceptance_criteria": [
+      "Produce the expected script artifact at expected_outputs[0].path",
+      "Script behavior remains runnable, deterministic, and reviewable",
+      "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
+      "Artifact behavior remains parameter-driven for input_dir and output_xlsx rather than hardcoding unrelated local defaults.",
+      "Dry-run or zero-input behavior is represented as a reviewable partial outcome instead of artifact-production success.",
+      "Relative preferred_base_script resolution remains portable and does not depend on Path.cwd().",
+      "Wrapper success requires stronger delegate evidence than zero exit code plus a non-empty output file alone.",
+      "Wrapper success attestation requires delegate fields excel_written=true, output_exists=true, output_size_bytes>0, and status_counter.partial/status_counter.failed equal to 0.",
+      "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
+      "Delegate report handoff can consume JSON printed to stdout without relying exclusively on report sidecar file discovery.",
+      "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",
+      "Dry-run semantics remain explicit: short-circuit stays partial with no delegated execution, or delegated dry-run is passed through honestly.",
+      "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
+      "Delegate execution is bounded by an explicit timeout and reports timeout honestly."
+    ],
+    "metadata": {
+      "integration_phase": "8B",
+      "pipeline": "inbox->adapter->manager->automation->critic",
+      "request_type": "pdf_to_excel_ocr",
+      "payload_hash": "c19150aca7c7434e4ac5564a324cadc8cc4b697f1e6157813ada824f2409e1c0",
+      "regeneration_token": "regen-20260325-bl041-001",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "external_metadata": {
+        "source_system": "trello",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "card_short_id": 7,
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "date_last_activity": "2026-03-24T08:35:56.234Z",
+        "readonly_mapped_at": "2026-03-25T05:52:58.249528Z",
+        "contract_profile": "best_effort_evidence_backed",
+        "ocr_claim_policy": "do_not_claim_success_without_evidence",
+        "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+        "regeneration_token": "regen-20260325-bl041-001"
+      },
+      "automation_contract_profile": "narrow_script_artifact_with_repo_reuse_and_reviewable_runner_contract"
+    }
+  },
+  "result": {
+    "task_id": "AUTO-20260325-861",
+    "worker": "automation",
+    "status": "failed",
+    "summary": "Worker execution failed",
+    "artifacts": [],
+    "errors": [
+      "LLM call exhausted (attempts=1/3, class=http_403, endpoint=https://fast.vpsairobot.com/v1/chat/completions, retryable=False): HTTP Error 403: Forbidden"
+    ],
+    "metadata": {},
+    "duration_ms": 1474,
+    "timestamp": "2026-03-25T05:54:41.107074Z"
+  },
+  "error": "LLM call exhausted (attempts=1/3, class=http_403, endpoint=https://fast.vpsairobot.com/v1/chat/completions, retryable=False): HTTP Error 403: Forbidden"
+}

--- a/runtime_archives/bl041/runtime/automation-output.json
+++ b/runtime_archives/bl041/runtime/automation-output.json
@@ -1,0 +1,13 @@
+{
+  "task_id": "AUTO-20260325-861",
+  "worker": "automation",
+  "status": "failed",
+  "summary": "Worker execution failed",
+  "artifacts": [],
+  "errors": [
+    "LLM call exhausted (attempts=1/3, class=http_403, endpoint=https://fast.vpsairobot.com/v1/chat/completions, retryable=False): HTTP Error 403: Forbidden"
+  ],
+  "metadata": {},
+  "duration_ms": 1474,
+  "timestamp": "2026-03-25T05:54:41.107074Z"
+}

--- a/runtime_archives/bl041/runtime/automation-runtime.attempt-1.log
+++ b/runtime_archives/bl041/runtime/automation-runtime.attempt-1.log
@@ -1,0 +1,19 @@
+task_id: AUTO-20260325-861
+worker: automation
+attempt: 1
+container_name: argus-automation-auto-20260325-861
+worker_image: argus-worker:latest
+started_at: 2026-03-25T05:54:39.384026Z
+finished_at: 2026-03-25T05:54:41.212675Z
+exit_code: 0
+timed_out: False
+wait_error: 
+
+=== stdout ===
+[2026-03-25T05:54:39.633527Z] [automation] [INFO] Worker started using endpoint https://fast.vpsairobot.com/v1/chat/completions (timeout=120s, attempts=3)
+[2026-03-25T05:54:41.105918Z] [automation] [WARN] LLM call failed attempt 1/3 (endpoint=https://fast.vpsairobot.com/v1/chat/completions, class=http_403, retryable=False): HTTP Error 403: Forbidden
+[2026-03-25T05:54:41.106178Z] [automation] [ERROR] Task failed AUTO-20260325-861: LLM call exhausted (attempts=1/3, class=http_403, endpoint=https://fast.vpsairobot.com/v1/chat/completions, retryable=False): HTTP Error 403: Forbidden
+[2026-03-25T05:54:41.110783Z] [automation] [INFO] Worker exiting from /app/workspaces/automation/AUTO-20260325-861
+
+=== stderr ===
+

--- a/runtime_archives/bl041/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7.json
+++ b/runtime_archives/bl041/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7.json
@@ -1,0 +1,355 @@
+{
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7",
+  "created_at": "2026-03-25T05:53:23.227757Z",
+  "approved": true,
+  "source": {
+    "kind": "local_inbox",
+    "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+    "received_at": "2026-03-25T05:53:23.227184Z",
+    "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl041-001.json",
+    "regeneration_token": "regen-20260325-bl041-001"
+  },
+  "external_input": {
+    "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+    "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+    "labels": [
+      "best_effort",
+      "evidence_backed",
+      "readonly",
+      "reviewable",
+      "trello"
+    ],
+    "metadata": {
+      "source_system": "trello",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "card_short_id": 7,
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "date_last_activity": "2026-03-24T08:35:56.234Z",
+      "readonly_mapped_at": "2026-03-25T05:52:58.249528Z",
+      "contract_profile": "best_effort_evidence_backed",
+      "ocr_claim_policy": "do_not_claim_success_without_evidence",
+      "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+      "regeneration_token": "regen-20260325-bl041-001"
+    },
+    "request_type": "pdf_to_excel_ocr",
+    "input": {
+      "input_dir": "~/Desktop/pdf样本",
+      "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+      "ocr": "auto",
+      "dry_run": false
+    }
+  },
+  "task_summary": {
+    "automation": {
+      "task_id": "AUTO-20260325-861",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+      "expected_outputs": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ]
+    },
+    "critic": {
+      "task_id": "CRITIC-20260325-281",
+      "worker": "critic",
+      "task_type": "review_artifact",
+      "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+      "expected_outputs": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ]
+    }
+  },
+  "internal_tasks": {
+    "automation": {
+      "task_id": "AUTO-20260325-861",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+      "inputs": {
+        "params": {
+          "input_dir": "~/Desktop/pdf样本",
+          "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+          "ocr": "auto",
+          "dry_run": false,
+          "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+          "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+          "description": "Purpose: | Controlled Trello live preview smoke for openclaw-team. | Expected behavior: | - read-only Trello ingest | - preview creation smoke only | - no business execution claim | - no Trello writeback expected in this step | Traceability: | - backlog: BL-20260324-014 | - blocker context: BL-20260324-015 | - created_by: Oscarling | - created_at: 2026-03-24 Asia/Shanghai | Note: | This card is only for governed smoke verification and should remain open until the smoke is finished.",
+          "labels": [
+            "best_effort",
+            "evidence_backed",
+            "readonly",
+            "reviewable",
+            "trello"
+          ],
+          "preferred_wrapper_script": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "preferred_base_script": "artifacts/scripts/pdf_to_excel_ocr.py",
+          "reference_docs": [
+            "artifacts/docs/pdf_to_excel_ocr_usage.md",
+            "artifacts/reviews/pdf_to_excel_ocr_review.md"
+          ],
+          "contract_hints": {
+            "output_format_fidelity": "If output_xlsx ends with .xlsx, produce a real XLSX workbook container or fail honestly before writing mismatched text/XML/CSV content to a .xlsx path.",
+            "path_portability": "Use the provided input_dir parameter as runtime input. Do not hardcode a user-home or absolute input path when params already declare the path.",
+            "traceability": "Preserve meaningful description context from the external input; do not collapse it to a heading fragment such as Purpose:.",
+            "reuse_preference": "Prefer reusing artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py as the wrapper baseline and artifacts/scripts/pdf_to_excel_ocr.py as the reviewed delegate when compatible, so workbook semantics and contract behavior stay aligned with repository evidence.",
+            "outcome_status_model": "Use the reviewable status model success/partial/failed. Dry-run requests or zero-PDF discovery should resolve to partial rather than claiming success without an output artifact.",
+            "delegate_resolution": "If preferred_base_script is relative, resolve it from the repository or script location instead of Path.cwd() so behavior stays portable across shells and CI.",
+            "reviewed_delegate_contract": "For readonly reviewable preview flows, delegate only to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py or fail honestly instead of broadening behavior through an arbitrary helper.",
+            "delegate_success_evidence": "Do not treat zero exit code plus output-file existence as sufficient wrapper success evidence on their own. Prefer a structured delegate report that confirms a real success outcome before the wrapper claims success. Require delegate status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, and explicit output attestation fields excel_written=true, output_exists=true, and output_size_bytes>0.",
+            "delegate_timeout": "Bound delegate subprocess execution with an explicit timeout and report timeout as an honest failed/partial outcome instead of allowing smoke automation to hang indefinitely.",
+            "runtime_summary": "The generated script should emit a structured summary of what it produced so later review can inspect behavior without guessing.",
+            "delegate_report_schema": "Treat delegate JSON report fields status/total_files/status_counter/dry_run as the canonical evidence contract. Do not require undeclared processed_files/succeeded_files/failed_files counters.",
+            "delegate_report_handoff": "When the delegate prints a JSON report to stdout, parse that JSON directly instead of relying only on sidecar-report file path discovery.",
+            "delegate_report_flag_contract": "If wrapper passes a sidecar report path to the reviewed delegate, use the reviewed delegate CLI flag --report-json (or another explicitly supported alias). Do not invent undeclared flags such as --report-file.",
+            "dry_run_semantics": "If wrapper dry-run short-circuits before delegate execution, keep execution.delegated=false and report partial honestly. If wrapper does delegate under dry-run, pass through --dry-run explicitly.",
+            "pdf_discovery_consistency": "Keep wrapper preflight PDF discovery semantics aligned with the reviewed delegate (for example recursive vs non-recursive), so wrapper evidence and delegated execution count the same candidate set."
+          }
+        }
+      },
+      "expected_outputs": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ],
+      "constraints": [
+        "Follow the local inbox normalized request",
+        "Do not claim unsupported runtime dependencies",
+        "Keep output deterministic and executable",
+        "Produce only the expected script artifact",
+        "Prefer honest, reviewable intermediate behavior over unsupported OCR claims",
+        "If the requested output path ends with .xlsx, do not write non-XLSX text/XML/CSV content to that path.",
+        "Do not hardcode an input directory when the task params already provide input_dir.",
+        "Preserve meaningful traceability from the incoming description instead of collapsing it to a heading fragment.",
+        "Prefer wrapping or adapting artifacts/scripts/pdf_to_excel_ocr.py when that existing repo script already matches the requested behavior.",
+        "When artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py already exists, prefer updating that reviewed wrapper baseline instead of rewriting a new control flow from scratch.",
+        "If dry_run is true or no PDFs are discovered, report a reviewable partial outcome instead of claiming success without an XLSX artifact.",
+        "Resolve relative delegate script paths from the repository or script location, not from Path.cwd().",
+        "For readonly reviewable preview flows, only delegate to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py unless failing honestly.",
+        "Do not claim wrapper success from exit code plus output existence alone when the reviewed delegate report does not provide strong enough success evidence.",
+        "When wrapper reports success, enforce delegate evidence gates: status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, excel_written=true, output_exists=true, and output_size_bytes>0.",
+        "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
+        "When delegate emits JSON to stdout, parse that report directly instead of depending only on sidecar report-file discovery.",
+        "When wrapper passes a sidecar report path to the reviewed delegate, use --report-json exactly unless the reviewed delegate explicitly supports another alias.",
+        "If wrapper supports dry-run short-circuit semantics, keep execution.delegated=false and preserve partial status honestly.",
+        "Keep wrapper PDF discovery semantics aligned with reviewed delegate discovery semantics to avoid preflight/execution evidence drift.",
+        "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely."
+      ],
+      "priority": "medium",
+      "source": {
+        "kind": "local_inbox",
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl041-001.json",
+        "received_at": "2026-03-25T05:53:23.227184Z",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "regeneration_token": "regen-20260325-bl041-001"
+      },
+      "acceptance_criteria": [
+        "Produce the expected script artifact at expected_outputs[0].path",
+        "Script behavior remains runnable, deterministic, and reviewable",
+        "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
+        "Artifact behavior remains parameter-driven for input_dir and output_xlsx rather than hardcoding unrelated local defaults.",
+        "Dry-run or zero-input behavior is represented as a reviewable partial outcome instead of artifact-production success.",
+        "Relative preferred_base_script resolution remains portable and does not depend on Path.cwd().",
+        "Wrapper success requires stronger delegate evidence than zero exit code plus a non-empty output file alone.",
+        "Wrapper success attestation requires delegate fields excel_written=true, output_exists=true, output_size_bytes>0, and status_counter.partial/status_counter.failed equal to 0.",
+        "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
+        "Delegate report handoff can consume JSON printed to stdout without relying exclusively on report sidecar file discovery.",
+        "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",
+        "Dry-run semantics remain explicit: short-circuit stays partial with no delegated execution, or delegated dry-run is passed through honestly.",
+        "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
+        "Delegate execution is bounded by an explicit timeout and reports timeout honestly."
+      ],
+      "metadata": {
+        "integration_phase": "8B",
+        "pipeline": "inbox->adapter->manager->automation->critic",
+        "request_type": "pdf_to_excel_ocr",
+        "payload_hash": "c19150aca7c7434e4ac5564a324cadc8cc4b697f1e6157813ada824f2409e1c0",
+        "regeneration_token": "regen-20260325-bl041-001",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "external_metadata": {
+          "source_system": "trello",
+          "card_id": "69c24cd3c1a2359ddd7a1bf8",
+          "card_short_id": 7,
+          "board_id": "69be462743bfa0038ca10f7a",
+          "list_id": "69be462743bfa0038ca10f8f",
+          "date_last_activity": "2026-03-24T08:35:56.234Z",
+          "readonly_mapped_at": "2026-03-25T05:52:58.249528Z",
+          "contract_profile": "best_effort_evidence_backed",
+          "ocr_claim_policy": "do_not_claim_success_without_evidence",
+          "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+          "regeneration_token": "regen-20260325-bl041-001"
+        },
+        "automation_contract_profile": "narrow_script_artifact_with_repo_reuse_and_reviewable_runner_contract"
+      }
+    },
+    "critic": {
+      "task_id": "CRITIC-20260325-281",
+      "worker": "critic",
+      "task_type": "review_artifact",
+      "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+      "inputs": {
+        "artifacts": [
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "type": "script"
+          },
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+            "type": "script"
+          }
+        ],
+        "params": {
+          "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+          "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+          "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+          "labels": [
+            "best_effort",
+            "evidence_backed",
+            "readonly",
+            "reviewable",
+            "trello"
+          ],
+          "review_scope": {
+            "primary_artifact": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "paired_artifacts": [
+              "artifacts/scripts/pdf_to_excel_ocr.py"
+            ],
+            "goal": "Audit the wrapper and the reviewed delegate together so the review evidence can speak to the end-to-end readonly smoke path."
+          }
+        }
+      },
+      "expected_outputs": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ],
+      "constraints": [
+        "Review must be grounded in produced automation artifact",
+        "When both wrapper and reviewed delegate snapshots are supplied, evaluate them as one end-to-end readonly pair instead of ignoring the delegate evidence.",
+        "Do not invent missing artifact content",
+        "Return a clear verdict: pass, fail, or needs_revision",
+        "Include metadata.verdict in output",
+        "Generate review artifact markdown for expected_outputs[0].path"
+      ],
+      "priority": "medium",
+      "source": {
+        "kind": "local_inbox",
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl041-001.json",
+        "received_at": "2026-03-25T05:53:23.227184Z",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "regeneration_token": "regen-20260325-bl041-001"
+      },
+      "acceptance_criteria": [
+        "Produce a review artifact with explicit verdict (pass/fail/needs_revision)"
+      ],
+      "metadata": {
+        "integration_phase": "8B",
+        "pipeline": "inbox->adapter->manager->automation->critic",
+        "request_type": "pdf_to_excel_ocr",
+        "payload_hash": "c19150aca7c7434e4ac5564a324cadc8cc4b697f1e6157813ada824f2409e1c0",
+        "regeneration_token": "regen-20260325-bl041-001",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "external_metadata": {
+          "source_system": "trello",
+          "card_id": "69c24cd3c1a2359ddd7a1bf8",
+          "card_short_id": 7,
+          "board_id": "69be462743bfa0038ca10f7a",
+          "list_id": "69be462743bfa0038ca10f8f",
+          "date_last_activity": "2026-03-24T08:35:56.234Z",
+          "readonly_mapped_at": "2026-03-25T05:52:58.249528Z",
+          "contract_profile": "best_effort_evidence_backed",
+          "ocr_claim_policy": "do_not_claim_success_without_evidence",
+          "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+          "regeneration_token": "regen-20260325-bl041-001"
+        }
+      }
+    }
+  },
+  "expected_artifacts": [
+    "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+    "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py"
+  ],
+  "dedupe_keys": [
+    "origin_regeneration:trello:69c24cd3c1a2359ddd7a1bf8:regen-20260325-bl041-001",
+    "hash:c19150aca7c7434e4ac5564a324cadc8cc4b697f1e6157813ada824f2409e1c0"
+  ],
+  "risk_warnings": [],
+  "execution": {
+    "status": "rejected",
+    "executed": true,
+    "attempts": 2,
+    "executed_at": "2026-03-25T05:54:41.245023Z",
+    "decision_reason": "Automation task failed: {\"task_id\": \"AUTO-20260325-861\", \"worker\": \"automation\", \"status\": \"failed\", \"summary\": \"Worker execution failed\", \"artifacts\": [], \"errors\": [\"LLM call exhausted (attempts=1/3, class=http_403, endpoint=https://fast.vpsairobot.com/v1/chat/completions, retryable=False): HTTP Error 403: Forbidden\"], \"metadata\": {}, \"duration_ms\": 1474, \"timestamp\": \"2026-03-25T05:54:41.107074Z\"}"
+  },
+  "approval": {
+    "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7.json",
+    "approved_by": "Oscarling",
+    "approved_at": "2026-03-25T05:53:47Z",
+    "note": "BL-20260325-041 governed validation execute only; no Git finalization; no Trello Done."
+  },
+  "last_execution": {
+    "decision": "rejected",
+    "decision_reason": "Automation task failed: {\"task_id\": \"AUTO-20260325-861\", \"worker\": \"automation\", \"status\": \"failed\", \"summary\": \"Worker execution failed\", \"artifacts\": [], \"errors\": [\"LLM call exhausted (attempts=1/3, class=http_403, endpoint=https://fast.vpsairobot.com/v1/chat/completions, retryable=False): HTTP Error 403: Forbidden\"], \"metadata\": {}, \"duration_ms\": 1474, \"timestamp\": \"2026-03-25T05:54:41.107074Z\"}",
+    "automation_result": {
+      "task_id": "AUTO-20260325-861",
+      "worker": "automation",
+      "status": "failed",
+      "summary": "Worker execution failed",
+      "artifacts": [],
+      "errors": [
+        "LLM call exhausted (attempts=1/3, class=http_403, endpoint=https://fast.vpsairobot.com/v1/chat/completions, retryable=False): HTTP Error 403: Forbidden"
+      ],
+      "metadata": {},
+      "duration_ms": 1474,
+      "timestamp": "2026-03-25T05:54:41.107074Z"
+    },
+    "critic_result": null,
+    "critic_verdict": "needs_revision"
+  }
+}

--- a/runtime_archives/bl041/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7.result.json
+++ b/runtime_archives/bl041/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7.result.json
@@ -1,0 +1,9 @@
+{
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7",
+  "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7.json",
+  "executed_at": "2026-03-25T05:54:41.245750Z",
+  "status": "rejected",
+  "decision_reason": "Automation task failed: {\"task_id\": \"AUTO-20260325-861\", \"worker\": \"automation\", \"status\": \"failed\", \"summary\": \"Worker execution failed\", \"artifacts\": [], \"errors\": [\"LLM call exhausted (attempts=1/3, class=http_403, endpoint=https://fast.vpsairobot.com/v1/chat/completions, retryable=False): HTTP Error 403: Forbidden\"], \"metadata\": {}, \"duration_ms\": 1474, \"timestamp\": \"2026-03-25T05:54:41.107074Z\"}",
+  "critic_verdict": "needs_revision",
+  "test_mode": "off"
+}

--- a/runtime_archives/bl041/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl041-001.json
+++ b/runtime_archives/bl041/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl041-001.json
@@ -1,0 +1,41 @@
+{
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "metadata": {
+    "source_system": "trello",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "card_short_id": 7,
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "date_last_activity": "2026-03-24T08:35:56.234Z",
+    "readonly_mapped_at": "2026-03-25T05:52:58.249528Z",
+    "contract_profile": "best_effort_evidence_backed",
+    "ocr_claim_policy": "do_not_claim_success_without_evidence",
+    "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+    "regeneration_token": "regen-20260325-bl041-001"
+  },
+  "source": {
+    "provider": "trello",
+    "mode": "readonly",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "regeneration_token": "regen-20260325-bl041-001"
+  },
+  "request_type": "pdf_to_excel_ocr",
+  "input": {
+    "input_dir": "~/Desktop/pdf样本",
+    "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+    "ocr": "auto",
+    "dry_run": false
+  },
+  "regeneration_token": "regen-20260325-bl041-001"
+}

--- a/runtime_archives/bl041/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl041-001.json.result.json
+++ b/runtime_archives/bl041/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl041-001.json.result.json
@@ -1,0 +1,23 @@
+{
+  "ingested_at": "2026-03-25T05:53:23.228124Z",
+  "status": "processed",
+  "decision": "preview_created_pending_approval",
+  "decision_reason": "preview_created; waiting_for_explicit_approval",
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "payload_hash": "c19150aca7c7434e4ac5564a324cadc8cc4b697f1e6157813ada824f2409e1c0",
+  "dedupe_keys": [
+    "origin_regeneration:trello:69c24cd3c1a2359ddd7a1bf8:regen-20260325-bl041-001",
+    "hash:c19150aca7c7434e4ac5564a324cadc8cc4b697f1e6157813ada824f2409e1c0"
+  ],
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7",
+  "preview_file": "/Users/lingguozhong/openclaw-team/preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7.json",
+  "regeneration_token": "regen-20260325-bl041-001"
+}

--- a/runtime_archives/bl041/tmp/bl041_execute_once_elevated.json
+++ b/runtime_archives/bl041/tmp/bl041_execute_once_elevated.json
@@ -1,0 +1,18 @@
+{
+  "status": "done",
+  "processed": 0,
+  "rejected": 1,
+  "skipped": 0,
+  "test_mode": "off",
+  "allow_replay": true,
+  "results": [
+    {
+      "status": "rejected",
+      "decision_reason": "Automation task failed: {\"task_id\": \"AUTO-20260325-861\", \"worker\": \"automation\", \"status\": \"failed\", \"summary\": \"Worker execution failed\", \"artifacts\": [], \"errors\": [\"LLM call exhausted (attempts=1/3, class=http_403, endpoint=https://fast.vpsairobot.com/v1/chat/completions, retryable=False): HTTP Error 403: Forbidden\"], \"metadata\": {}, \"duration_ms\": 1474, \"timestamp\": \"2026-03-25T05:54:41.107074Z\"}",
+      "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7",
+      "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7.json",
+      "result_sidecar": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7.result.json",
+      "critic_verdict": "needs_revision"
+    }
+  ]
+}

--- a/runtime_archives/bl041/tmp/bl041_execute_once_sandbox.json
+++ b/runtime_archives/bl041/tmp/bl041_execute_once_sandbox.json
@@ -1,0 +1,18 @@
+{
+  "status": "done",
+  "processed": 0,
+  "rejected": 1,
+  "skipped": 0,
+  "test_mode": "off",
+  "allow_replay": false,
+  "results": [
+    {
+      "status": "rejected",
+      "decision_reason": "Failed to initialize docker client from environment. Ensure Docker access is available or pass docker_client explicitly.",
+      "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7",
+      "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7.json",
+      "result_sidecar": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7.result.json",
+      "critic_verdict": "needs_revision"
+    }
+  ]
+}

--- a/runtime_archives/bl041/tmp/bl041_ingest_once.json
+++ b/runtime_archives/bl041/tmp/bl041_ingest_once.json
@@ -1,0 +1,21 @@
+{
+  "status": "done",
+  "processed": 1,
+  "rejected": 0,
+  "duplicate_skipped": 0,
+  "preview_created": 1,
+  "inbox_claimed": 1,
+  "processing_recovered": 0,
+  "test_mode": "success",
+  "results": [
+    {
+      "status": "processed",
+      "decision": "preview_created_pending_approval",
+      "decision_reason": "preview_created; waiting_for_explicit_approval",
+      "file": "/Users/lingguozhong/openclaw-team/processed/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl041-001.json",
+      "result_sidecar": "/Users/lingguozhong/openclaw-team/processed/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl041-001.json.result.json",
+      "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7",
+      "preview_file": "/Users/lingguozhong/openclaw-team/preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7.json"
+    }
+  ]
+}

--- a/runtime_archives/bl041/tmp/bl041_live_mapped_preview.json
+++ b/runtime_archives/bl041/tmp/bl041_live_mapped_preview.json
@@ -1,0 +1,38 @@
+{
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "metadata": {
+    "source_system": "trello",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "card_short_id": 7,
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "date_last_activity": "2026-03-24T08:35:56.234Z",
+    "readonly_mapped_at": "2026-03-25T05:52:58.249528Z",
+    "contract_profile": "best_effort_evidence_backed",
+    "ocr_claim_policy": "do_not_claim_success_without_evidence",
+    "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable"
+  },
+  "source": {
+    "provider": "trello",
+    "mode": "readonly",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f"
+  },
+  "request_type": "pdf_to_excel_ocr",
+  "input": {
+    "input_dir": "~/Desktop/pdf样本",
+    "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+    "ocr": "auto",
+    "dry_run": false
+  }
+}

--- a/runtime_archives/bl041/tmp/bl041_smoke_elevated.json
+++ b/runtime_archives/bl041/tmp/bl041_smoke_elevated.json
@@ -1,0 +1,90 @@
+{
+  "status": "done",
+  "fixture": "/Users/lingguozhong/openclaw-team/adapters/samples/trello_card_fixture.json",
+  "mapped_output": "/private/tmp/bl041_mapped_live.json",
+  "required_env": {
+    "credentials": [
+      "TRELLO_API_KEY",
+      "TRELLO_API_TOKEN"
+    ],
+    "credentials_aliases": [
+      "TRELLO_KEY",
+      "TRELLO_TOKEN"
+    ],
+    "credentials_priority": [
+      "TRELLO_API_KEY/TRELLO_API_TOKEN",
+      "TRELLO_KEY/TRELLO_TOKEN"
+    ],
+    "scope": [
+      "TRELLO_BOARD_ID",
+      "TRELLO_LIST_ID"
+    ],
+    "scope_rule": [
+      "TRELLO_BOARD_ID or TRELLO_LIST_ID (either one)"
+    ]
+  },
+  "smoke_read": {
+    "status": "pass",
+    "read_count": 1,
+    "scope": {
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": null
+    },
+    "scope_kind": "board",
+    "mapped_preview": {
+      "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+      "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+      "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "metadata": {
+        "source_system": "trello",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "card_short_id": 7,
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "date_last_activity": "2026-03-24T08:35:56.234Z",
+        "readonly_mapped_at": "2026-03-25T05:52:58.249528Z",
+        "contract_profile": "best_effort_evidence_backed",
+        "ocr_claim_policy": "do_not_claim_success_without_evidence",
+        "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable"
+      },
+      "source": {
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f"
+      },
+      "request_type": "pdf_to_excel_ocr",
+      "input": {
+        "input_dir": "~/Desktop/pdf样本",
+        "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+        "ocr": "auto",
+        "dry_run": false
+      }
+    },
+    "auth_env": {
+      "selected_names": {
+        "key": "TRELLO_API_KEY",
+        "token": "TRELLO_API_TOKEN"
+      },
+      "priority": "TRELLO_API_* first, fallback to TRELLO_*",
+      "presence": {
+        "TRELLO_API_KEY": "set",
+        "TRELLO_KEY": "set",
+        "TRELLO_API_TOKEN": "set",
+        "TRELLO_TOKEN": "set",
+        "TRELLO_BOARD_ID": "set",
+        "TRELLO_LIST_ID": "missing"
+      }
+    },
+    "note": "Read-only GET only. No write operations performed."
+  },
+  "mode": "trello_readonly_prep"
+}

--- a/runtime_archives/bl041/tmp/bl041_smoke_result.json
+++ b/runtime_archives/bl041/tmp/bl041_smoke_result.json
@@ -1,0 +1,48 @@
+{
+  "status": "done",
+  "fixture": "/Users/lingguozhong/openclaw-team/adapters/samples/trello_card_fixture.json",
+  "mapped_output": "/private/tmp/bl041_mapped.json",
+  "required_env": {
+    "credentials": [
+      "TRELLO_API_KEY",
+      "TRELLO_API_TOKEN"
+    ],
+    "credentials_aliases": [
+      "TRELLO_KEY",
+      "TRELLO_TOKEN"
+    ],
+    "credentials_priority": [
+      "TRELLO_API_KEY/TRELLO_API_TOKEN",
+      "TRELLO_KEY/TRELLO_TOKEN"
+    ],
+    "scope": [
+      "TRELLO_BOARD_ID",
+      "TRELLO_LIST_ID"
+    ],
+    "scope_rule": [
+      "TRELLO_BOARD_ID or TRELLO_LIST_ID (either one)"
+    ]
+  },
+  "smoke_read": {
+    "status": "blocked",
+    "reason": "Read-only Trello request failed before HTTP response: ConnectionError",
+    "error_type": "ConnectionError",
+    "response_preview": "HTTPSConnectionPool(host='api.trello.com', port=443): Max retries exceeded with url: /1/boards/69be462743bfa0038ca10f7a/cards?key=***redacted_key***&token=***redacted_token***&fields=id%2CidShort%2Cname%2Cdesc%2CidList%2CidBoard%2CdateLastActivity%2Clabels&limit=1 (Caused by NameResolutionError(\"HTT",
+    "auth_env": {
+      "selected_names": {
+        "key": "TRELLO_API_KEY",
+        "token": "TRELLO_API_TOKEN"
+      },
+      "priority": "TRELLO_API_* first, fallback to TRELLO_*",
+      "presence": {
+        "TRELLO_API_KEY": "set",
+        "TRELLO_KEY": "set",
+        "TRELLO_API_TOKEN": "set",
+        "TRELLO_TOKEN": "set",
+        "TRELLO_BOARD_ID": "set",
+        "TRELLO_LIST_ID": "missing"
+      }
+    }
+  },
+  "mode": "trello_readonly_prep"
+}

--- a/runtime_archives/bl041/tmp/bl041_smoke_sandbox.json
+++ b/runtime_archives/bl041/tmp/bl041_smoke_sandbox.json
@@ -1,0 +1,48 @@
+{
+  "status": "done",
+  "fixture": "/Users/lingguozhong/openclaw-team/adapters/samples/trello_card_fixture.json",
+  "mapped_output": "/private/tmp/bl041_mapped.json",
+  "required_env": {
+    "credentials": [
+      "TRELLO_API_KEY",
+      "TRELLO_API_TOKEN"
+    ],
+    "credentials_aliases": [
+      "TRELLO_KEY",
+      "TRELLO_TOKEN"
+    ],
+    "credentials_priority": [
+      "TRELLO_API_KEY/TRELLO_API_TOKEN",
+      "TRELLO_KEY/TRELLO_TOKEN"
+    ],
+    "scope": [
+      "TRELLO_BOARD_ID",
+      "TRELLO_LIST_ID"
+    ],
+    "scope_rule": [
+      "TRELLO_BOARD_ID or TRELLO_LIST_ID (either one)"
+    ]
+  },
+  "smoke_read": {
+    "status": "blocked",
+    "reason": "Read-only Trello request failed before HTTP response: ConnectionError",
+    "error_type": "ConnectionError",
+    "response_preview": "HTTPSConnectionPool(host='api.trello.com', port=443): Max retries exceeded with url: /1/boards/69be462743bfa0038ca10f7a/cards?key=***redacted_key***&token=***redacted_token***&fields=id%2CidShort%2Cname%2Cdesc%2CidList%2CidBoard%2CdateLastActivity%2Clabels&limit=1 (Caused by NameResolutionError(\"HTT",
+    "auth_env": {
+      "selected_names": {
+        "key": "TRELLO_API_KEY",
+        "token": "TRELLO_API_TOKEN"
+      },
+      "priority": "TRELLO_API_* first, fallback to TRELLO_*",
+      "presence": {
+        "TRELLO_API_KEY": "set",
+        "TRELLO_KEY": "set",
+        "TRELLO_API_TOKEN": "set",
+        "TRELLO_TOKEN": "set",
+        "TRELLO_BOARD_ID": "set",
+        "TRELLO_LIST_ID": "missing"
+      }
+    }
+  },
+  "mode": "trello_readonly_prep"
+}


### PR DESCRIPTION
## Summary
- complete BL-20260325-041 governed validation on a fresh same-origin candidate
- record runtime truth: BL-040 wrapper success-evidence effect remained unverified because automation failed early with HTTP 403 before critic dispatch
- archive BL-041 runtime artifacts and update backlog/work log, including next blocker BL-20260325-042

## Validation Flow (BL-041)
- Trello smoke: sandbox blocked by DNS, elevated rerun passed
- regeneration token: `regen-20260325-bl041-001`
- preview: `preview-trello-69c24cd3c1a2359ddd7a1bf8-c19150aca7c7`
- execute: sandbox Docker-init rejection, elevated replay rejected with automation `AUTO-20260325-861` (`http_403`)

## Verification
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py

Closes #75
