### PR TITLE
fix: harden wrapper partial evidence semantics for BL-046

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -826,8 +826,8 @@ Allowed enum values:
 ### BL-20260325-046
 - title: Harden wrapper success/partial evidence semantics after BL-20260325-045 critic findings
 - type: blocker
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-045
@@ -835,7 +835,24 @@ Allowed enum values:
 - done_when: Source-side contract hardening aligns wrapper verdict behavior with best-effort evidence-backed partial semantics (without over-claiming success or over-failing reviewable partial outcomes), focused tests cover the targeted semantics, and one blocker report records the mitigation
 - source: `POST_MULTI_ENDPOINT_POLICY_HARDENING_VALIDATION_REPORT.md` on 2026-03-25 records that multi-endpoint policy blocker is no longer dominant in the governed run and the next blocker is critic-identified wrapper/delegate evidence semantics
 - link: /Users/lingguozhong/openclaw-team/WRAPPER_PARTIAL_EVIDENCE_SEMANTICS_HARDENING_REPORT.md
-- issue: deferred:phase=next until BL-20260325-045 lands on main
+- issue: https://github.com/Oscarling/openclaw-team/issues/84
+- evidence: `WRAPPER_PARTIAL_EVIDENCE_SEMANTICS_HARDENING_REPORT.md` records source-side contract hardening in `adapters/local_inbox_adapter.py` that explicitly distinguishes wrapper success-only evidence gates from contract-compliant partial outcomes, adds partial-evidence guidance and next-step requirements, and is covered by focused regressions in `tests/test_local_inbox_adapter.py`
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-047
+- title: Validate BL-20260325-046 wrapper partial-evidence semantics hardening on a fresh same-origin governed candidate
+- type: mainline
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-046
+- start_when: `BL-20260325-046` is merged so a fresh same-origin governed run can verify whether updated wrapper contract semantics reduce recurrence of critic findings around success-vs-partial evidence handling under real execute
+- done_when: One governed validation creates a fresh same-origin preview candidate after BL-20260325-046, runs one explicit approval plus one real execute, and records whether critic findings shift away from wrapper partial-evidence semantics
+- source: `WRAPPER_PARTIAL_EVIDENCE_SEMANTICS_HARDENING_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation rather than assuming source-side semantic hardening success without live evidence
+- link: /Users/lingguozhong/openclaw-team/POST_WRAPPER_PARTIAL_EVIDENCE_SEMANTICS_VALIDATION_REPORT.md
+- issue: deferred:phase=next until BL-20260325-046 lands on main
 - evidence: -
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -1981,6 +1981,56 @@ Verification snapshot on 2026-03-25:
   - `runtime_archives/bl045/state/`
   - `runtime_archives/bl045/tmp/`
 
+### 54. Wrapper Partial-Evidence Semantics Hardening After BL-045 Findings
+
+User objective:
+
+- continue from `BL-20260325-045` without mixing another governed runtime rerun
+  into the same phase
+- harden source-side wrapper contract guidance so best-effort
+  evidence-backed `partial` outcomes remain reviewable partial states instead
+  of being escalated to failure by success-only gates
+- keep the hardening minimal, explicit, and test-backed
+
+Main work areas:
+
+- activated and completed `BL-20260325-046` and mirrored it to GitHub issue
+  `#84`
+- updated `adapters/local_inbox_adapter.py`:
+  - refined `delegate_success_evidence` hint so strict evidence gates are
+    explicitly scoped to wrapper `success` claims
+  - added `delegate_partial_evidence` guidance requiring contract-compliant
+    delegate `partial` outcomes to remain wrapper `partial`
+  - added explicit next-step guidance requirement for partial/failed wrapper
+    outputs
+  - expanded constraints and acceptance criteria to encode success-vs-partial
+    behavior boundaries
+- expanded `tests/test_local_inbox_adapter.py` with focused assertions for:
+  - new partial-evidence hint semantics
+  - new constraint enforcing `partial` (not `failed`) on contract-compliant
+    partial evidence paths
+  - new acceptance criterion covering non-escalation of partial outcomes
+- recorded next governed validation phase as `BL-20260325-047`
+
+Primary output:
+
+- [WRAPPER_PARTIAL_EVIDENCE_SEMANTICS_HARDENING_REPORT.md](/Users/lingguozhong/openclaw-team/WRAPPER_PARTIAL_EVIDENCE_SEMANTICS_HARDENING_REPORT.md)
+
+Key result:
+
+- `BL-20260325-046` completed as a source-side blocker-hardening phase
+- wrapper contract text now explicitly preserves honest, reviewable `partial`
+  outcomes while keeping strict anti-overclaim gates for `success`
+- live effectiveness is intentionally deferred to fresh governed validation
+  phase `BL-20260325-047`
+
+Verification snapshot on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_local_inbox_adapter.py` passed
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed with no phase=now actionable issue
+  mirroring required
+
 ### 31. Post-Timeout Governed Validation On Fresh Same-Origin Candidate
 
 User objective:

--- a/WRAPPER_PARTIAL_EVIDENCE_SEMANTICS_HARDENING_REPORT.md
+++ b/WRAPPER_PARTIAL_EVIDENCE_SEMANTICS_HARDENING_REPORT.md
@@ -1,0 +1,74 @@
+# Wrapper Partial-Evidence Semantics Hardening Report
+
+## Objective
+
+Complete `BL-20260325-046` by hardening source-side wrapper contract guidance so
+best-effort evidence-backed `partial` outcomes are treated as first-class
+reviewable states (not implicitly escalated to `failed`) while preserving strict
+anti-overclaim gates for wrapper `success` claims.
+
+## Scope
+
+In scope:
+
+- update local inbox automation contract hints for success-vs-partial semantics
+- update wrapper constraints/acceptance criteria to require explicit limitations
+  and next-step guidance for contract-compliant partial outcomes
+- focused regression coverage for the updated guidance text
+
+Out of scope:
+
+- live governed rerun in this phase
+- changes to worker runtime retry implementation
+- changes to external endpoint credentials/network conditions
+
+## Changes
+
+### 1) Refined wrapper success-vs-partial guidance
+
+Updated `adapters/local_inbox_adapter.py`:
+
+- strengthened `delegate_success_evidence` hint to clarify that strict evidence
+  gates apply when wrapper status is `success`
+- added new `delegate_partial_evidence` hint requiring:
+  - contract-compliant delegate `partial` evidence to remain wrapper `partial`
+  - no escalation to `failed` solely because success-only gates are unmet
+  - explicit limitations and next-step guidance in wrapper output
+
+### 2) Strengthened policy text in constraints and acceptance criteria
+
+Updated automation task contract text in `adapters/local_inbox_adapter.py`:
+
+- added explicit constraint requiring wrapper to keep evidence-backed partial
+  outcomes as `partial` and include next-step guidance
+- added explicit acceptance criterion that contract-compliant `partial`
+  outcomes must not be escalated to `failed` by success-only gates
+
+### 3) Added focused regression assertions
+
+Updated `tests/test_local_inbox_adapter.py`:
+
+- extended contract-hint assertions to cover new partial-evidence guidance
+- added checks for new constraint and acceptance-criteria text ensuring
+  success-vs-partial semantics remain explicit and enforced
+
+## Verification
+
+Passed on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_local_inbox_adapter.py`
+- `python3 scripts/backlog_lint.py`
+- `python3 scripts/backlog_sync.py`
+
+## Conclusion
+
+`BL-20260325-046` can be treated as complete as a source-side blocker-hardening
+phase.
+
+The local inbox contract now explicitly preserves honest, reviewable `partial`
+outcomes while keeping strict evidence requirements for wrapper `success`
+claims.
+
+Next required step: run a fresh same-origin governed validation to verify that
+updated source-side semantics reduce recurrence of critic findings under real
+execute conditions.

