### PR TITLE
fix: harden wrapper dry-run delegate propagation for BL-056

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -996,8 +996,8 @@ Allowed enum values:
 ### BL-20260325-056
 - title: Harden wrapper dry-run delegate propagation semantics after BL-20260325-055 critic needs_revision verdict
 - type: blocker
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-055
@@ -1005,7 +1005,24 @@ Allowed enum values:
 - done_when: Source-side wrapper hardening ensures dry-run semantics are propagated consistently to the reviewed delegate path, and one blocker report records mitigation with focused tests
 - source: `POST_AUTOMATION_TIMEOUT_RUNTIME_RELIABILITY_VALIDATION_REPORT.md` on 2026-03-25 records critic verdict `needs_revision` citing missing dry-run forwarding in the wrapper/delegate pair
 - link: /Users/lingguozhong/openclaw-team/WRAPPER_DRYRUN_DELEGATE_PROPAGATION_HARDENING_REPORT.md
-- issue: deferred:phase=next until BL-20260325-055 lands on main
+- issue: https://github.com/Oscarling/openclaw-team/issues/104
+- evidence: `WRAPPER_DRYRUN_DELEGATE_PROPAGATION_HARDENING_REPORT.md` records source-side hardening in `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py` that forwards `--dry-run` through the delegate path and preserves partial semantics from delegate dry-run evidence, with focused regression coverage in `tests/test_pdf_to_excel_ocr_inbox_runner.py`
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-057
+- title: Validate BL-20260325-056 wrapper dry-run delegate propagation hardening on a fresh same-origin governed candidate
+- type: mainline
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-056
+- start_when: `BL-20260325-056` is merged so a fresh same-origin governed run can verify whether critic no longer flags wrapper/delegate dry-run propagation semantics
+- done_when: One governed validation creates a fresh same-origin preview candidate after BL-20260325-056, runs one explicit approval plus one real execute, and records whether critic findings move away from dry-run propagation concerns
+- source: `WRAPPER_DRYRUN_DELEGATE_PROPAGATION_HARDENING_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation under real execute conditions
+- link: /Users/lingguozhong/openclaw-team/POST_WRAPPER_DRYRUN_DELEGATE_PROPAGATION_VALIDATION_REPORT.md
+- issue: deferred:phase=next until BL-20260325-056 lands on main
 - evidence: -
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -2315,6 +2315,45 @@ Verification snapshot on 2026-03-25:
   - `execution.status = rejected`
   - `execution.executed = true`
   - `execution.attempts = 2`
+
+### 64. Wrapper Dry-Run Delegate Propagation Hardening After BL-055 Critic Blocker
+
+User objective:
+
+- continue next blocker phase without drift
+- harden wrapper/delegate dry-run propagation semantics after BL-055 critic
+  `needs_revision` finding
+
+Main work areas:
+
+- activated `BL-20260325-056` and mirrored it to issue `#104`
+- updated `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`:
+  - removed dry-run early return before delegation
+  - now forwards `--dry-run` to delegate command when dry-run is requested
+  - keeps wrapper dry-run outcome conservative (`partial`) with explicit
+    delegate dry-run attestation notes
+- updated focused regression in `tests/test_pdf_to_excel_ocr_inbox_runner.py`:
+  - `test_dry_run_forwards_flag_to_delegate_and_returns_partial`
+- produced blocker hardening report and prepared next governed validation item
+  (`BL-20260325-057`)
+
+Primary output:
+
+- [WRAPPER_DRYRUN_DELEGATE_PROPAGATION_HARDENING_REPORT.md](/Users/lingguozhong/openclaw-team/WRAPPER_DRYRUN_DELEGATE_PROPAGATION_HARDENING_REPORT.md)
+
+Key result:
+
+- `BL-20260325-056` is complete as a source-side blocker-hardening phase
+- dry-run intent now propagates through wrapper -> reviewed delegate path with
+  explicit semantics
+- next phase `BL-20260325-057` is defined as fresh governed validation
+
+Verification snapshot on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py` passed
+  `10/10`
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed with BL-056 issue mirror to `#104`
 - automation worker:
   - task `AUTO-20260325-854`
   - `status = success`

