### PR TITLE
fix: harden multi-endpoint retry policy for BL-044

### DIFF
--- a/AUTOMATION_MULTI_ENDPOINT_POLICY_HARDENING_REPORT.md
+++ b/AUTOMATION_MULTI_ENDPOINT_POLICY_HARDENING_REPORT.md
@@ -1,0 +1,79 @@
+# Automation Multi-Endpoint Policy Hardening Report
+
+## Objective
+
+Complete `BL-20260325-044` by hardening automation multi-endpoint retry
+behavior for the mixed failure pattern confirmed in `BL-20260325-043`:
+
+- primary endpoint fails authorization (`http_403`)
+- fallback endpoint fails transport (`tls_eof`)
+- retry rotation can return to the known-auth-failed primary endpoint within the
+  same call, re-triggering a terminal `http_403` before critic dispatch
+
+This phase targets deterministic source-side policy hardening, not live runtime
+closure.
+
+## Scope
+
+In scope:
+
+- harden endpoint selection policy in `call_llm(...)` for the specific
+  auth-fallback path
+- keep retries bounded and behavior deterministic
+- add focused regression coverage for mixed auth/transport sequence
+
+Out of scope:
+
+- live governed execute rerun
+- endpoint credential rotation
+- infrastructure/network remediations external to repository code
+
+## Changes
+
+### 1) Added per-call endpoint quarantine after auth-fallback trigger
+
+Updated `dispatcher/worker_runtime.py`:
+
+- added helper `remove_endpoint_for_current_call(chat_urls, blocked_url)`
+- when a primary endpoint `http_401/http_403` activates the one-time
+  auth-fallback retry, the failed endpoint is removed from candidate rotation
+  for the remainder of the current call
+- emitted explicit log line:
+  - `Quarantined endpoint for current call due to authorization failure: <url>`
+
+Result:
+
+- current call no longer rotates back to a known-authorized-failed endpoint
+  after fallback transport retry
+- endpoint order stays deterministic and bounded inside the same retry budget
+
+### 2) Added focused mixed-failure regression coverage
+
+Updated `tests/test_argus_hardening.py`:
+
+- added
+  `test_call_llm_quarantines_primary_after_http_403_and_retries_fallback`
+- asserts call order under mixed failures with `max_retries=3` is:
+  - primary (`http_403`)
+  - fallback (`tls_eof`)
+  - fallback (success)
+- verifies timeout stability and successful structured response return
+
+## Verification
+
+Passed on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_argus_hardening.py`
+
+## Conclusion
+
+`BL-20260325-044` can be treated as complete as a source-side blocker-hardening
+phase.
+
+Automation runtime now quarantines authorization-failed primary endpoints for
+the remainder of a call once auth-fallback is triggered, preventing immediate
+re-entry into known-403 endpoints during the same retry cycle.
+
+Next required step: run a fresh same-origin governed validation to confirm this
+policy change improves end-to-end live execute progression to artifact
+generation and critic dispatch.

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -792,8 +792,8 @@ Allowed enum values:
 ### BL-20260325-044
 - title: Harden multi-endpoint automation runtime policy after BL-20260325-043 mixed auth/transport blocker
 - type: blocker
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-043
@@ -801,7 +801,24 @@ Allowed enum values:
 - done_when: Automation endpoint policy/runtime handling is hardened so governed execute has at least one reliable authorized endpoint path (with deterministic endpoint-order policy and explicit diagnostics), focused tests cover the mixed auth/transport failure path, and one blocker report records the mitigation
 - source: `POST_HTTP403_HARDENING_VALIDATION_REPORT.md` on 2026-03-25 records the new mixed blocker pattern (`primary=http_403`, `fallback=tls_eof`) after BL-20260325-042 behavior activation
 - link: /Users/lingguozhong/openclaw-team/AUTOMATION_MULTI_ENDPOINT_POLICY_HARDENING_REPORT.md
-- issue: deferred:phase=next until BL-20260325-043 lands on main
+- issue: -
+- evidence: `AUTOMATION_MULTI_ENDPOINT_POLICY_HARDENING_REPORT.md` records source-side hardening in `dispatcher/worker_runtime.py` that quarantines authorization-failed endpoints for the remainder of a call after auth-fallback activation, preventing deterministic retry rotation back to known-`http_403` primary endpoints, with focused mixed-failure regression coverage in `tests/test_argus_hardening.py`
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-045
+- title: Validate BL-20260325-044 multi-endpoint runtime policy hardening on a fresh same-origin governed candidate
+- type: mainline
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-044
+- start_when: `BL-20260325-044` is merged so a fresh same-origin governed run can verify whether endpoint quarantine policy prevents same-call return to known-`http_403` primary endpoint and improves progression toward artifact generation and critic dispatch
+- done_when: One governed validation creates a fresh same-origin preview candidate after BL-20260325-044, runs one explicit approval plus one real execute, and records whether runtime now avoids same-call primary-endpoint `http_403` re-entry after auth-fallback activation
+- source: `AUTOMATION_MULTI_ENDPOINT_POLICY_HARDENING_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation under real execute conditions
+- link: /Users/lingguozhong/openclaw-team/POST_MULTI_ENDPOINT_POLICY_HARDENING_VALIDATION_REPORT.md
+- issue: deferred:phase=next until BL-20260325-044 lands on main
 - evidence: -
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -1867,6 +1867,52 @@ Verification snapshot on 2026-03-25:
   - `runtime_archives/bl043/state/`
   - `runtime_archives/bl043/tmp/`
 
