### PR TITLE
fix: harden delegate ocr status reporting semantics for BL-048

### DIFF
--- a/DELEGATE_OCR_STATUS_REPORTING_HARDENING_REPORT.md
+++ b/DELEGATE_OCR_STATUS_REPORTING_HARDENING_REPORT.md
@@ -1,0 +1,75 @@
+# Delegate OCR/Status Reporting Hardening Report
+
+## Objective
+
+Complete `BL-20260325-048` by hardening delegate OCR/status/reporting semantics
+so best-effort readonly outcomes remain truthful and evidence-rich, addressing
+critic findings surfaced in `BL-20260325-047`.
+
+## Scope
+
+In scope:
+
+- refine delegate per-file status semantics when text exists but extraction
+  attempts include errors
+- enrich delegate JSON report with per-file evidence and actionable guidance
+- add focused tests for delegate status/report contract behavior
+
+Out of scope:
+
+- live governed rerun in this phase
+- runtime endpoint/retry policy changes
+- Trello or finalization flow changes
+
+## Changes
+
+### 1) Hardened per-file status semantics for mixed extraction outcomes
+
+Updated `artifacts/scripts/pdf_to_excel_ocr.py`:
+
+- in `process_one_pdf(...)`, when text is extracted but OCR/extraction errors are
+  present, status is now `partial` (with explicit warning) instead of always
+  `success`
+- this prevents over-claiming successful extraction in mixed-evidence paths and
+  keeps outcomes aligned with best-effort honesty
+
+### 2) Enriched delegate report contract for reviewability
+
+Updated `artifacts/scripts/pdf_to_excel_ocr.py` report payload:
+
+- added `files` with per-file structured evidence (`FileResult` fields)
+- added `notes` and `next_steps` for actionable guidance
+- preserved existing aggregate fields (`status`, `status_counter`,
+  `total_files`, output attestation) for compatibility
+- added `next_steps` on no-file path and write-failure path to improve
+  downstream diagnosis quality
+
+### 3) Added focused regression tests
+
+Added `tests/test_pdf_to_excel_ocr_script.py`:
+
+- verifies per-file status is `partial` when text exists but OCR step fails
+- verifies clean extraction path remains `success`
+- verifies `main()` report includes `files`, `notes`, and `next_steps` with
+  partial evidence guidance
+
+## Verification
+
+Passed on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_script.py`
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py`
+- `python3 scripts/backlog_lint.py`
+- `python3 scripts/backlog_sync.py`
+
+## Conclusion
+
+`BL-20260325-048` can be treated as complete as a source-side blocker-hardening
+phase.
+
+Delegate outcomes and reporting are now more evidence-rich and semantically
+conservative for best-effort readonly flows.
+
+Next required step: run a fresh same-origin governed validation to verify
+whether critic findings on delegate OCR/status/reporting evidence quality are
+reduced under real execute.

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -860,8 +860,8 @@ Allowed enum values:
 ### BL-20260325-048
 - title: Harden delegate OCR/status reporting semantics after BL-20260325-047 critic blocker
 - type: blocker
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-047
@@ -869,7 +869,24 @@ Allowed enum values:
 - done_when: Source-side delegate/report hardening ensures OCR/status outcomes remain truthful and evidence-rich for best-effort readonly flows, focused tests cover the targeted semantics, and one blocker report records the mitigation
 - source: `POST_WRAPPER_PARTIAL_EVIDENCE_SEMANTICS_VALIDATION_REPORT.md` on 2026-03-25 records the remaining dominant blocker as delegate-side OCR/status/report evidence quality after BL-20260325-046 activation
 - link: /Users/lingguozhong/openclaw-team/DELEGATE_OCR_STATUS_REPORTING_HARDENING_REPORT.md
