### PR TITLE
fix: harden automation timeout runtime reliability for BL-054

### DIFF
--- a/AUTOMATION_TIMEOUT_RUNTIME_RELIABILITY_HARDENING_REPORT.md
+++ b/AUTOMATION_TIMEOUT_RUNTIME_RELIABILITY_HARDENING_REPORT.md
@@ -1,0 +1,104 @@
+# Automation Timeout Runtime Reliability Hardening Report
+
+## Objective
+
+Complete `BL-20260325-054` by hardening automation runtime timeout handling
+after `BL-20260325-053` confirmed pre-critic exhaustion on terminal timeout
+(`http_520 -> http_401 -> timeout`, exhausted at `3/3`).
+
+## Scope
+
+In scope:
+
+- add a targeted timeout-resilience mechanism in runtime retry flow
+- keep endpoint/auth fallback and quarantine behavior compatible with BL-052
+- add focused regressions for the exact mixed failure profile from BL-053
+
+Out of scope:
+
+- live governed rerun in this phase
+- endpoint credential provisioning or secret rotation
+- Trello/read-only ingest and preview approval workflow changes
+
+## Changes
+
+### 1) Added configurable terminal timeout recovery retry budget
+
+Updated `dispatcher/worker_runtime.py`:
+
+- introduced `DEFAULT_LLM_TIMEOUT_RECOVERY_RETRIES = 1`
+- added env-driven reader `llm_timeout_recovery_retries()` for
+  `ARGUS_LLM_TIMEOUT_RECOVERY_RETRIES` (minimum `0`)
+- added `should_grant_timeout_recovery_retry(...)` guard for:
+  - `error_class == timeout`
+  - retryable timeout
+  - currently terminal attempt
+  - remaining recovery budget > 0
+
+Effect:
+
+- runtime can grant one extra attempt when a retryable terminal timeout would
+  otherwise exhaust immediately.
+
+### 2) Made retry loop support bounded dynamic extension
+
+Updated `call_llm(...)`:
+
+- changed loop from fixed `for range(max_attempts)` to bounded `while` loop
+- when terminal timeout recovery criteria are met:
+  - decrement recovery budget
+  - extend `max_attempts` by one
+  - emit explicit runtime log line
+
+Effect:
+
+- preserves finite retry semantics while reducing timeout-only terminal exits in
+  the observed mixed failure path.
+
+### 3) Improved startup observability for timeout hardening settings
+
+Updated worker startup log line to include:
+
+- `timeout`
+- `attempts`
+- `timeout_recovery_retries`
+
+Effect:
+
+- governed runtime logs can now directly show whether timeout-recovery budget
+  was active during a run.
+
+## Test Coverage
+
+Updated `tests/test_argus_hardening.py` with focused regressions:
+
+- `test_call_llm_grants_terminal_timeout_recovery_retry_after_auth_quarantine`
+- `test_call_llm_can_disable_timeout_recovery_retry`
+
+Coverage intent:
+
+- validate default resilience path for BL-053-like sequence
+  (`520 -> 401 -> timeout -> recovery`)
+- validate explicit opt-out keeps old terminal behavior
+  (`ARGUS_LLM_TIMEOUT_RECOVERY_RETRIES=0` -> `attempts=3/3` timeout exhaustion)
+
+## Verification
+
+Passed on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_argus_hardening.py` (15/15)
+- `python3 scripts/backlog_lint.py`
+- `python3 scripts/backlog_sync.py`
+
+## Conclusion
+
+`BL-20260325-054` is complete as a source-side timeout/runtime reliability
+hardening phase.
+
+The automation runtime now has a bounded, configurable timeout recovery path
+that directly addresses the BL-053 terminal timeout blocker while retaining
+finite retries and existing endpoint/auth quarantine logic.
+
+Next required step: run one fresh same-origin governed validation to verify
+this hardening improves real execute progression to critic dispatch under live
+conditions.

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -962,8 +962,8 @@ Allowed enum values:
 ### BL-20260325-054
 - title: Harden automation timeout/runtime reliability after BL-20260325-053 pre-critic timeout blocker
 - type: blocker
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-053
@@ -971,7 +971,24 @@ Allowed enum values:
 - done_when: Source-side automation runtime hardening reduces timeout-induced pre-critic exhaustion and one blocker report records mitigation with focused tests
 - source: `POST_AUTOMATION_ENDPOINT_AUTH_RUNTIME_RESILIENCE_VALIDATION_REPORT.md` on 2026-03-25 records timeout reliability as the dominant unresolved pre-critic blocker after BL-052 activation
 - link: /Users/lingguozhong/openclaw-team/AUTOMATION_TIMEOUT_RUNTIME_RELIABILITY_HARDENING_REPORT.md
-- issue: deferred:phase=next until BL-20260325-053 lands on main
+- issue: https://github.com/Oscarling/openclaw-team/issues/100
+- evidence: `AUTOMATION_TIMEOUT_RUNTIME_RELIABILITY_HARDENING_REPORT.md` records source-side runtime hardening in `dispatcher/worker_runtime.py` that grants one configurable terminal timeout recovery retry before exhaustion, with focused regressions in `tests/test_argus_hardening.py` covering both default recovery (`520 -> 401 -> timeout -> recovery`) and explicit disable (`ARGUS_LLM_TIMEOUT_RECOVERY_RETRIES=0`)
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-055
+- title: Validate BL-20260325-054 automation timeout/runtime reliability hardening on a fresh same-origin governed candidate
+- type: mainline
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-054
+- start_when: `BL-20260325-054` is merged so a fresh same-origin governed run can verify whether timeout-resilience hardening consistently reaches critic dispatch after endpoint/auth recovery
+- done_when: One governed validation creates a fresh same-origin preview candidate after BL-20260325-054, runs one explicit approval plus one real execute, and records whether runtime now reaches critic dispatch without timeout exhaustion
+- source: `AUTOMATION_TIMEOUT_RUNTIME_RELIABILITY_HARDENING_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation under real execute conditions
+- link: /Users/lingguozhong/openclaw-team/POST_AUTOMATION_TIMEOUT_RUNTIME_RELIABILITY_VALIDATION_REPORT.md
+- issue: deferred:phase=next until BL-20260325-054 lands on main
 - evidence: -
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -2211,6 +2211,46 @@ Verification snapshot on 2026-03-25:
   - `execution.status = rejected`
   - `execution.executed = true`
   - `execution.attempts = 2`