--- a/WRAPPER_DRYRUN_DELEGATE_PROPAGATION_HARDENING_REPORT.md
+++ b/WRAPPER_DRYRUN_DELEGATE_PROPAGATION_HARDENING_REPORT.md
@@ -1,0 +1,82 @@
+# Wrapper Dry-Run Delegate Propagation Hardening Report
+
+## Objective
+
+Complete `BL-20260325-056` by hardening wrapper dry-run semantics after
+`BL-20260325-055` critic verdict `needs_revision` reported that dry-run intent
+was not propagated through the wrapper/delegate path.
+
+## Scope
+
+In scope:
+
+- harden `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py` dry-run path
+- preserve readonly/best-effort partial semantics
+- add focused regression for dry-run delegate flag propagation
+
+Out of scope:
+
+- governed live rerun in this phase
+- non-dry-run workflow redesign
+- Trello ingest/approval pipeline changes
+
+## Changes
+
+### 1) Forward dry-run intent to the reviewed delegate
+
+Updated `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`:
+
+- removed the early dry-run short-circuit before delegate execution
+- when `--dry-run true` is requested, wrapper now appends `--dry-run` to
+  delegate command
+- wrapper records explicit note that dry-run is forwarded end-to-end
+
+Effect:
+
+- wrapper/delegate pair now carries dry-run semantics explicitly instead of
+  dropping them before delegate handoff.
+
+### 2) Preserve conservative partial semantics for dry-run delegate outcomes
+
+Updated dry-run result handling in wrapper:
+
+- if delegate returns `0` under dry-run, wrapper status remains `partial`
+- wrapper no longer misclassifies dry-run as missing XLSX failure path
+- wrapper records whether delegate report attests `dry_run=true`
+
+Effect:
+
+- dry-run validation remains reviewable and truthful without overclaiming real
+  conversion success.
+
+## Test Coverage
+
+Updated `tests/test_pdf_to_excel_ocr_inbox_runner.py`:
+
+- replaced dry-run regression with
+  `test_dry_run_forwards_flag_to_delegate_and_returns_partial`
+
+This test validates:
+
+- wrapper delegates under dry-run
+- delegate command includes `--dry-run`
+- delegate report carries `dry_run=true`
+- wrapper final status remains `partial`
+
+## Verification
+
+Passed on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py` (10/10)
+- `python3 scripts/backlog_lint.py`
+- `python3 scripts/backlog_sync.py`
+
+## Conclusion
+
+`BL-20260325-056` is complete as a source-side blocker-hardening phase.
+
+Wrapper dry-run intent now propagates through the reviewed delegate path and
+preserves conservative partial semantics with explicit evidence.
+
+Next required step: run one fresh same-origin governed validation to confirm
+critic findings move away from dry-run propagation concerns.

--- a/artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
+++ b/artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
@@ -298,12 +298,6 @@ def main() -> int:
         emit_summary(summary, args.summary_json)
         return 0
 
-    if args.dry_run:
-        summary["status"] = "partial"
-        summary["notes"].append("Dry run requested; no conversion attempted and no XLSX output is claimed.")
-        emit_summary(summary, args.summary_json)
-        return 0
-
     if not base_script.exists():
         summary["notes"].append("Preferred base script was not found; no unsupported fallback conversion was attempted.")
         emit_summary(summary, args.summary_json)
@@ -321,6 +315,9 @@ def main() -> int:
     ]
     if args.ocr:
         cmd.extend(["--ocr", args.ocr])
+    if args.dry_run:
+        cmd.append("--dry-run")
+        summary["notes"].append("Dry run requested; forwarding --dry-run to delegate for end-to-end contract semantics.")
 
     summary["execution"]["delegated"] = True
     summary["execution"]["command"] = cmd
@@ -369,7 +366,18 @@ def main() -> int:
         if candidate in ALLOWED_SUMMARY_STATUSES:
             delegate_status = candidate
 
-    if completed.returncode == 0 and output_exists:
+    if args.dry_run:
+        if completed.returncode == 0:
+            summary["status"] = "partial"
+            if isinstance(delegate_report, dict) and bool(delegate_report.get("dry_run", False)):
+                summary["notes"].append("Delegate report confirmed dry_run=true.")
+            elif isinstance(delegate_report, dict):
+                summary["notes"].append("Delegate report did not attest dry_run=true; preserving partial status conservatively.")
+            else:
+                summary["notes"].append("Delegate did not emit a structured dry-run report; preserving partial status conservatively.")
+        else:
+            summary["notes"].append("Delegate script returned a non-zero exit code during dry-run mode.")
+    elif completed.returncode == 0 and output_exists:
         success_evidence_ok, success_evidence_note = has_strong_delegate_success_evidence(delegate_report)
         if delegate_status == "partial":
             summary["status"] = "partial"

--- a/tests/test_pdf_to_excel_ocr_inbox_runner.py
+++ b/tests/test_pdf_to_excel_ocr_inbox_runner.py
@@ -82,19 +82,43 @@ class PdfToExcelOcrInboxRunnerTests(unittest.TestCase):
         summary = json.loads(summary_path.read_text(encoding="utf-8"))
         return exit_code, summary, stdout.getvalue()
 
-    def test_dry_run_returns_partial_without_delegation(self) -> None:
+    def test_dry_run_forwards_flag_to_delegate_and_returns_partial(self) -> None:
         input_dir = self._make_input_dir(with_pdf=True)
+        fake_base = self.tmpdir / "fake_pdf_to_excel_ocr_dry_run.py"
+        fake_base.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env python3
+                import argparse
+                import json
+
+                parser = argparse.ArgumentParser()
+                parser.add_argument("--input-dir", required=True)
+                parser.add_argument("--output-xlsx", required=True)
+                parser.add_argument("--ocr", default="auto")
+                parser.add_argument("--dry-run", action="store_true")
+                args = parser.parse_args()
+
+                print(json.dumps({"status": "partial", "dry_run": bool(args.dry_run), "total_files": 1}))
+                """
+            ),
+            encoding="utf-8",
+        )
 
         exit_code, summary, _ = self._invoke_main(
             input_dir=input_dir,
-            extra_args=["--dry-run", "true"],
+            extra_args=["--dry-run", "true", "--preferred-base-script", str(fake_base)],
+            reviewed_base_script=fake_base,
         )
 
         self.assertEqual(exit_code, 0)
         self.assertEqual(summary["status"], "partial")
-        self.assertFalse(summary["execution"]["delegated"])
+        self.assertTrue(summary["execution"]["delegated"])
+        self.assertIn("--dry-run", summary["execution"]["command"])
+        self.assertIsInstance(summary["execution"]["delegate_report"], dict)
+        self.assertTrue(summary["execution"]["delegate_report"]["dry_run"])
         self.assertFalse(summary["output"]["exists"])
-        self.assertTrue(any("Dry run requested" in note for note in summary["notes"]))
+        self.assertTrue(any("forwarding --dry-run to delegate" in note for note in summary["notes"]))
 
     def test_zero_pdf_input_short_circuits_to_partial(self) -> None:
         input_dir = self._make_input_dir(with_pdf=False)


### PR DESCRIPTION
## Summary
- forward `--dry-run` from wrapper to reviewed delegate path
- preserve conservative partial semantics for dry-run delegate outcomes
- update dry-run regression test to assert delegate flag propagation
- close BL-056 docs and queue BL-057 governed validation

## Verification
- python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh

Closes #104