+### 52. Multi-Endpoint Policy Hardening After BL-043 Mixed Failure
+
+User objective:
+
+- continue from `BL-20260325-043` without forcing another live replay in the
+  same phase
+- harden source-side endpoint policy so auth-fallback calls do not rotate back
+  to a known `http_403` primary endpoint during the same retry cycle
+- keep the hardening bounded, deterministic, and test-backed
+
+Main work areas:
+
+- activated and completed `BL-20260325-044` as a source-side blocker-hardening
+  phase
+- updated `dispatcher/worker_runtime.py`:
+  - added `remove_endpoint_for_current_call(...)`
+  - in `call_llm(...)`, when `http_401/http_403` triggers bounded auth-fallback
+    retry, current failed endpoint is quarantined for the remainder of that call
+  - added explicit log for endpoint quarantine activation
+- expanded `tests/test_argus_hardening.py` with focused mixed-failure coverage:
+  - new test asserts call sequence
+    `[primary(http_403), fallback(tls_eof), fallback(success)]`
+  - verifies primary endpoint is not retried again within the same call after
+    quarantine
+- recorded next governed validation phase as `BL-20260325-045`
+
+Primary output:
+
+- [AUTOMATION_MULTI_ENDPOINT_POLICY_HARDENING_REPORT.md](/Users/lingguozhong/openclaw-team/AUTOMATION_MULTI_ENDPOINT_POLICY_HARDENING_REPORT.md)
+
+Key result:
+
+- `BL-20260325-044` completed as a source-side hardening phase
+- runtime retry behavior now avoids same-call re-entry to authorization-failed
+  primary endpoints once auth-fallback path is activated
+- live runtime effectiveness remains intentionally deferred to fresh governed
+  validation phase `BL-20260325-045`
+
+Verification snapshot on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_argus_hardening.py` passed
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed with no phase=now actionable issue
+  mirroring required
+- `bash scripts/premerge_check.sh` passed with `Warnings: 0` and `Failures: 0`
+
 ### 31. Post-Timeout Governed Validation On Fresh Same-Origin Candidate
 
 User objective:

--- a/dispatcher/worker_runtime.py
+++ b/dispatcher/worker_runtime.py
@@ -389,6 +389,15 @@ def should_retry_auth_failure_on_fallback(error_class, attempt, max_attempts, ch
     return current_url != next_url
 
 
+def remove_endpoint_for_current_call(chat_urls, blocked_url):
+    if len(chat_urls) <= 1:
+        return chat_urls
+    filtered = [url for url in chat_urls if url != blocked_url]
+    if not filtered:
+        return chat_urls
+    return filtered
+
+
 # ==========================================
 # LLM Call with retry
 # ==========================================
@@ -458,6 +467,14 @@ def call_llm(system_prompt, user_prompt, worker, llm_settings):
                 ) from e
             if auth_fallback_retry:
                 log(worker, "INFO", "Authorization failure detected; retrying once on fallback endpoint.")
+                next_chat_urls = remove_endpoint_for_current_call(chat_urls, chat_url)
+                if next_chat_urls != chat_urls:
+                    chat_urls = next_chat_urls
+                    log(
+                        worker,
+                        "INFO",
+                        f"Quarantined endpoint for current call due to authorization failure: {chat_url}",
+                    )
             delay_seconds = 2 ** attempt
             next_url = chat_urls[(attempt + 1) % len(chat_urls)]
             log(worker, "INFO", f"Retrying LLM call in {delay_seconds}s (next_endpoint={next_url})")

--- a/tests/test_argus_hardening.py
+++ b/tests/test_argus_hardening.py
@@ -642,6 +642,74 @@ class ArgusHardeningTests(unittest.TestCase):
         self.assertIn("attempts=1/3", message)
         self.assertEqual(attempts["count"], 1)
 
+    def test_call_llm_quarantines_primary_after_http_403_and_retries_fallback(self) -> None:
+        calls: list[tuple[str, int]] = []
+        fallback_attempts = {"count": 0}
+
+        class FakeResponse:
+            def __enter__(self) -> "FakeResponse":
+                return self
+
+            def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+                return False
+
+            def read(self) -> bytes:
+                payload = {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": json.dumps({"status": "success", "summary": "ok"})
+                            }
+                        }
+                    ]
+                }
+                return json.dumps(payload).encode("utf-8")
+
+        class MixedFailureOpener:
+            def open(self, req: Any, timeout: int | None = None) -> FakeResponse:
+                calls.append((req.full_url, timeout or 0))
+                if "primary.invalid" in req.full_url:
+                    raise urllib.error.HTTPError(req.full_url, 403, "Forbidden", None, None)
+                fallback_attempts["count"] += 1
+                if fallback_attempts["count"] == 1:
+                    raise urllib.error.URLError(
+                        "[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol"
+                    )
+                return FakeResponse()
+
+        with mock.patch.object(worker_runtime, "NO_PROXY_OPENER", MixedFailureOpener()):
+            with mock.patch.object(worker_runtime.time, "sleep", return_value=None):
+                with mock.patch.dict(
+                    os.environ,
+                    {
+                        "ARGUS_LLM_MAX_RETRIES": "3",
+                        "ARGUS_LLM_FALLBACK_CHAT_URLS": "https://fallback.invalid/v1/chat/completions",
+                    },
+                    clear=False,
+                ):
+                    content = worker_runtime.call_llm(
+                        "system",
+                        "user",
+                        "automation",
+                        {
+                            "api_key": "key",
+                            "api_base": "https://primary.invalid/v1",
+                            "chat_url": "https://primary.invalid/v1/chat/completions",
+                            "model_name": "demo-model",
+                        },
+                    )
+
+        self.assertEqual(
+            [url for url, _timeout in calls],
+            [
+                "https://primary.invalid/v1/chat/completions",
+                "https://fallback.invalid/v1/chat/completions",
+                "https://fallback.invalid/v1/chat/completions",
+            ],
+        )
+        self.assertEqual([timeout for _url, timeout in calls], [120, 120, 120])
+        self.assertEqual(json.loads(content)["status"], "success")
+
     def test_call_llm_raises_classified_tls_error_after_exhaustion(self) -> None:
         class AlwaysFailOpener:
             def open(self, req: Any, timeout: int | None = None) -> Any:  # noqa: ARG002


### PR DESCRIPTION
## Summary
- quarantine primary endpoint for the current call when auth-fallback is triggered by http_401/http_403
- prevent same-call retry rotation back to known authorization-failed primary endpoint
- add focused regression test for mixed auth/transport failure sequence
- close BL-20260325-044 and record next governed validation phase BL-20260325-045

## Validation
- bash scripts/premerge_check.sh
- python3 -m unittest -v tests/test_argus_hardening.py
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py

## Risks
- behavior change is scoped to auth-fallback-triggered calls only; normal retry rotation is unchanged