+
+### 62. Automation Timeout Runtime Reliability Hardening After BL-053 Blocker
+
+User objective:
+
+- continue phase-by-phase without drift
+- harden automation runtime timeout reliability after BL-053 pre-critic timeout
+  exhaustion
+
+Main work areas:
+
+- activated `BL-20260325-054` and mirrored it to issue `#100`
+- updated `dispatcher/worker_runtime.py` to add bounded timeout recovery:
+  - introduced `ARGUS_LLM_TIMEOUT_RECOVERY_RETRIES` (default `1`)
+  - added terminal-timeout recovery guard
+  - switched retry loop to bounded dynamic `while` so one recovery attempt can
+    be granted without unbounded retries
+- kept existing endpoint/auth fallback quarantine semantics unchanged
+- expanded focused regressions in `tests/test_argus_hardening.py`:
+  - `test_call_llm_grants_terminal_timeout_recovery_retry_after_auth_quarantine`
+  - `test_call_llm_can_disable_timeout_recovery_retry`
+- produced blocker hardening report and prepared next governed validation item
+  (`BL-20260325-055`)
+
+Primary output:
+
+- [AUTOMATION_TIMEOUT_RUNTIME_RELIABILITY_HARDENING_REPORT.md](/Users/lingguozhong/openclaw-team/AUTOMATION_TIMEOUT_RUNTIME_RELIABILITY_HARDENING_REPORT.md)
+
+Key result:
+
+- `BL-20260325-054` is complete as a source-side blocker-hardening phase
+- runtime now supports one bounded, configurable terminal-timeout recovery
+  retry before exhaustion
+- next phase `BL-20260325-055` is defined as fresh governed validation
+
+Verification snapshot on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_argus_hardening.py` passed `15/15`
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed with BL-054 issue mirror to `#100`
 - automation worker:
   - task `AUTO-20260325-854`
   - `status = success`

--- a/dispatcher/worker_runtime.py
+++ b/dispatcher/worker_runtime.py
@@ -82,6 +82,7 @@ def read_int_env(name, default, *, minimum=1):
 # ==========================================
 DEFAULT_LLM_TIMEOUT_SECONDS = 120
 DEFAULT_LLM_MAX_RETRIES = 3
+DEFAULT_LLM_TIMEOUT_RECOVERY_RETRIES = 1
 MAX_ARTIFACT_SIZE = 2 * 1024 * 1024  # 2MB
 NO_PROXY_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({}))
 HTTP_USER_AGENT = "Mozilla/5.0"
@@ -158,6 +159,14 @@ def llm_max_retries():
         "ARGUS_LLM_MAX_RETRIES",
         DEFAULT_LLM_MAX_RETRIES,
         minimum=1,
+    )
+
+
+def llm_timeout_recovery_retries():
+    return read_int_env(
+        "ARGUS_LLM_TIMEOUT_RECOVERY_RETRIES",
+        DEFAULT_LLM_TIMEOUT_RECOVERY_RETRIES,
+        minimum=0,
     )
 
 
@@ -404,6 +413,20 @@ def should_retry_auth_failure_on_fallback(error_class, attempt, max_attempts, ch
     return current_url != next_url
 
 
+def should_grant_timeout_recovery_retry(
+    error_class,
+    retryable,
+    attempt,
+    max_attempts,
+    timeout_recovery_retries_remaining,
+):
+    if error_class != "timeout" or not retryable:
+        return False
+    if timeout_recovery_retries_remaining <= 0:
+        return False
+    return attempt >= max_attempts - 1
+
+
 def remove_endpoint_for_current_call(chat_urls, blocked_url):
     if len(chat_urls) <= 1:
         return chat_urls
@@ -419,6 +442,7 @@ def remove_endpoint_for_current_call(chat_urls, blocked_url):
 def call_llm(system_prompt, user_prompt, worker, llm_settings):
     timeout_seconds = llm_timeout_seconds()
     max_attempts = llm_max_retries()
+    timeout_recovery_retries_remaining = llm_timeout_recovery_retries()
     chat_urls = llm_candidate_chat_urls(llm_settings)
     payload = {
         "model": llm_settings["model_name"],
@@ -435,7 +459,8 @@ def call_llm(system_prompt, user_prompt, worker, llm_settings):
         "Connection": "close",
     }
     auth_fallback_retry_used = False
-    for attempt in range(max_attempts):
+    attempt = 0
+    while attempt < max_attempts:
         chat_url = chat_urls[attempt % len(chat_urls)]
         try:
             req = urllib.request.Request(
@@ -464,6 +489,24 @@ def call_llm(system_prompt, user_prompt, worker, llm_settings):
                 )
                 if auth_fallback_retry:
                     auth_fallback_retry_used = True
+            if should_grant_timeout_recovery_retry(
+                error_class=error_class,
+                retryable=retryable,
+                attempt=attempt,
+                max_attempts=max_attempts,
+                timeout_recovery_retries_remaining=timeout_recovery_retries_remaining,
+            ):
+                timeout_recovery_retries_remaining -= 1
+                max_attempts += 1
+                log(
+                    worker,
+                    "INFO",
+                    (
+                        "Granted timeout recovery retry; "
+                        f"extended max attempts to {max_attempts} "
+                        f"(remaining={timeout_recovery_retries_remaining})"
+                    ),
+                )
             effective_retryable = retryable or auth_fallback_retry
             log(
                 worker,
@@ -494,6 +537,7 @@ def call_llm(system_prompt, user_prompt, worker, llm_settings):
             next_url = chat_urls[(attempt + 1) % len(chat_urls)]
             log(worker, "INFO", f"Retrying LLM call in {delay_seconds}s (next_endpoint={next_url})")
             time.sleep(delay_seconds)
+            attempt += 1
     return ""
 
 
@@ -890,7 +934,8 @@ def run_worker(task_dir=None, worker_override=None, base_dir=None, llm_override=
                     "INFO",
                     "Worker started using endpoint "
                     f"{llm_settings['chat_url']} "
-                    f"(timeout={llm_timeout_seconds()}s, attempts={llm_max_retries()})",
+                    f"(timeout={llm_timeout_seconds()}s, attempts={llm_max_retries()}, "
+                    f"timeout_recovery_retries={llm_timeout_recovery_retries()})",
                 )
                 soul = load_soul(worker)
                 user_prompt = build_user_prompt(task)

--- a/tests/test_argus_hardening.py
+++ b/tests/test_argus_hardening.py
@@ -776,6 +776,139 @@ class ArgusHardeningTests(unittest.TestCase):
         self.assertEqual([timeout for _url, timeout in calls], [120, 120, 120])
         self.assertEqual(json.loads(content)["status"], "success")
 
+    def test_call_llm_grants_terminal_timeout_recovery_retry_after_auth_quarantine(self) -> None:
+        calls: list[tuple[str, int]] = []
+        primary_attempts = {"count": 0}
+
+        class FakeResponse:
+            def __enter__(self) -> "FakeResponse":
+                return self
+
+            def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> bool:
+                return False
+
+            def read(self) -> bytes:
+                payload = {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": json.dumps({"status": "success", "summary": "ok"})
+                            }
+                        }
+                    ]
+                }
+                return json.dumps(payload).encode("utf-8")
+
+        class TimeoutRecoveryOpener:
+            def open(self, req: Any, timeout: int | None = None) -> FakeResponse:
+                calls.append((req.full_url, timeout or 0))
+                if "primary.invalid" in req.full_url:
+                    primary_attempts["count"] += 1
+                    if primary_attempts["count"] == 1:
+                        raise urllib.error.HTTPError(
+                            req.full_url,
+                            520,
+                            "Web Server Returned an Unknown Error",
+                            None,
+                            None,
+                        )
+                    if primary_attempts["count"] == 2:
+                        raise TimeoutError("The read operation timed out")
+                    return FakeResponse()
+                raise urllib.error.HTTPError(req.full_url, 401, "Unauthorized", None, None)
+
+        with mock.patch.object(worker_runtime, "NO_PROXY_OPENER", TimeoutRecoveryOpener()):
+            with mock.patch.object(worker_runtime.time, "sleep", return_value=None):
+                with mock.patch.dict(
+                    os.environ,
+                    {
+                        "ARGUS_LLM_MAX_RETRIES": "3",
+                        "ARGUS_LLM_FALLBACK_CHAT_URLS": "https://fallback.invalid/v1/chat/completions",
+                    },
+                    clear=False,
+                ):
+                    content = worker_runtime.call_llm(
+                        "system",
+                        "user",
+                        "automation",
+                        {
+                            "api_key": "key",
+                            "api_base": "https://primary.invalid/v1",
+                            "chat_url": "https://primary.invalid/v1/chat/completions",
+                            "model_name": "demo-model",
+                        },
+                    )
+
+        self.assertEqual(
+            [url for url, _timeout in calls],
+            [
+                "https://primary.invalid/v1/chat/completions",
+                "https://fallback.invalid/v1/chat/completions",
+                "https://primary.invalid/v1/chat/completions",
+                "https://primary.invalid/v1/chat/completions",
+            ],
+        )
+        self.assertEqual([timeout for _url, timeout in calls], [120, 120, 120, 120])
+        self.assertEqual(primary_attempts["count"], 3)
+        self.assertEqual(json.loads(content)["status"], "success")
+
+    def test_call_llm_can_disable_timeout_recovery_retry(self) -> None:
+        calls: list[tuple[str, int]] = []
+        primary_attempts = {"count": 0}
+
+        class TimeoutStillFailsOpener:
+            def open(self, req: Any, timeout: int | None = None) -> Any:
+                calls.append((req.full_url, timeout or 0))
+                if "primary.invalid" in req.full_url:
+                    primary_attempts["count"] += 1
+                    if primary_attempts["count"] == 1:
+                        raise urllib.error.HTTPError(
+                            req.full_url,
+                            520,
+                            "Web Server Returned an Unknown Error",
+                            None,
+                            None,
+                        )
+                    raise TimeoutError("The read operation timed out")
+                raise urllib.error.HTTPError(req.full_url, 401, "Unauthorized", None, None)
+
+        with mock.patch.object(worker_runtime, "NO_PROXY_OPENER", TimeoutStillFailsOpener()):
+            with mock.patch.object(worker_runtime.time, "sleep", return_value=None):
+                with mock.patch.dict(
+                    os.environ,
+                    {
+                        "ARGUS_LLM_MAX_RETRIES": "3",
+                        "ARGUS_LLM_TIMEOUT_RECOVERY_RETRIES": "0",
+                        "ARGUS_LLM_FALLBACK_CHAT_URLS": "https://fallback.invalid/v1/chat/completions",
+                    },
+                    clear=False,
+                ):
+                    with self.assertRaises(RuntimeError) as ctx:
+                        worker_runtime.call_llm(
+                            "system",
+                            "user",
+                            "automation",
+                            {
+                                "api_key": "key",
+                                "api_base": "https://primary.invalid/v1",
+                                "chat_url": "https://primary.invalid/v1/chat/completions",
+                                "model_name": "demo-model",
+                            },
+                        )
+
+        message = str(ctx.exception)
+        self.assertIn("class=timeout", message)
+        self.assertIn("attempts=3/3", message)
+        self.assertEqual(
+            [url for url, _timeout in calls],
+            [
+                "https://primary.invalid/v1/chat/completions",
+                "https://fallback.invalid/v1/chat/completions",
+                "https://primary.invalid/v1/chat/completions",
+            ],
+        )
+        self.assertEqual([timeout for _url, timeout in calls], [120, 120, 120])
+
     def test_classify_llm_call_error_marks_http_520_as_retryable(self) -> None:
         err = urllib.error.HTTPError("https://primary.invalid/v1/chat/completions", 520, "Unknown Error", None, None)
         error_class, retryable = worker_runtime.classify_llm_call_error(err)


### PR DESCRIPTION
## Summary
- add bounded terminal-timeout recovery retry support in automation runtime
- keep endpoint/auth quarantine flow intact and configurable via env
- add focused regressions for recovery and explicit disable behavior
- close BL-054 docs and queue BL-055 governed validation

## Verification
- python3 -m unittest -v tests/test_argus_hardening.py
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh

Closes #100