### PR TITLE
BL-20260325-052: harden automation endpoint/auth runtime resilience

### DIFF
--- a/AUTOMATION_ENDPOINT_AUTH_RUNTIME_RESILIENCE_HARDENING_REPORT.md
+++ b/AUTOMATION_ENDPOINT_AUTH_RUNTIME_RESILIENCE_HARDENING_REPORT.md
@@ -1,0 +1,78 @@
+# Automation Endpoint/Auth Runtime Resilience Hardening Report
+
+## Objective
+
+Complete `BL-20260325-052` by hardening automation runtime endpoint/auth
+resilience after `BL-20260325-051` pre-critic failures (`http_520` / `http_401`).
+
+## Scope
+
+In scope:
+
+- improve LLM retry classification for transient upstream gateway failures
+- preserve existing auth-fallback quarantine behavior
+- add focused regressions for mixed failure sequences observed in governed runs
+
+Out of scope:
+
+- live governed rerun in this phase
+- secrets rotation or credential provisioning changes
+- Trello/read-only ingest behavior changes
+
+## Changes
+
+### 1) Expanded retryable HTTP classification for upstream transient failures
+
+Updated `dispatcher/worker_runtime.py`:
+
+- introduced `RETRYABLE_HTTP_STATUS_CODES` constant
+- added transient upstream/proxy status codes to retryable set:
+  - `520`, `521`, `522`, `523`, `524`
+- kept existing retryable codes (`408`, `409`, `425`, `429`, `500`, `502`,
+  `503`, `504`)
+
+Effect:
+
+- `classify_llm_call_error(...)` now treats `http_520` class failures as
+  retryable instead of immediate exhaustion on first attempt.
+
+### 2) Preserved endpoint quarantine flow for auth failures under mixed profiles
+
+No contract-breaking behavior changes were made to auth-fallback logic itself.
+With `http_520` now retryable, mixed sequences can now progress through existing
+logic:
+
+- transient upstream failure (`520`) -> retry to fallback endpoint
+- fallback auth failure (`401`) -> one-time auth-fallback quarantine/retry
+- retry on remaining endpoint for recovery opportunity
+
+## Test Coverage
+
+Updated `tests/test_argus_hardening.py` with focused regressions:
+
+- `test_classify_llm_call_error_marks_http_520_as_retryable`
+- `test_call_llm_retries_http_520_then_recovers_after_fallback_http_401`
+
+These tests validate the targeted BL-051 failure pattern and ensure resilience
+improvement is preserved.
+
+## Verification
+
+Passed on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_argus_hardening.py` (13/13)
+- `python3 scripts/backlog_lint.py`
+- `python3 scripts/backlog_sync.py`
+
+## Conclusion
+
+`BL-20260325-052` can be treated as complete as a source-side blocker-hardening
+phase.
+
+Automation runtime classification now gives transient `http_520` failures a
+retry path, enabling endpoint rotation and auth-quarantine mechanisms to engage
+before exhausting the run.
+
+Next required step: run a fresh same-origin governed validation to confirm
+runtime now reaches critic dispatch more reliably under the active endpoint/auth
+profile.

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -928,8 +928,8 @@ Allowed enum values:
 ### BL-20260325-052
 - title: Harden automation endpoint/auth runtime resilience after BL-20260325-051 pre-critic blocker
 - type: blocker
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-051
@@ -937,7 +937,24 @@ Allowed enum values:
 - done_when: Source-side automation runtime hardening improves endpoint/auth handling so one governed execute can reliably progress beyond automation dispatch under the active environment profile, and one blocker report records mitigation with focused tests
 - source: `POST_WRAPPER_PROVENANCE_PATH_TRACEABILITY_VALIDATION_REPORT.md` on 2026-03-25 records that BL-050 validation remained inconclusive due pre-critic automation endpoint/auth runtime failures
 - link: /Users/lingguozhong/openclaw-team/AUTOMATION_ENDPOINT_AUTH_RUNTIME_RESILIENCE_HARDENING_REPORT.md
-- issue: deferred:phase=next until BL-20260325-051 lands on main
+- issue: https://github.com/Oscarling/openclaw-team/issues/96
+- evidence: `AUTOMATION_ENDPOINT_AUTH_RUNTIME_RESILIENCE_HARDENING_REPORT.md` records source-side hardening in `dispatcher/worker_runtime.py` that classifies upstream `http_520-524` as retryable transient failures and preserves auth-fallback quarantine flow, with focused regressions in `tests/test_argus_hardening.py` covering `http_520 -> http_401 -> recovery` behavior
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-053
+- title: Validate BL-20260325-052 automation endpoint/auth runtime resilience hardening on a fresh same-origin governed candidate
+- type: mainline
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-052
+- start_when: `BL-20260325-052` is merged so a fresh same-origin governed run can verify whether automation now progresses beyond pre-critic endpoint/auth blockers under real execute
+- done_when: One governed validation creates a fresh same-origin preview candidate after BL-20260325-052, runs one explicit approval plus one real execute, and records whether runtime reaches critic dispatch more reliably
+- source: `AUTOMATION_ENDPOINT_AUTH_RUNTIME_RESILIENCE_HARDENING_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation under real execute conditions
+- link: /Users/lingguozhong/openclaw-team/POST_AUTOMATION_ENDPOINT_AUTH_RUNTIME_RESILIENCE_VALIDATION_REPORT.md
+- issue: deferred:phase=next until BL-20260325-052 lands on main
 - evidence: -
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -3010,3 +3010,42 @@ Verification snapshot on 2026-03-25:
   - `execution.status = rejected`
   - `execution.executed = true`
   - `execution.attempts = 3`
+
+### 60. Automation Endpoint/Auth Runtime Resilience Hardening After BL-051 Blocker
+
+User objective:
+
+- continue next blocker phase without drift
+- harden automation endpoint/auth runtime handling after BL-051 pre-critic
+  failures (`http_520` / `http_401`)
+
+Main work areas:
+
+- activated `BL-20260325-052` and mirrored it to issue `#96`
+- updated `dispatcher/worker_runtime.py` to widen transient retry classification:
+  - added `RETRYABLE_HTTP_STATUS_CODES`
+  - expanded retryable HTTP set to include upstream/proxy transient
+    `520/521/522/523/524`
+- preserved existing auth-fallback quarantine mechanism and validated mixed-path
+  recovery behavior under the new classification
+- expanded focused regressions in `tests/test_argus_hardening.py`:
+  - `test_classify_llm_call_error_marks_http_520_as_retryable`
+  - `test_call_llm_retries_http_520_then_recovers_after_fallback_http_401`
+- produced blocker hardening report and prepared next governed validation item
+
+Primary output:
+
+- [AUTOMATION_ENDPOINT_AUTH_RUNTIME_RESILIENCE_HARDENING_REPORT.md](/Users/lingguozhong/openclaw-team/AUTOMATION_ENDPOINT_AUTH_RUNTIME_RESILIENCE_HARDENING_REPORT.md)
+
+Key result:
+
+- `BL-20260325-052` is complete as a source-side blocker-hardening phase
+- automation runtime no longer treats `http_520` as immediate terminal failure;
+  it now retries and can flow into fallback/quarantine recovery path
+- next phase `BL-20260325-053` is defined as fresh governed validation
+
+Verification snapshot on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_argus_hardening.py` passed `13/13`
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed with BL-052 issue mirror to `#96`

--- a/dispatcher/worker_runtime.py
+++ b/dispatcher/worker_runtime.py
@@ -85,6 +85,22 @@ DEFAULT_LLM_MAX_RETRIES = 3
 MAX_ARTIFACT_SIZE = 2 * 1024 * 1024  # 2MB
 NO_PROXY_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
 HTTP_USER_AGENT = "Mozilla/5.0"