-- issue: deferred:phase=next until BL-20260325-047 lands on main
+- issue: https://github.com/Oscarling/openclaw-team/issues/88
+- evidence: `DELEGATE_OCR_STATUS_REPORTING_HARDENING_REPORT.md` records source-side hardening in `artifacts/scripts/pdf_to_excel_ocr.py` that preserves truthful per-file status semantics for mixed extraction outcomes and enriches delegate JSON evidence (`files`, `notes`, `next_steps`), with focused regressions in `tests/test_pdf_to_excel_ocr_script.py`
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-049
+- title: Validate BL-20260325-048 delegate OCR/status reporting hardening on a fresh same-origin governed candidate
+- type: mainline
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-048
+- start_when: `BL-20260325-048` is merged so a fresh same-origin governed run can verify whether updated delegate OCR/status/report semantics reduce recurrence of critic findings under real execute
+- done_when: One governed validation creates a fresh same-origin preview candidate after BL-20260325-048, runs one explicit approval plus one real execute, and records whether critic findings shift away from delegate OCR/status/reporting evidence quality
+- source: `DELEGATE_OCR_STATUS_REPORTING_HARDENING_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation rather than assuming delegate-hardening success without live evidence
+- link: /Users/lingguozhong/openclaw-team/POST_DELEGATE_OCR_STATUS_REPORTING_VALIDATION_REPORT.md
+- issue: deferred:phase=next until BL-20260325-048 lands on main
 - evidence: -
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -2100,6 +2100,55 @@ Verification snapshot on 2026-03-25:
   - `runtime_archives/bl047/state/`
   - `runtime_archives/bl047/tmp/`
 
+### 56. Delegate OCR/Status Reporting Hardening After BL-047 Findings
+
+User objective:
+
+- continue from `BL-20260325-047` without mixing another governed runtime rerun
+  into the same phase
+- harden delegate OCR/status/report semantics so best-effort readonly outcomes
+  remain truthful and evidence-rich
+- keep the hardening focused, test-backed, and compatible with existing report
+  consumers
+
+Main work areas:
+
+- activated and completed `BL-20260325-048` and mirrored it to GitHub issue
+  `#88`
+- updated `artifacts/scripts/pdf_to_excel_ocr.py`:
+  - refined `process_one_pdf(...)` semantics so mixed outcomes with extracted
+    text plus extraction errors are represented as `partial` instead of
+    over-claiming `success`
+  - enriched aggregate report payload with per-file `files` evidence,
+    `notes`, and actionable `next_steps`
+  - added guidance fields for no-file and write-failure paths
+- added focused regression file `tests/test_pdf_to_excel_ocr_script.py`:
+  - verifies mixed extraction path status semantics
+  - verifies clean success path behavior
+  - verifies report includes `files` / `notes` / `next_steps`
+- recorded next governed validation phase as `BL-20260325-049`
+
+Primary output:
+
+- [DELEGATE_OCR_STATUS_REPORTING_HARDENING_REPORT.md](/Users/lingguozhong/openclaw-team/DELEGATE_OCR_STATUS_REPORTING_HARDENING_REPORT.md)
+
+Key result:
+
+- `BL-20260325-048` completed as a source-side blocker-hardening phase
+- delegate report contract is now more evidence-rich and semantically
+  conservative for readonly best-effort flows
+- live effectiveness is intentionally deferred to fresh governed validation
+  phase `BL-20260325-049`
+
+Verification snapshot on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_script.py` passed
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py` passed
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed with no phase=now actionable issue
+  mirroring required
+- `bash scripts/premerge_check.sh` passed with `Warnings: 0` and `Failures: 0`
+
 ### 31. Post-Timeout Governed Validation On Fresh Same-Origin Candidate
 
 User objective:

--- a/artifacts/scripts/pdf_to_excel_ocr.py
+++ b/artifacts/scripts/pdf_to_excel_ocr.py
@@ -206,7 +206,11 @@ def process_one_pdf(
             status = "partial"
             warnings.append("No extractable text captured")
     else:
-        status = "success"
+        if errors:
+            status = "partial"
+            warnings.append("Text was extracted, but one or more extraction attempts failed; review errors")
+        else:
+            status = "success"
 
     return FileResult(
         file_name=pdf_path.name,
@@ -273,12 +277,16 @@ def main() -> int:
                 "output_xlsx": str(output_xlsx),
                 "ocr_mode": args.ocr,
                 "total_files": 0,
+                "files": [],
                 "status_counter": {},
                 "dry_run": bool(args.dry_run),
                 "excel_written": False,
                 "output_exists": False,
                 "output_size_bytes": 0,
                 "notes": [f"No PDF files found under {input_dir}"],
+                "next_steps": [
+                    "Add one or more .pdf files under the input directory and rerun.",
+                ],
             },
             args.report_json,
         )
@@ -315,12 +323,25 @@ def main() -> int:
     for item in results:
         status_counter[item.status] = status_counter.get(item.status, 0) + 1
 
+    files_payload = [asdict(item) for item in results]
     failed_count = status_counter.get("failed", 0)
     partial_count = status_counter.get("partial", 0)
     if failed_count == 0 and partial_count == 0:
         aggregate_status = "success"
     else:
         aggregate_status = "partial"
+
+    notes: list[str] = []
+    next_steps: list[str] = []
+    if ocr_runtime != "available":
+        notes.append(f"OCR runtime status is {ocr_runtime}; missing dependencies: {', '.join(missing) or 'none'}")
+        next_steps.append("Install missing OCR runtime dependencies if OCR fallback is required.")
+    if partial_count > 0:
+        notes.append(f"{partial_count} file(s) reported partial status.")
+        next_steps.append("Inspect per-file partial records in `files` and address listed warnings/errors.")
+    if failed_count > 0:
+        notes.append(f"{failed_count} file(s) reported failed status.")
+        next_steps.append("Inspect per-file failures in `files` and resolve the extraction or OCR error causes.")
 
     report = {
         "status": aggregate_status,
@@ -330,11 +351,14 @@ def main() -> int:
         "ocr_runtime_status": ocr_runtime,
         "ocr_missing_dependencies": missing,
         "total_files": len(results),
+        "files": files_payload,
         "status_counter": status_counter,
         "dry_run": bool(args.dry_run),
         "excel_written": False,
         "output_exists": False,
         "output_size_bytes": 0,
+        "notes": notes,
+        "next_steps": next_steps,
     }
 
     if args.dry_run:
