### PR TITLE
fix: harden automation auth fallback behavior for BL-042

### DIFF
--- a/AUTOMATION_ENDPOINT_HTTP403_HARDENING_REPORT.md
+++ b/AUTOMATION_ENDPOINT_HTTP403_HARDENING_REPORT.md
@@ -1,0 +1,70 @@
+# Automation Endpoint HTTP 403 Hardening Report
+
+## Objective
+
+Complete `BL-20260325-042` by hardening automation LLM endpoint behavior so a
+primary-endpoint authorization failure (`HTTP 401/403`) can perform one
+controlled fallback-endpoint retry when fallback endpoints are configured,
+instead of terminating immediately before artifact generation.
+
+## Scope
+
+In scope:
+
+- adjust worker-runtime retry policy for authorization failures under
+  multi-endpoint configuration
+- preserve non-retry behavior for HTTP 401/403 when no fallback endpoint exists
+- focused regression coverage for the new authorization-fallback behavior
+
+Out of scope:
+
+- live governed runtime validation rerun
+- endpoint credential rotation or external secret changes
+- critic-side contract changes
+
+## Changes
+
+### 1) Added explicit auth-fallback retry gate
+
+Updated `dispatcher/worker_runtime.py`:
+
+- added helper `should_retry_auth_failure_on_fallback(...)` to permit retry only
+  when all of the following are true:
+  - error class is `http_401` or `http_403`
+  - at least one remaining retry attempt exists
+  - there is a distinct fallback endpoint candidate
+- in `call_llm(...)`, added one-time authorization fallback retry state so
+  endpoint-authorization fallback is explicit and bounded
+- logging now reflects the effective retryability decision and emits a clear
+  info log when auth-fallback retry is activated
+
+Result: authorization failure on the primary endpoint can now move to a
+configured fallback endpoint once, while keeping behavior deterministic.
+
+### 2) Added focused regression tests
+
+Updated `tests/test_argus_hardening.py`:
+
+- `test_call_llm_rotates_to_fallback_chat_url_after_http_403_on_primary`
+  verifies primary `HTTP 403` now rotates to fallback endpoint and succeeds
+- `test_call_llm_http_403_without_fallback_remains_non_retryable`
+  verifies no fallback still fails immediately on first `HTTP 403`
+
+## Verification
+
+Passed on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_argus_hardening.py`
+
+## Conclusion
+
+`BL-20260325-042` can be treated as complete as a source-side blocker-hardening
+phase.
+
+Automation runtime now has deterministic, bounded authorization-fallback behavior
+for endpoint-specific `HTTP 401/403` failures when fallback endpoints are
+configured. Live effectiveness still requires fresh governed validation.
+
+Next required step: run a fresh same-origin governed validation to verify
+whether this hardening restores automation artifact generation and critic
+execution under real runtime conditions.

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -758,8 +758,8 @@ Allowed enum values:
 ### BL-20260325-042
 - title: Harden automation endpoint authorization/runtime access after BL-20260325-041 HTTP 403 blocker
 - type: blocker
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-041
@@ -767,7 +767,24 @@ Allowed enum values:
 - done_when: Automation LLM path handles or avoids endpoint authorization/runtime-access blockers (credential/endpoint policy hardening with explicit diagnostics and deterministic behavior), focused tests cover the new behavior, and one blocker report records the implemented mitigation
 - source: `POST_WRAPPER_SUCCESS_EVIDENCE_VALIDATION_REPORT.md` on 2026-03-25 records automation failure class `http_403` at `https://fast.vpsairobot.com/v1/chat/completions` as the active blocker that prevented runtime validation closure of BL-20260325-040
 - link: /Users/lingguozhong/openclaw-team/AUTOMATION_ENDPOINT_HTTP403_HARDENING_REPORT.md