+RETRYABLE_HTTP_STATUS_CODES = {
+    408,
+    409,
+    425,
+    429,
+    500,
+    502,
+    503,
+    504,
+    # Common upstream/proxy transient errors (for example Cloudflare-class gateways).
+    520,
+    521,
+    522,
+    523,
+    524,
+}
 ALLOWED_STATUSES = {"success", "failed", "partial"}
 ARTIFACT_TYPE_BY_PREFIX = {
     "artifacts/architecture/": "architecture",
@@ -370,8 +386,7 @@ def classify_llm_call_error(error):
     if "remote end closed connection" in lowered:
         return "remote_closed", True
     if status_code is not None:
-        retryable_codes = {408, 409, 425, 429, 500, 502, 503, 504}
-        return f"http_{status_code}", status_code in retryable_codes
+        return f"http_{status_code}", status_code in RETRYABLE_HTTP_STATUS_CODES
     if isinstance(error, TimeoutError):
         return "timeout", True
     return "unknown", True

--- a/tests/test_argus_hardening.py
+++ b/tests/test_argus_hardening.py
@@ -710,6 +710,78 @@ class ArgusHardeningTests(unittest.TestCase):
         self.assertEqual([timeout for _url, timeout in calls], [120, 120, 120])
         self.assertEqual(json.loads(content)["status"], "success")
 
+    def test_call_llm_retries_http_520_then_recovers_after_fallback_http_401(self) -> None:
+        calls: list[tuple[str, int]] = []
+        primary_attempts = {"count": 0}
+
+        class FakeResponse:
+            def __enter__(self) -> "FakeResponse":
+                return self
+
+            def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+                return False
+
+            def read(self) -> bytes:
+                payload = {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": json.dumps({"status": "success", "summary": "ok"})
+                            }
+                        }
+                    ]
+                }
+                return json.dumps(payload).encode("utf-8")
+
+        class MixedFailureOpener:
+            def open(self, req: Any, timeout: int | None = None) -> FakeResponse:
+                calls.append((req.full_url, timeout or 0))
+                if "primary.invalid" in req.full_url:
+                    primary_attempts["count"] += 1
+                    if primary_attempts["count"] == 1:
+                        raise urllib.error.HTTPError(req.full_url, 520, "Web Server Returned an Unknown Error", None, None)
+                    return FakeResponse()
+                raise urllib.error.HTTPError(req.full_url, 401, "Unauthorized", None, None)
+
+        with mock.patch.object(worker_runtime, "NO_PROXY_OPENER", MixedFailureOpener()):
+            with mock.patch.object(worker_runtime.time, "sleep", return_value=None):
+                with mock.patch.dict(
+                    os.environ,
+                    {
+                        "ARGUS_LLM_MAX_RETRIES": "3",
+                        "ARGUS_LLM_FALLBACK_CHAT_URLS": "https://fallback.invalid/v1/chat/completions",
+                    },
+                    clear=False,
+                ):
+                    content = worker_runtime.call_llm(
+                        "system",
+                        "user",
+                        "automation",
+                        {
+                            "api_key": "key",
+                            "api_base": "https://primary.invalid/v1",
+                            "chat_url": "https://primary.invalid/v1/chat/completions",
+                            "model_name": "demo-model",
+                        },
+                    )
+
+        self.assertEqual(
+            [url for url, _timeout in calls],
+            [
+                "https://primary.invalid/v1/chat/completions",
+                "https://fallback.invalid/v1/chat/completions",
+                "https://primary.invalid/v1/chat/completions",
+            ],
+        )
+        self.assertEqual([timeout for _url, timeout in calls], [120, 120, 120])
+        self.assertEqual(json.loads(content)["status"], "success")
+
+    def test_classify_llm_call_error_marks_http_520_as_retryable(self) -> None:
+        err = urllib.error.HTTPError("https://primary.invalid/v1/chat/completions", 520, "Unknown Error", None, None)
+        error_class, retryable = worker_runtime.classify_llm_call_error(err)
+        self.assertEqual(error_class, "http_520")
+        self.assertTrue(retryable)
+
     def test_call_llm_raises_classified_tls_error_after_exhaustion(self) -> None:
         class AlwaysFailOpener:
             def open(self, req: Any, timeout: int | None = None) -> Any:  # noqa: ARG002


### PR DESCRIPTION
## Summary\n- complete BL-052 automation endpoint/auth runtime hardening\n- classify http_520-524 as retryable transient upstream failures\n- add focused regressions for 520->401->recovery sequence\n\n## Validation\n- python3 -m unittest -v tests/test_argus_hardening.py\n- python3 scripts/backlog_lint.py\n- python3 scripts/backlog_sync.py\n- bash scripts/premerge_check.sh\n\nCloses #96