@@ -356,6 +380,8 @@ def main() -> int:
         if report["output_exists"]:
             report["output_size_bytes"] = int(output_xlsx.stat().st_size)
         report["excel_written"] = bool(report["output_exists"] and report["output_size_bytes"] > 0)
+        report["notes"] = report.get("notes", []) + ["Excel write step failed after extraction."]
+        report["next_steps"] = report.get("next_steps", []) + ["Check pandas/openpyxl availability and output path permissions."]
         emit_report(report, args.report_json)
         return 3
 

--- a/tests/test_pdf_to_excel_ocr_script.py
+++ b/tests/test_pdf_to_excel_ocr_script.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "artifacts" / "scripts" / "pdf_to_excel_ocr.py"
+
+
+def load_script_module():
+    spec = importlib.util.spec_from_file_location("pdf_to_excel_ocr", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load module from {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class PdfToExcelOcrScriptTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.script = load_script_module()
+
+    def test_process_one_pdf_returns_partial_when_text_exists_but_ocr_fails(self) -> None:
+        with mock.patch.object(self.script, "extract_text_pypdf", return_value=("base text", 1)):
+            with mock.patch.object(self.script, "extract_text_ocr", side_effect=RuntimeError("ocr boom")):
+                result = self.script.process_one_pdf(
+                    Path("/tmp/sample.pdf"),
+                    ocr_mode="on",
+                    ocr_lang="chi_sim+eng",
+                    auto_ocr_min_chars=50,
+                )
+
+        self.assertEqual(result.status, "partial")
+        self.assertIn("OCR failed", result.error)
+        self.assertIn("Text was extracted", result.warnings)
+
+    def test_process_one_pdf_success_without_errors(self) -> None:
+        with mock.patch.object(self.script, "extract_text_pypdf", return_value=("plain text", 2)):
+            result = self.script.process_one_pdf(
+                Path("/tmp/sample.pdf"),
+                ocr_mode="off",
+                ocr_lang="chi_sim+eng",
+                auto_ocr_min_chars=50,
+            )
+
+        self.assertEqual(result.status, "success")
+        self.assertEqual(result.error, "")
+        self.assertEqual(result.extract_method, "text")
+        self.assertEqual(result.page_count, 2)
+
+    def test_main_report_includes_files_notes_and_next_steps(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="pdf-to-excel-ocr-script-") as tmp:
+            tmpdir = Path(tmp)
+            input_dir = tmpdir / "input"
+            input_dir.mkdir(parents=True, exist_ok=True)
+            output_xlsx = tmpdir / "output.xlsx"
+            sample_pdf = input_dir / "sample.pdf"
+            sample_pdf.write_bytes(b"%PDF-1.4\n")
+
+            args = SimpleNamespace(
+                input_dir=str(input_dir),
+                output_xlsx=str(output_xlsx),
+                ocr="auto",
+                dry_run=True,
+                ocr_lang="chi_sim+eng",
+                auto_ocr_min_chars=50,
+                report_json="",
+            )
+            partial_file = self.script.FileResult(
+                file_name="sample.pdf",
+                file_path=str(sample_pdf),
+                status="partial",
+                extract_method="text",
+                page_count=1,
+                text_chars=10,
+                text_preview="preview",
+                warnings="warn",
+                error="",
+            )
+
+            stdout = io.StringIO()
+            with mock.patch.object(self.script, "parse_args", return_value=args):
+                with mock.patch.object(self.script, "discover_pdfs", return_value=[sample_pdf]):
+                    with mock.patch.object(self.script, "detect_ocr_runtime_status", return_value=("partial", ["binary tesseract"])):
+                        with mock.patch.object(self.script, "process_one_pdf", return_value=partial_file):
+                            with contextlib.redirect_stdout(stdout):
+                                exit_code = self.script.main()
+
+        self.assertEqual(exit_code, 0)
+        report = json.loads(stdout.getvalue())
+        self.assertEqual(report["status"], "partial")
+        self.assertEqual(len(report["files"]), 1)
+        self.assertEqual(report["files"][0]["status"], "partial")
+        self.assertTrue(any("OCR runtime status" in note for note in report["notes"]))
+        self.assertTrue(any("Inspect per-file partial records" in step for step in report["next_steps"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- refine delegate per-file status semantics in mixed extraction paths (text extracted + extraction errors => partial)
- enrich delegate report payload with files/notes/next_steps for evidence-backed reviewability
- add focused delegate tests in tests/test_pdf_to_excel_ocr_script.py
- close BL-20260325-048 and register fresh governed validation phase BL-20260325-049

Closes #88

## Validation
- python3 -m unittest -v tests/test_pdf_to_excel_ocr_script.py
- python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh
