### PR TITLE
BL-20260325-050: harden wrapper provenance/path traceability semantics

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -894,8 +894,8 @@ Allowed enum values:
 ### BL-20260325-050
 - title: Harden wrapper provenance/path traceability semantics after BL-20260325-049 critic findings
 - type: blocker
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-049
@@ -903,7 +903,24 @@ Allowed enum values:
 - done_when: Source-side wrapper hardening removes path-resolution ambiguity, strengthens provenance and readonly traceability attestations, and one blocker report records mitigation with focused tests
 - source: `POST_DELEGATE_OCR_STATUS_REPORTING_VALIDATION_REPORT.md` on 2026-03-25 records the next required phase as wrapper-level provenance/path traceability hardening after delegate evidence semantics were validated
 - link: /Users/lingguozhong/openclaw-team/WRAPPER_PROVENANCE_PATH_TRACEABILITY_HARDENING_REPORT.md
-- issue: deferred:phase=next until BL-20260325-049 lands on main
+- issue: https://github.com/Oscarling/openclaw-team/issues/92
+- evidence: `WRAPPER_PROVENANCE_PATH_TRACEABILITY_HARDENING_REPORT.md` records source-side hardening in `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py` that enforces deterministic repo-root delegate path resolution, adds explicit provenance and readonly traceability attestation fields, and is covered by focused regressions in `tests/test_pdf_to_excel_ocr_inbox_runner.py`
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-051
+- title: Validate BL-20260325-050 wrapper provenance/path traceability hardening on a fresh same-origin governed candidate
+- type: mainline
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-050
+- start_when: `BL-20260325-050` is merged so a fresh same-origin governed run can verify whether wrapper provenance/path/readonly traceability hardening reduces recurrence of critic findings under real execute
+- done_when: One governed validation creates a fresh same-origin preview candidate after BL-20260325-050, runs one explicit approval plus one real execute, and records whether critic findings shift away from wrapper provenance/path traceability concerns
+- source: `WRAPPER_PROVENANCE_PATH_TRACEABILITY_HARDENING_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation rather than assuming wrapper hardening success without live evidence
+- link: /Users/lingguozhong/openclaw-team/POST_WRAPPER_PROVENANCE_PATH_TRACEABILITY_VALIDATION_REPORT.md
+- issue: deferred:phase=next until BL-20260325-050 lands on main
 - evidence: -
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -2902,3 +2902,50 @@ Verification snapshot on 2026-03-25:
   - `execution.status = rejected`
   - `execution.executed = true`
   - `execution.attempts = 3`
+
+### 58. Wrapper Provenance/Path Traceability Hardening After BL-049 Findings
+
+User objective:
+
+- continue the next planned phase without drift
+- harden wrapper provenance/path traceability semantics after BL-049 critic focus
+  shift
+- preserve existing best-effort status semantics and verification flow
+
+Main work areas:
+
+- activated `BL-20260325-050` and mirrored it to issue `#92`
+- hardened `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py` with:
+  - deterministic delegate path resolution strategy (`absolute` vs
+    `repo_root_relative`)
+  - explicit path-resolution provenance payload (`requested`, `expanded`,
+    `strategy`, `resolved`, `within_repo_root`, `repo_relative_path`)
+  - repository-boundary guard for reviewed-script mode
+  - explicit `run_id`, `provenance`, and `readonly_attestation` summary blocks
+  - improved delegate JSON parsing fallback for trailing-json stdout lines
+- expanded focused regressions in
+  `tests/test_pdf_to_excel_ocr_inbox_runner.py` to cover:
+  - deterministic repo-root resolution assertions
+  - repository-boundary rejection for escape paths
+  - required provenance/readonly traceability attestation fields
+- produced blocker closeout report and prepared next validation phase item
+
+Primary output:
+
+- [WRAPPER_PROVENANCE_PATH_TRACEABILITY_HARDENING_REPORT.md](/Users/lingguozhong/openclaw-team/WRAPPER_PROVENANCE_PATH_TRACEABILITY_HARDENING_REPORT.md)
+
+Key result:
+
+- `BL-20260325-050` is complete as a source-side blocker-hardening phase
+- wrapper now emits explicit, machine-readable provenance/traceability evidence
+  instead of relying on implicit path behavior
+- delegate path resolution is deterministic and boundary-aware in reviewed-script
+  mode
+- next phase `BL-20260325-051` is defined as fresh governed validation
+
+Verification snapshot on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py` passed
+  `10/10`
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed with BL-050 issue mirror to `#92`

--- a/WRAPPER_PROVENANCE_PATH_TRACEABILITY_HARDENING_REPORT.md
+++ b/WRAPPER_PROVENANCE_PATH_TRACEABILITY_HARDENING_REPORT.md
@@ -1,0 +1,89 @@
+# Wrapper Provenance/Path Traceability Hardening Report
+
+## Objective
+
+Complete `BL-20260325-050` by hardening wrapper provenance/path traceability
+semantics after `BL-20260325-049` critic findings, while preserving existing
+best-effort evidence-backed status behavior.
+
+## Scope
+
+In scope:
+
+- remove path-resolution ambiguity for delegate script selection
+- strengthen readonly provenance and traceability attestation in wrapper summary
+- add focused tests covering path-boundary and traceability contract behavior
+
+Out of scope:
+
+- live governed rerun in this phase
+- delegate OCR algorithm changes
+- Trello writeback or finalization behavior changes
+
+## Changes
+
+### 1) Path-resolution strategy is now single-rule and audit-visible
+
+Updated `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`:
+
+- replaced implicit path handling with a deterministic delegate resolution model:
+  - absolute path -> resolve as absolute
+  - relative path -> resolve strictly from `REPO_ROOT`
+- added `provenance.delegate_path_resolution` fields in summary:
+  - `requested`, `expanded`, `strategy`, `resolved`,
+    `within_repo_root`, `repo_relative_path`
+- added repository-boundary guard so default reviewed-script mode cannot escape
+  the repository root
+
+### 2) Readonly provenance/traceability attestation strengthened
+
+Updated wrapper summary payload with explicit contract evidence:
+
+- `run_id` for stable run traceability
+- `provenance` block:
+  - `runner_path`, `repo_root`, `origin_id`
+  - `delegate_path_resolution`
+  - `input_dir_resolution` with discovery mode
+- `readonly_attestation` block:
+  - `mode = local_filesystem_delegate_only`
+  - `network_calls_performed = false`
+  - `trello_write_performed = false`
+  - `delegate_restricted_to_reviewed_script`
+  - explicit statement of local-only behavior
+
+### 3) Delegate report parsing robustness improved
+
+Updated wrapper report parsing:
+
+- still supports whole-stdout JSON object
+- now also supports trailing JSON line extraction when stdout includes extra logs
+
+### 4) Focused regressions expanded
+
+Updated `tests/test_pdf_to_excel_ocr_inbox_runner.py`:
+
+- extended path-resolution test to assert deterministic
+  `repo_root_relative` strategy and repo-relative resolved path
+- added test that rejects delegate path escaping repository root
+- added test that enforces provenance/readonly attestation fields
+- preserved existing behavior tests for dry-run/partial/success-gating/timeout
+
+## Verification
+
+Passed on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py`
+- `python3 scripts/backlog_lint.py`
+- `python3 scripts/backlog_sync.py`
+
+## Conclusion
+
+`BL-20260325-050` can be treated as complete as a source-side blocker-hardening
+phase.
+
+Wrapper output now carries explicit provenance/path/readonly attestation
+semantics, and delegate path resolution is deterministic and boundary-aware.
+
+Next required step: run a fresh same-origin governed validation to verify
+whether critic findings shift away from wrapper provenance/path traceability
+concerns under real execute.

--- a/artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
+++ b/artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
@@ -41,18 +41,44 @@ def expand_path(path_str: str) -> Path:
     return Path(path_str).expanduser()
 
 
-def resolve_repo_relative_path(path_str: str) -> Path:
-    path = expand_path(path_str)
-    if not path.is_absolute():
-        path = REPO_ROOT / path
-    return path.resolve()
+def repo_relative_path(path: Path) -> str | None:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return None
 
 
-def resolve_delegate_script(path_str: str) -> Path:
-    return resolve_repo_relative_path(path_str)
+def resolve_delegate_script(path_str: str) -> tuple[Path, dict[str, Any]]:
+    requested = expand_path(path_str)
+    if requested.is_absolute():
+        resolved = requested.resolve()
+        strategy = "absolute"
+    else:
+        # Keep one deterministic rule for relative delegate paths.
+        resolved = (REPO_ROOT / requested).resolve()
+        strategy = "repo_root_relative"
+
+    relative_to_repo = repo_relative_path(resolved)
+    resolution = {
+        "requested": path_str,
+        "expanded": str(requested),
+        "strategy": strategy,
+        "resolved": str(resolved),
+        "within_repo_root": relative_to_repo is not None,
+        "repo_relative_path": relative_to_repo,
+    }
+    return resolved, resolution
 
 
 def validate_delegate_script(base_script: Path) -> str | None:
+    reviewed_in_repo = repo_relative_path(REVIEWED_BASE_SCRIPT) is not None
+    base_in_repo = repo_relative_path(base_script) is not None
+
+    if reviewed_in_repo and not base_in_repo:
+        return (
+            "Preferred base script must stay within repository root "
+            f"{REPO_ROOT} to preserve readonly provenance boundaries."
+        )
     if base_script != REVIEWED_BASE_SCRIPT:
         return (
             "Preferred base script must resolve to the reviewed repository script "
@@ -80,12 +106,22 @@ def parse_delegate_report(stdout_text: str) -> dict[str, Any] | None:
     stripped = stdout_text.strip()
     if not stripped:
         return None
+
     try:
         payload = json.loads(stripped)
     except json.JSONDecodeError:
-        return None
+        payload = None
+
     if isinstance(payload, dict):
         return payload
+
+    for line in reversed([line.strip() for line in stripped.splitlines() if line.strip()]):
+        try:
+            candidate = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(candidate, dict):
+            return candidate
     return None
 
 
@@ -156,9 +192,11 @@ def emit_summary(summary: dict[str, Any], summary_json: str) -> None:
 def main() -> int:
     args = build_parser().parse_args()
 
+    requested_at = utc_now()
+    run_id = "bl050-wrapper-" + requested_at.replace(":", "").replace("-", "").replace(".", "")
     input_dir = expand_path(args.input_dir)
     output_xlsx = expand_path(args.output_xlsx)
-    base_script = resolve_delegate_script(args.preferred_base_script)
+    base_script, delegate_resolution = resolve_delegate_script(args.preferred_base_script)
     pdfs = discover_pdfs(input_dir)
     readonly_labels_present = any(str(label).strip().lower() == "readonly" for label in args.labels)
     delegate_contract_error = validate_delegate_script(base_script)
@@ -166,7 +204,8 @@ def main() -> int:
     summary: dict[str, Any] = {
         "status": "failed",
         "runner": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
-        "requested_at": utc_now(),
+        "requested_at": requested_at,
+        "run_id": run_id,
         "origin": {
             "origin_id": args.origin_id,
             "title": args.title,
@@ -179,6 +218,7 @@ def main() -> int:
             "ocr": args.ocr,
             "dry_run": args.dry_run,
             "preferred_base_script": str(base_script),
+            "preferred_base_script_requested": args.preferred_base_script,
             "reference_docs": args.reference_docs,
         },
         "contract": {
@@ -190,6 +230,28 @@ def main() -> int:
             "delegate_success_evidence_policy": (
                 "Require delegate report status=success, total_files>=1, no failed files, "
                 "and a real XLSX artifact before the wrapper reports success."
+            ),
+        },
+        "provenance": {
+            "runner_path": str(RUNNER_PATH),
+            "repo_root": str(REPO_ROOT),
+            "origin_id": args.origin_id,
+            "delegate_path_resolution": delegate_resolution,
+            "input_dir_resolution": {
+                "requested": args.input_dir,
+                "resolved": str(input_dir.resolve()),
+                "discovery_mode": "recursive_rglob_*.pdf",
+            },
+        },
+        "readonly_attestation": {
+            "mode": "local_filesystem_delegate_only",
+            "network_calls_performed": False,
+            "trello_write_performed": False,
+            "readonly_label_present": readonly_labels_present,
+            "delegate_restricted_to_reviewed_script": delegate_contract_error is None,
+            "statement": (
+                "Wrapper performs local file discovery and local delegate execution only; "
+                "it performs no Trello writeback and no direct network calls."
             ),
         },
         "discovery": {
@@ -216,6 +278,9 @@ def main() -> int:
             "If XLSX output cannot be produced honestly, the runner reports failure instead of writing mismatched content.",
         ],
     }
+
+    if not readonly_labels_present:
+        summary["notes"].append("Readonly label is missing; preserving conservative local-only execution contract.")
 
     if output_xlsx.suffix.lower() != ".xlsx":
         summary["notes"].append("Requested output path does not end with .xlsx; refusing mismatched workbook contract.")

--- a/tests/test_pdf_to_excel_ocr_inbox_runner.py
+++ b/tests/test_pdf_to_excel_ocr_inbox_runner.py
@@ -123,6 +123,15 @@ class PdfToExcelOcrInboxRunnerTests(unittest.TestCase):
             summary["parameters"]["preferred_base_script"],
             str((REPO_ROOT / "artifacts" / "scripts" / "pdf_to_excel_ocr.py").resolve()),
         )
+        self.assertEqual(
+            summary["provenance"]["delegate_path_resolution"]["strategy"],
+            "repo_root_relative",
+        )
+        self.assertEqual(
+            summary["provenance"]["delegate_path_resolution"]["repo_relative_path"],
+            "artifacts/scripts/pdf_to_excel_ocr.py",
+        )
+        self.assertTrue(summary["provenance"]["delegate_path_resolution"]["within_repo_root"])
 
     def test_rejects_unreviewed_delegate_script(self) -> None:
         input_dir = self._make_input_dir(with_pdf=True)
@@ -138,7 +147,26 @@ class PdfToExcelOcrInboxRunnerTests(unittest.TestCase):
         self.assertEqual(summary["status"], "failed")
         self.assertFalse(summary["execution"]["delegated"])
         self.assertFalse(summary["contract"]["readonly_delegate_verified"])
-        self.assertTrue(any("reviewed repository script" in note for note in summary["notes"]))
+        self.assertTrue(
+            any(
+                ("reviewed repository script" in note) or ("within repository root" in note)
+                for note in summary["notes"]
+            )
+        )
+
+    def test_rejects_delegate_path_outside_repo_root(self) -> None:
+        input_dir = self._make_input_dir(with_pdf=True)
+
+        exit_code, summary, _ = self._invoke_main(
+            input_dir=input_dir,
+            extra_args=["--preferred-base-script", "../../outside-repo/delegate.py"],
+        )
+
+        self.assertEqual(exit_code, 5)
+        self.assertEqual(summary["status"], "failed")
+        self.assertFalse(summary["execution"]["delegated"])
+        self.assertFalse(summary["provenance"]["delegate_path_resolution"]["within_repo_root"])
+        self.assertTrue(any("within repository root" in note for note in summary["notes"]))
 
     def test_propagates_delegate_partial_status_when_output_exists(self) -> None:
         input_dir = self._make_input_dir(with_pdf=True)
@@ -240,6 +268,20 @@ class PdfToExcelOcrInboxRunnerTests(unittest.TestCase):
         self.assertIn("Traceability:", self.runner.DEFAULT_DESCRIPTION)
         self.assertIn("BL-20260324-014", self.runner.DEFAULT_DESCRIPTION)
         self.assertNotIn("...", self.runner.DEFAULT_DESCRIPTION)
+
+    def test_emits_provenance_and_readonly_attestation(self) -> None:
+        input_dir = self._make_input_dir(with_pdf=False)
+
+        exit_code, summary, _ = self._invoke_main(input_dir=input_dir)
+
+        self.assertEqual(exit_code, 0)
+        self.assertIn("run_id", summary)
+        self.assertEqual(summary["readonly_attestation"]["mode"], "local_filesystem_delegate_only")
+        self.assertFalse(summary["readonly_attestation"]["network_calls_performed"])
+        self.assertFalse(summary["readonly_attestation"]["trello_write_performed"])
+        self.assertTrue(summary["readonly_attestation"]["readonly_label_present"])
+        self.assertIn("delegate_path_resolution", summary["provenance"])
+        self.assertIn("input_dir_resolution", summary["provenance"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary\n- complete BL-050 wrapper provenance/path traceability hardening\n- add deterministic delegate path resolution and readonly attestation fields\n- expand focused wrapper regressions and close blocker report\n\n## Validation\n- python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py\n- python3 scripts/backlog_lint.py\n- python3 scripts/backlog_sync.py\n- bash scripts/premerge_check.sh\n\nCloses #92