-- issue: deferred:phase=next until BL-20260325-041 lands on main
+- issue: https://github.com/Oscarling/openclaw-team/issues/77
+- evidence: `AUTOMATION_ENDPOINT_HTTP403_HARDENING_REPORT.md` records source-side hardening in `dispatcher/worker_runtime.py` that allows one bounded fallback-endpoint retry for primary-endpoint `http_401/http_403` authorization failures when fallback endpoints are configured, with focused regressions in `tests/test_argus_hardening.py`
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-043
+- title: Validate BL-20260325-042 HTTP 403 authorization hardening on a fresh same-origin governed candidate
+- type: mainline
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-042
+- start_when: `BL-20260325-042` is merged so a fresh same-origin governed run can verify whether authorization-fallback hardening restores automation artifact generation and critic dispatch under real execute
+- done_when: One governed validation creates a fresh same-origin preview candidate after BL-20260325-042, runs one explicit approval plus one real execute, and records whether runtime now clears the `http_403` automation blocker observed in BL-20260325-041
+- source: `AUTOMATION_ENDPOINT_HTTP403_HARDENING_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation rather than assuming source-side auth-fallback hardening success without live evidence
+- link: /Users/lingguozhong/openclaw-team/POST_HTTP403_HARDENING_VALIDATION_REPORT.md
+- issue: deferred:phase=next until BL-20260325-042 lands on main
 - evidence: -
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -1748,6 +1748,52 @@ Verification snapshot on 2026-03-25:
   - `runtime_archives/bl041/state/`
   - `runtime_archives/bl041/tmp/`
 
+### 50. Automation HTTP 403 Authorization Hardening After BL-041
+
+User objective:
+
+- continue after `BL-20260325-041` without mixing another governed runtime run
+  into the same phase
+- harden source-side runtime behavior so primary-endpoint authorization failure
+  (`http_401` / `http_403`) can take one bounded fallback endpoint retry when
+  fallback endpoints are configured
+- keep the hardening minimal, deterministic, and test-backed
+
+Main work areas:
+
+- activated `BL-20260325-042` and mirrored it to GitHub issue `#77`
+- updated `dispatcher/worker_runtime.py`:
+  - added `should_retry_auth_failure_on_fallback(...)` gate
+  - updated `call_llm(...)` retry logic to:
+    - allow one bounded fallback retry for primary-endpoint auth failures
+      (`http_401` / `http_403`) when a distinct fallback endpoint exists
+    - preserve non-retry behavior when no fallback endpoint is configured
+    - emit explicit log line when auth-fallback retry is activated
+- expanded `tests/test_argus_hardening.py` with focused assertions:
+  - primary `http_403` rotates to fallback endpoint and succeeds
+  - `http_403` without fallback remains non-retryable and fails on first
+    attempt
+- recorded next fresh governed validation phase as `BL-20260325-043`
+
+Primary output:
+
+- [AUTOMATION_ENDPOINT_HTTP403_HARDENING_REPORT.md](/Users/lingguozhong/openclaw-team/AUTOMATION_ENDPOINT_HTTP403_HARDENING_REPORT.md)
+
+Key result:
+
+- `BL-20260325-042` completed as a source-side blocker-hardening phase
+- automation runtime now supports deterministic, bounded authorization-fallback
+  behavior for endpoint-specific `HTTP 401/403` failures
+- runtime closure is intentionally deferred to governed validation phase
+  `BL-20260325-043`
+
+Verification snapshot on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_argus_hardening.py` passed
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed with no phase=now actionable issue
+  mirroring required
+
 ### 31. Post-Timeout Governed Validation On Fresh Same-Origin Candidate
 
 User objective:

--- a/dispatcher/worker_runtime.py
+++ b/dispatcher/worker_runtime.py
@@ -377,6 +377,18 @@ def classify_llm_call_error(error):
     return "unknown", True
 
 
+def should_retry_auth_failure_on_fallback(error_class, attempt, max_attempts, chat_urls):
+    if error_class not in {"http_401", "http_403"}:
+        return False
+    if attempt >= max_attempts - 1:
+        return False
+    if len(chat_urls) < 2:
+        return False
+    current_url = chat_urls[attempt % len(chat_urls)]
+    next_url = chat_urls[(attempt + 1) % len(chat_urls)]
+    return current_url != next_url
+
+
 # ==========================================
 # LLM Call with retry
 # ==========================================
@@ -398,6 +410,7 @@ def call_llm(system_prompt, user_prompt, worker, llm_settings):
         "User-Agent": HTTP_USER_AGENT,
         "Connection": "close",
     }
+    auth_fallback_retry_used = False
     for attempt in range(max_attempts):
         chat_url = chat_urls[attempt % len(chat_urls)]
         try:
@@ -417,21 +430,34 @@ def call_llm(system_prompt, user_prompt, worker, llm_settings):
             return content
         except Exception as e:
             error_class, retryable = classify_llm_call_error(e)
+            auth_fallback_retry = False
+            if not retryable and not auth_fallback_retry_used:
+                auth_fallback_retry = should_retry_auth_failure_on_fallback(
+                    error_class=error_class,
+                    attempt=attempt,
+                    max_attempts=max_attempts,
+                    chat_urls=chat_urls,
+                )
+                if auth_fallback_retry:
+                    auth_fallback_retry_used = True
+            effective_retryable = retryable or auth_fallback_retry
             log(
                 worker,
                 "WARN",
                 (
                     f"LLM call failed attempt {attempt + 1}/{max_attempts} "
-                    f"(endpoint={chat_url}, class={error_class}, retryable={retryable}): {e}"
+                    f"(endpoint={chat_url}, class={error_class}, retryable={effective_retryable}): {e}"
                 ),
             )
-            if attempt == max_attempts - 1 or not retryable:
+            if attempt == max_attempts - 1 or not effective_retryable:
                 raise RuntimeError(
                     (
                         f"LLM call exhausted (attempts={attempt + 1}/{max_attempts}, "
-                        f"class={error_class}, endpoint={chat_url}, retryable={retryable}): {e}"
+                        f"class={error_class}, endpoint={chat_url}, retryable={effective_retryable}): {e}"
                     )
                 ) from e
+            if auth_fallback_retry:
+                log(worker, "INFO", "Authorization failure detected; retrying once on fallback endpoint.")
             delay_seconds = 2 ** attempt
             next_url = chat_urls[(attempt + 1) % len(chat_urls)]
             log(worker, "INFO", f"Retrying LLM call in {delay_seconds}s (next_endpoint={next_url})")

--- a/tests/test_argus_hardening.py
+++ b/tests/test_argus_hardening.py
@@ -545,6 +545,103 @@ class ArgusHardeningTests(unittest.TestCase):
         self.assertEqual([timeout for _url, timeout in calls], [120, 120])
         self.assertEqual(json.loads(content)["status"], "success")
 
+    def test_call_llm_rotates_to_fallback_chat_url_after_http_403_on_primary(self) -> None:
+        calls: list[tuple[str, int]] = []
+
+        class FakeResponse:
+            def __enter__(self) -> "FakeResponse":
+                return self
+
+            def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+                return False
+
+            def read(self) -> bytes:
+                payload = {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": json.dumps({"status": "success", "summary": "ok"})
+                            }
+                        }
+                    ]
+                }
+                return json.dumps(payload).encode("utf-8")
+
+        class AuthFallbackOpener:
+            def open(self, req: Any, timeout: int | None = None) -> FakeResponse:
+                calls.append((req.full_url, timeout or 0))
+                if "primary.invalid" in req.full_url:
+                    raise urllib.error.HTTPError(req.full_url, 403, "Forbidden", None, None)
+                return FakeResponse()
+
+        with mock.patch.object(worker_runtime, "NO_PROXY_OPENER", AuthFallbackOpener()):
+            with mock.patch.object(worker_runtime.time, "sleep", return_value=None):
+                with mock.patch.dict(
+                    os.environ,
+                    {
+                        "ARGUS_LLM_MAX_RETRIES": "2",
+                        "ARGUS_LLM_FALLBACK_CHAT_URLS": "https://fallback.invalid/v1/chat/completions",
+                    },
+                    clear=False,
+                ):
+                    content = worker_runtime.call_llm(
+                        "system",
+                        "user",
+                        "automation",
+                        {
+                            "api_key": "key",
+                            "api_base": "https://primary.invalid/v1",
+                            "chat_url": "https://primary.invalid/v1/chat/completions",
+                            "model_name": "demo-model",
+                        },
+                    )
+
+        self.assertEqual(
+            [url for url, _timeout in calls],
+            [
+                "https://primary.invalid/v1/chat/completions",
+                "https://fallback.invalid/v1/chat/completions",
+            ],
+        )
+        self.assertEqual([timeout for _url, timeout in calls], [120, 120])
+        self.assertEqual(json.loads(content)["status"], "success")
+
+    def test_call_llm_http_403_without_fallback_remains_non_retryable(self) -> None:
+        attempts = {"count": 0}
+
+        class AlwaysForbiddenOpener:
+            def open(self, req: Any, timeout: int | None = None) -> Any:  # noqa: ARG002
+                attempts["count"] += 1
+                raise urllib.error.HTTPError(req.full_url, 403, "Forbidden", None, None)
+
+        with mock.patch.object(worker_runtime, "NO_PROXY_OPENER", AlwaysForbiddenOpener()):
+            with mock.patch.object(worker_runtime.time, "sleep", return_value=None):
+                with mock.patch.dict(
+                    os.environ,
+                    {
+                        "ARGUS_LLM_MAX_RETRIES": "3",
+                        "ARGUS_LLM_FALLBACK_CHAT_URLS": "",
+                    },
+                    clear=False,
+                ):
+                    with self.assertRaises(RuntimeError) as ctx:
+                        worker_runtime.call_llm(
+                            "system",
+                            "user",
+                            "automation",
+                            {
+                                "api_key": "key",
+                                "api_base": "https://primary.invalid/v1",
+                                "chat_url": "https://primary.invalid/v1/chat/completions",
+                                "model_name": "demo-model",
+                            },
+                        )
+
+        message = str(ctx.exception)
+        self.assertIn("class=http_403", message)
+        self.assertIn("attempts=1/3", message)
+        self.assertEqual(attempts["count"], 1)
+
     def test_call_llm_raises_classified_tls_error_after_exhaustion(self) -> None:
         class AlwaysFailOpener:
             def open(self, req: Any, timeout: int | None = None) -> Any:  # noqa: ARG002


### PR DESCRIPTION
## Summary
- complete BL-20260325-042 by hardening automation endpoint authorization fallback behavior
- allow one bounded retry onto a distinct fallback endpoint when primary returns `HTTP 401/403`
- keep `HTTP 401/403` non-retryable when no fallback endpoint is configured
- add focused regression coverage and update backlog/work log for BL-042 -> BL-043 handoff

## Verification
- python3 -m unittest -v tests/test_argus_hardening.py
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py

Closes #77