--- a/adapters/local_inbox_adapter.py
+++ b/adapters/local_inbox_adapter.py
@@ -330,7 +330,14 @@ def normalize_local_inbox_payload(
                         "success. Require delegate status=success, total_files>=1, dry_run=false, "
                         "status_counter.failed=0, status_counter.partial=0, and explicit output "
                         "attestation fields excel_written=true, output_exists=true, and "
-                        "output_size_bytes>0."
+                        "output_size_bytes>0. Apply these gates only when wrapper status is "
+                        "success."
+                    ),
+                    "delegate_partial_evidence": (
+                        "For best-effort readonly flows, if delegate status is partial and "
+                        "structured evidence is present, keep wrapper status partial instead of "
+                        "escalating to failed solely because success-only gates are unmet. "
+                        "Surface explicit limitations and next-step guidance in wrapper output."
                     ),
                     "delegate_timeout": (
                         "Bound delegate subprocess execution with an explicit timeout and "
@@ -388,6 +395,7 @@ def normalize_local_inbox_payload(
             "For readonly reviewable preview flows, only delegate to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py unless failing honestly.",
             "Do not claim wrapper success from exit code plus output existence alone when the reviewed delegate report does not provide strong enough success evidence.",
             "When wrapper reports success, enforce delegate evidence gates: status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, excel_written=true, output_exists=true, and output_size_bytes>0.",
+            "If delegate reports partial with structured evidence in readonly best-effort mode, keep wrapper status partial (not failed) and include explicit limitations with next-step guidance.",
             "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
             "When delegate emits JSON to stdout, parse that report directly instead of depending only on sidecar report-file discovery.",
             "When wrapper passes a sidecar report path to the reviewed delegate, use --report-json exactly unless the reviewed delegate explicitly supports another alias.",
@@ -406,6 +414,7 @@ def normalize_local_inbox_payload(
             "Relative preferred_base_script resolution remains portable and does not depend on Path.cwd().",
             "Wrapper success requires stronger delegate evidence than zero exit code plus a non-empty output file alone.",
             "Wrapper success attestation requires delegate fields excel_written=true, output_exists=true, output_size_bytes>0, and status_counter.partial/status_counter.failed equal to 0.",
+            "Contract-compliant delegate partial outcomes remain partial with explicit limitations and next-step guidance, rather than being escalated to failed by success-only gates.",
             "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
             "Delegate report handoff can consume JSON printed to stdout without relying exclusively on report sidecar file discovery.",
             "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",

--- a/tests/test_local_inbox_adapter.py
+++ b/tests/test_local_inbox_adapter.py
@@ -106,6 +106,10 @@ Execution contract: treat this as a best-effort, evidence-backed PDF extraction/
         self.assertIn("excel_written=true", contract_hints["delegate_success_evidence"])
         self.assertIn("output_exists=true", contract_hints["delegate_success_evidence"])
         self.assertIn("output_size_bytes>0", contract_hints["delegate_success_evidence"])
+        self.assertIn("wrapper status is success", contract_hints["delegate_success_evidence"])
+        self.assertIn("status is partial", contract_hints["delegate_partial_evidence"])
+        self.assertIn("status partial instead of escalating to failed", contract_hints["delegate_partial_evidence"])
+        self.assertIn("next-step guidance", contract_hints["delegate_partial_evidence"])
         self.assertIn("explicit timeout", contract_hints["delegate_timeout"])
         self.assertIn(
             "status/total_files/status_counter/dry_run",
@@ -163,6 +167,12 @@ Execution contract: treat this as a best-effort, evidence-backed PDF extraction/
         )
         self.assertTrue(
             any(
+                "keep wrapper status partial (not failed)" in item
+                for item in auto_task["constraints"]
+            )
+        )
+        self.assertTrue(
+            any(
                 "emits JSON to stdout" in item
                 for item in auto_task["constraints"]
             )
@@ -199,6 +209,10 @@ Execution contract: treat this as a best-effort, evidence-backed PDF extraction/
         )
         self.assertIn(
             "Wrapper success attestation requires delegate fields excel_written=true, output_exists=true, output_size_bytes>0, and status_counter.partial/status_counter.failed equal to 0.",
+            auto_task["acceptance_criteria"],
+        )
+        self.assertIn(
+            "Contract-compliant delegate partial outcomes remain partial with explicit limitations and next-step guidance, rather than being escalated to failed by success-only gates.",
             auto_task["acceptance_criteria"],
         )
         self.assertIn(


### PR DESCRIPTION
## Summary
- refine local inbox contract hints to distinguish success-only evidence gates from contract-compliant partial outcomes
- add explicit partial-evidence guidance to keep wrapper status partial (not failed) when delegate returns structured partial evidence
- add next-step guidance requirement for partial/failed wrapper outcomes
- expand constraints and acceptance criteria for success-vs-partial behavior boundaries
- close BL-20260325-046 and register next governed validation BL-20260325-047

Closes #84

## Validation
- python3 -m unittest -v tests/test_local_inbox_adapter.py
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh