### PR TITLE
docs: close BL-057 validation and queue evidence-handoff blocker

### DIFF
--- a/POST_WRAPPER_DRYRUN_DELEGATE_PROPAGATION_VALIDATION_REPORT.md
+++ b/POST_WRAPPER_DRYRUN_DELEGATE_PROPAGATION_VALIDATION_REPORT.md
@@ -1,0 +1,170 @@
+# Post-Wrapper Dry-Run Delegate Propagation Validation Report
+
+## Objective
+
+Validate `BL-20260325-056` on one fresh same-origin governed candidate by
+running:
+
+- one live Trello read-only smoke
+- one explicit same-origin regeneration
+- one preview creation
+- one explicit approval
+- one real execute (`test_mode=off`)
+
+This phase objective is validation truth, not forcing a `pass` verdict.
+
+## Scope
+
+In scope:
+
+- one governed run against origin `trello:69c24cd3c1a2359ddd7a1bf8`
+- one regeneration token and one fresh preview candidate
+- runtime evidence capture for automation/critic progression
+- explicit recording of whether critic findings moved away from wrapper
+  dry-run propagation concerns after BL-056
+
+Out of scope:
+
+- source-code hardening inside this validation phase
+- git finalization and Trello Done writeback
+- additional live reruns beyond this one governed candidate
+
+## Pre-Run Checks
+
+- branch: `phase9l/validate-bl057-wrapper-dryrun-delegate-propagation`
+- Trello env loaded from `/tmp/trello_env.sh` with required credentials
+- OpenAI runtime values sourced from `secrets/`
+- execute step injected fallback endpoint env:
+  - `ARGUS_LLM_FALLBACK_CHAT_URLS=https://api.openai.com/v1/chat/completions`
+
+## Run Summary
+
+Target origin:
+
+- `trello:69c24cd3c1a2359ddd7a1bf8`
+
+Regeneration token:
+
+- `regen-20260325-bl057-001`
+
+### 1) Live Trello read-only smoke
+
+First sandboxed read:
+
+- blocked by DNS / sandbox network policy
+- error: `ConnectionError` / `NameResolutionError`
+- archive snapshot:
+  - `runtime_archives/bl057/tmp/bl057_smoke_sandbox.json`
+
+Elevated rerun:
+
+- `status = pass`
+- `read_count = 1`
+- archive snapshots:
+  - `runtime_archives/bl057/tmp/bl057_smoke_elevated.json`
+  - `runtime_archives/bl057/tmp/bl057_live_mapped_preview.json`
+
+### 2) Regenerated payload and preview ingest
+
+- generated inbox payload from elevated `smoke_read.mapped_preview` with token
+  `regen-20260325-bl057-001`
+- ingest decision:
+  - `status = processed`
+  - `decision = preview_created_pending_approval`
+  - `preview_id = preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf`
+- archive snapshot:
+  - `runtime_archives/bl057/tmp/bl057_ingest_once.json`
+
+### 3) Preview candidate and approval
+
+Generated preview:
+
+- `preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf`
+
+Pre-execute state:
+
+- `approved = false`
+- `execution.status = pending_approval`
+- `execution.attempts = 0`
+- `source.regeneration_token = regen-20260325-bl057-001`
+
+Approval file:
+
+- `approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf.json`
+
+### 4) Real execute (`test_mode=off`)
+
+First sandboxed execute:
+
+- rejected before worker dispatch
+- reason:
+  `Failed to initialize docker client from environment. Ensure Docker access is available or pass docker_client explicitly.`
+- archive snapshot:
+  - `runtime_archives/bl057/tmp/bl057_execute_once_sandbox.json`
+
+Elevated replay execute (`--preview-id ... --allow-replay`):
+
+- automation task created and completed:
+  - `AUTO-20260325-869`
+- critic task created and completed:
+  - `CRITIC-20260325-285`
+- run reached critic dispatch; no pre-critic timeout exhaustion blocker
+- final execute decision:
+  - `status = rejected`
+  - `decision_reason = critic_verdict=needs_revision`
+  - `critic_verdict = needs_revision`
+- archive snapshots:
+  - `runtime_archives/bl057/tmp/bl057_execute_once_elevated.json`
+  - `runtime_archives/bl057/runtime/automation-runtime.attempt-1.log`
+  - `runtime_archives/bl057/runtime/critic-runtime.attempt-1.log`
+  - `runtime_archives/bl057/runtime/automation-output.json`
+  - `runtime_archives/bl057/runtime/critic-output.json`
+  - `runtime_archives/bl057/runtime/critic-produced-pdf_to_excel_ocr_inbox_review.md`
+
+Final preview execution state:
+
+- `approved = true`
+- `execution.status = rejected`
+- `execution.executed = true`
+- `execution.attempts = 2`
+
+## Critical Findings
+
+This validation confirms BL-056 did not close the critic blocker under governed
+runtime execution:
+
+- runtime did progress to critic dispatch successfully
+- critic verdict remained `needs_revision`
+- dry-run propagation concern recurred in review findings
+- an additional evidence-handoff risk was flagged:
+  wrapper prefers stdout JSON scraping over explicit sidecar JSON when both are
+  present
+
+Inference from this run:
+
+- BL-056 source merge alone is insufficient to prevent governed recurrence of
+  wrapper/delegate contract issues
+- dominant unresolved blocker has shifted to enforcing contract preservation for
+  generated wrapper behavior (dry-run semantics + sidecar-first evidence
+  handling)
+
+## Validation Conclusion
+
+`BL-20260325-057` is complete as a governed validation phase.
+
+It answers the intended question with runtime evidence: critic findings did not
+move away from dry-run propagation concerns after BL-056 under this governed
+execute path.
+
+Next required phase: harden wrapper/delegate evidence-handoff contract so
+generated wrapper behavior consistently preserves dry-run propagation semantics
+and sidecar-first report truthfulness.
+
+## Archive Preservation
+
+To preserve runtime evidence and avoid loss from tracked artifact overwrite,
+this phase archived outputs under:
+
+- `runtime_archives/bl057/runtime/`
+- `runtime_archives/bl057/state/`
+- `runtime_archives/bl057/tmp/`

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -1013,8 +1013,8 @@ Allowed enum values:
 ### BL-20260325-057
 - title: Validate BL-20260325-056 wrapper dry-run delegate propagation hardening on a fresh same-origin governed candidate
 - type: mainline
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-056
@@ -1022,7 +1022,24 @@ Allowed enum values:
 - done_when: One governed validation creates a fresh same-origin preview candidate after BL-20260325-056, runs one explicit approval plus one real execute, and records whether critic findings move away from dry-run propagation concerns
 - source: `WRAPPER_DRYRUN_DELEGATE_PROPAGATION_HARDENING_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation under real execute conditions
 - link: /Users/lingguozhong/openclaw-team/POST_WRAPPER_DRYRUN_DELEGATE_PROPAGATION_VALIDATION_REPORT.md
-- issue: deferred:phase=next until BL-20260325-056 lands on main
+- issue: https://github.com/Oscarling/openclaw-team/issues/107
+- evidence: `POST_WRAPPER_DRYRUN_DELEGATE_PROPAGATION_VALIDATION_REPORT.md` records one fresh same-origin governed run (`regen-20260325-bl057-001`) to preview `preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf`; runtime reached automation (`AUTO-20260325-869`) and critic (`CRITIC-20260325-285`) without pre-critic timeout blockers, but critic still returned `needs_revision` citing unresolved wrapper/delegate contract gaps (dry-run propagation recurrence plus stdout-over-sidecar evidence precedence risk)
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-058
+- title: Harden wrapper/delegate evidence handoff contract to eliminate dry-run propagation recurrence and sidecar precedence risk
+- type: blocker
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-057
+- start_when: `BL-20260325-057` confirms governed runtime reaches critic dispatch but critic still reports `needs_revision` on wrapper/delegate dry-run semantics recurrence and stdout-over-sidecar report precedence risk
+- done_when: Source-side hardening ensures reviewed wrapper behavior is preserved under governed generation (dry-run delegate propagation and sidecar-first evidence handoff), and one blocker report records mitigation with focused tests
+- source: `POST_WRAPPER_DRYRUN_DELEGATE_PROPAGATION_VALIDATION_REPORT.md` on 2026-03-25 records critic `needs_revision` persisted on wrapper/delegate contract handling despite BL-056 source merge
+- link: /Users/lingguozhong/openclaw-team/WRAPPER_DELEGATE_EVIDENCE_HANDOFF_CONTRACT_HARDENING_REPORT.md
+- issue: deferred:phase=next until BL-20260325-057 lands on main
 - evidence: -
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -2354,6 +2354,69 @@ Verification snapshot on 2026-03-25:
   `10/10`
 - `python3 scripts/backlog_lint.py` passed
 - `python3 scripts/backlog_sync.py` passed with BL-056 issue mirror to `#104`
+
+### 65. Fresh Governed Validation After BL-056 Wrapper Dry-Run Propagation Hardening
+
+User objective:
+
+- continue phase-by-phase without drift
+- validate BL-056 wrapper dry-run delegate propagation hardening on one fresh
+  same-origin governed candidate
+
+Main work areas:
+
+- activated `BL-20260325-057` and mirrored it to issue `#107`
+- executed governed validation pipeline with token
+  `regen-20260325-bl057-001`:
+  - sandbox Trello smoke (captured network-policy block evidence)
+  - elevated Trello smoke (live pass + mapped preview)
+  - generated regeneration payload and ingest once -> fresh preview
+    `preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf`
+  - explicit approval write
+  - sandbox execute (captured Docker init block evidence)
+  - elevated replay with runtime env injection reached automation and critic
+- captured and archived runtime evidence:
+  - automation task completed (`AUTO-20260325-869`)
+  - critic task completed (`CRITIC-20260325-285`)
+  - final execute still `rejected` on critic `needs_revision`
+- critic finding focus did not move away from wrapper/delegate contract:
+  - dry-run propagation concern recurred
+  - sidecar-vs-stdout report precedence risk also flagged
+- produced validation report and queued next blocker phase
+  (`BL-20260325-058`)
+
+Primary output:
+
+- [POST_WRAPPER_DRYRUN_DELEGATE_PROPAGATION_VALIDATION_REPORT.md](/Users/lingguozhong/openclaw-team/POST_WRAPPER_DRYRUN_DELEGATE_PROPAGATION_VALIDATION_REPORT.md)
+
+Key result:
+
+- `BL-20260325-057` is complete as a governed validation phase
+- pipeline progressed to critic dispatch, but dry-run contract concerns persisted
+  under governed runtime
+- blocker focus moved to enforcing wrapper/delegate evidence handoff contract
+  (`BL-20260325-058`)
+
+Verification snapshot on 2026-03-25:
+
+- `python3 scripts/backlog_lint.py` passed after BL-057 activation
+- `python3 scripts/backlog_sync.py` passed with BL-057 issue mirror to `#107`
+- sandbox smoke evidence captured as blocked (`ConnectionError` /
+  `NameResolutionError`)
+- elevated smoke passed with `read_count = 1`
+- `python3 skills/ingest_tasks.py --once --test-mode success` returned:
+  - `processed = 1`
+  - `duplicate_skipped = 0`
+  - `preview_created = 1`
+- elevated execute replay returned:
+  - `status = rejected`
+  - `decision_reason = critic_verdict=needs_revision`
+  - `critic_verdict = needs_revision`
+- final preview state:
+  - `approved = true`
+  - `execution.status = rejected`
+  - `execution.executed = true`
+  - `execution.attempts = 2`
 - automation worker:
   - task `AUTO-20260325-854`
   - `status = success`

--- a/runtime_archives/bl057/runtime/AUTO-20260325-869.json
+++ b/runtime_archives/bl057/runtime/AUTO-20260325-869.json
@@ -1,0 +1,195 @@
+{
+  "task_id": "AUTO-20260325-869",
+  "worker": "automation",
+  "status": "success",
+  "created_at": "2026-03-25T08:56:42.581642Z",
+  "updated_at": "2026-03-25T08:58:12.633202Z",
+  "retries": 0,
+  "max_retries": 0,
+  "attempts": [
+    {
+      "attempt": 1,
+      "status": "success",
+      "retryable": false,
+      "error": null,
+      "runtime_log": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-869/runtime.attempt-1.log",
+      "exit_code": 0,
+      "timed_out": false,
+      "wait_error": null,
+      "output_path": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-869/output.json",
+      "started_at": "2026-03-25T08:56:42.585645Z",
+      "finished_at": "2026-03-25T08:58:12.605551Z"
+    }
+  ],
+  "task_dir": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-869",
+  "payload": {
+    "task_id": "AUTO-20260325-869",
+    "worker": "automation",
+    "task_type": "generate_script",
+    "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+    "inputs": {
+      "params": {
+        "input_dir": "~/Desktop/pdf样本",
+        "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+        "ocr": "auto",
+        "dry_run": false,
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "description": "Purpose: | Controlled Trello live preview smoke for openclaw-team. | Expected behavior: | - read-only Trello ingest | - preview creation smoke only | - no business execution claim | - no Trello writeback expected in this step | Traceability: | - backlog: BL-20260324-014 | - blocker context: BL-20260324-015 | - created_by: Oscarling | - created_at: 2026-03-24 Asia/Shanghai | Note: | This card is only for governed smoke verification and should remain open until the smoke is finished.",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "preferred_wrapper_script": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "preferred_base_script": "artifacts/scripts/pdf_to_excel_ocr.py",
+        "reference_docs": [
+          "artifacts/docs/pdf_to_excel_ocr_usage.md",
+          "artifacts/reviews/pdf_to_excel_ocr_review.md"
+        ],
+        "contract_hints": {
+          "output_format_fidelity": "If output_xlsx ends with .xlsx, produce a real XLSX workbook container or fail honestly before writing mismatched text/XML/CSV content to a .xlsx path.",
+          "path_portability": "Use the provided input_dir parameter as runtime input. Do not hardcode a user-home or absolute input path when params already declare the path.",
+          "traceability": "Preserve meaningful description context from the external input; do not collapse it to a heading fragment such as Purpose:.",
+          "reuse_preference": "Prefer reusing artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py as the wrapper baseline and artifacts/scripts/pdf_to_excel_ocr.py as the reviewed delegate when compatible, so workbook semantics and contract behavior stay aligned with repository evidence.",
+          "outcome_status_model": "Use the reviewable status model success/partial/failed. Dry-run requests or zero-PDF discovery should resolve to partial rather than claiming success without an output artifact.",
+          "delegate_resolution": "If preferred_base_script is relative, resolve it from the repository or script location instead of Path.cwd() so behavior stays portable across shells and CI.",
+          "reviewed_delegate_contract": "For readonly reviewable preview flows, delegate only to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py or fail honestly instead of broadening behavior through an arbitrary helper.",
+          "delegate_success_evidence": "Do not treat zero exit code plus output-file existence as sufficient wrapper success evidence on their own. Prefer a structured delegate report that confirms a real success outcome before the wrapper claims success. Require delegate status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, and explicit output attestation fields excel_written=true, output_exists=true, and output_size_bytes>0. Apply these gates only when wrapper status is success.",
+          "delegate_partial_evidence": "For best-effort readonly flows, if delegate status is partial and structured evidence is present, keep wrapper status partial instead of escalating to failed solely because success-only gates are unmet. Surface explicit limitations and next-step guidance in wrapper output.",
+          "delegate_timeout": "Bound delegate subprocess execution with an explicit timeout and report timeout as an honest failed/partial outcome instead of allowing smoke automation to hang indefinitely.",
+          "runtime_summary": "The generated script should emit a structured summary of what it produced so later review can inspect behavior without guessing.",
+          "delegate_report_schema": "Treat delegate JSON report fields status/total_files/status_counter/dry_run as the canonical evidence contract. Do not require undeclared processed_files/succeeded_files/failed_files counters.",
+          "delegate_report_handoff": "When the delegate prints a JSON report to stdout, parse that JSON directly instead of relying only on sidecar-report file path discovery.",
+          "delegate_report_flag_contract": "If wrapper passes a sidecar report path to the reviewed delegate, use the reviewed delegate CLI flag --report-json (or another explicitly supported alias). Do not invent undeclared flags such as --report-file.",
+          "dry_run_semantics": "If wrapper dry-run short-circuits before delegate execution, keep execution.delegated=false and report partial honestly. If wrapper does delegate under dry-run, pass through --dry-run explicitly.",
+          "pdf_discovery_consistency": "Keep wrapper preflight PDF discovery semantics aligned with the reviewed delegate (for example recursive vs non-recursive), so wrapper evidence and delegated execution count the same candidate set."
+        }
+      }
+    },
+    "expected_outputs": [
+      {
+        "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "type": "script"
+      }
+    ],
+    "constraints": [
+      "Follow the local inbox normalized request",
+      "Do not claim unsupported runtime dependencies",
+      "Keep output deterministic and executable",
+      "Produce only the expected script artifact",
+      "Prefer honest, reviewable intermediate behavior over unsupported OCR claims",
+      "If the requested output path ends with .xlsx, do not write non-XLSX text/XML/CSV content to that path.",
+      "Do not hardcode an input directory when the task params already provide input_dir.",
+      "Preserve meaningful traceability from the incoming description instead of collapsing it to a heading fragment.",
+      "Prefer wrapping or adapting artifacts/scripts/pdf_to_excel_ocr.py when that existing repo script already matches the requested behavior.",
+      "When artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py already exists, prefer updating that reviewed wrapper baseline instead of rewriting a new control flow from scratch.",
+      "If dry_run is true or no PDFs are discovered, report a reviewable partial outcome instead of claiming success without an XLSX artifact.",
+      "Resolve relative delegate script paths from the repository or script location, not from Path.cwd().",
+      "For readonly reviewable preview flows, only delegate to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py unless failing honestly.",
+      "Do not claim wrapper success from exit code plus output existence alone when the reviewed delegate report does not provide strong enough success evidence.",
+      "When wrapper reports success, enforce delegate evidence gates: status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, excel_written=true, output_exists=true, and output_size_bytes>0.",
+      "If delegate reports partial with structured evidence in readonly best-effort mode, keep wrapper status partial (not failed) and include explicit limitations with next-step guidance.",
+      "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
+      "When delegate emits JSON to stdout, parse that report directly instead of depending only on sidecar report-file discovery.",
+      "When wrapper passes a sidecar report path to the reviewed delegate, use --report-json exactly unless the reviewed delegate explicitly supports another alias.",
+      "If wrapper supports dry-run short-circuit semantics, keep execution.delegated=false and preserve partial status honestly.",
+      "Keep wrapper PDF discovery semantics aligned with reviewed delegate discovery semantics to avoid preflight/execution evidence drift.",
+      "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely."
+    ],
+    "priority": "medium",
+    "source": {
+      "kind": "local_inbox",
+      "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+      "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl057-001.json",
+      "received_at": "2026-03-25T08:53:07.470167Z",
+      "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "provider": "trello",
+      "mode": "readonly",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "regeneration_token": "regen-20260325-bl057-001"
+    },
+    "acceptance_criteria": [
+      "Produce the expected script artifact at expected_outputs[0].path",
+      "Script behavior remains runnable, deterministic, and reviewable",
+      "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
+      "Artifact behavior remains parameter-driven for input_dir and output_xlsx rather than hardcoding unrelated local defaults.",
+      "Dry-run or zero-input behavior is represented as a reviewable partial outcome instead of artifact-production success.",
+      "Relative preferred_base_script resolution remains portable and does not depend on Path.cwd().",
+      "Wrapper success requires stronger delegate evidence than zero exit code plus a non-empty output file alone.",
+      "Wrapper success attestation requires delegate fields excel_written=true, output_exists=true, output_size_bytes>0, and status_counter.partial/status_counter.failed equal to 0.",
+      "Contract-compliant delegate partial outcomes remain partial with explicit limitations and next-step guidance, rather than being escalated to failed by success-only gates.",
+      "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
+      "Delegate report handoff can consume JSON printed to stdout without relying exclusively on report sidecar file discovery.",
+      "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",
+      "Dry-run semantics remain explicit: short-circuit stays partial with no delegated execution, or delegated dry-run is passed through honestly.",
+      "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
+      "Delegate execution is bounded by an explicit timeout and reports timeout honestly."
+    ],
+    "metadata": {
+      "integration_phase": "8B",
+      "pipeline": "inbox->adapter->manager->automation->critic",
+      "request_type": "pdf_to_excel_ocr",
+      "payload_hash": "d472aab5e3bfd5e47ecb7dfc9ffffda4d8721a5ad56b9dd611be066645a67b40",
+      "regeneration_token": "regen-20260325-bl057-001",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "external_metadata": {
+        "source_system": "trello",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "card_short_id": 7,
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "date_last_activity": "2026-03-24T08:35:56.234Z",
+        "readonly_mapped_at": "2026-03-25T08:52:30.351021Z",
+        "contract_profile": "best_effort_evidence_backed",
+        "ocr_claim_policy": "do_not_claim_success_without_evidence",
+        "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+        "regeneration_token": "regen-20260325-bl057-001"
+      },
+      "automation_contract_profile": "narrow_script_artifact_with_repo_reuse_and_reviewable_runner_contract"
+    }
+  },
+  "result": {
+    "task_id": "AUTO-20260325-869",
+    "worker": "automation",
+    "status": "success",
+    "summary": "Generated one runnable helper wrapper script artifact that reuses the reviewed PDF-to-Excel delegate with portable path resolution, structured delegate-report parsing, timeout handling, honest partial/failure outcomes, and success evidence gates aligned to the provided contract.",
+    "artifacts": [
+      {
+        "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "type": "script"
+      }
+    ],
+    "timestamp": "2026-03-25T08:58:12.456707Z",
+    "duration_ms": 89619,
+    "notes": [
+      "Produced exactly one script artifact as requested.",
+      "The wrapper is parameter-driven and avoids hardcoded input/output defaults when explicit arguments are provided at runtime.",
+      "It prefers the reviewed delegate artifacts/scripts/pdf_to_excel_ocr.py, resolves relative delegate paths from the repository/script location, uses --report-json for sidecar handoff, parses JSON from stdout when available, and enforces stronger success evidence before claiming success.",
+      "Dry-run short-circuits to partial with execution.delegated=false, and zero-PDF discovery also resolves to partial."
+    ],
+    "metadata": {
+      "task_id": "AUTO-20260325-869",
+      "worker": "automation",
+      "output_contract": "single_json_object",
+      "generated_files": 1
+    }
+  }
+}

--- a/runtime_archives/bl057/runtime/CRITIC-20260325-285.json
+++ b/runtime_archives/bl057/runtime/CRITIC-20260325-285.json
@@ -1,0 +1,200 @@
+{
+  "task_id": "CRITIC-20260325-285",
+  "worker": "critic",
+  "status": "success",
+  "created_at": "2026-03-25T08:58:12.642590Z",
+  "updated_at": "2026-03-25T08:58:47.039261Z",
+  "retries": 0,
+  "max_retries": 0,
+  "attempts": [
+    {
+      "attempt": 1,
+      "status": "success",
+      "retryable": false,
+      "error": null,
+      "runtime_log": "/Users/lingguozhong/openclaw-team/workspaces/critic/CRITIC-20260325-285/runtime.attempt-1.log",
+      "exit_code": 0,
+      "timed_out": false,
+      "wait_error": null,
+      "output_path": "/Users/lingguozhong/openclaw-team/workspaces/critic/CRITIC-20260325-285/output.json",
+      "started_at": "2026-03-25T08:58:12.646230Z",
+      "finished_at": "2026-03-25T08:58:47.011127Z"
+    }
+  ],
+  "task_dir": "/Users/lingguozhong/openclaw-team/workspaces/critic/CRITIC-20260325-285",
+  "payload": {
+    "task_id": "CRITIC-20260325-285",
+    "worker": "critic",
+    "task_type": "review_artifact",
+    "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+    "inputs": {
+      "artifacts": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        },
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+          "type": "script"
+        }
+      ],
+      "params": {
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "review_scope": {
+          "primary_artifact": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "paired_artifacts": [
+            "artifacts/scripts/pdf_to_excel_ocr.py"
+          ],
+          "goal": "Audit the wrapper and the reviewed delegate together so the review evidence can speak to the end-to-end readonly smoke path."
+        },
+        "artifact_snapshots": [
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "available": true,
+            "content": "#!/usr/bin/env python3\n\"\"\"Reviewable inbox-style wrapper for the reviewed PDF-to-Excel OCR delegate.\n\nThis helper prefers repository reuse over reimplementation. It performs:\n- portable delegate resolution relative to repository/script location\n- honest preflight PDF discovery aligned to recursive semantics\n- dry-run short-circuit as partial without delegate execution\n- bounded delegate execution with explicit timeout\n- delegate JSON report handoff via stdout and --report-json sidecar\n- success gating based on structured evidence, not only exit code/output existence\n\nIt is intentionally best-effort and reviewable for readonly smoke usage.\n\"\"\"\n\nfrom __future__ import annotations\n\nimport argparse\nimport json\nimport os\nimport subprocess\nimport sys\nimport tempfile\nfrom pathlib import Path\nfrom typing import Any, Dict, List, Optional\n\nDEFAULT_INPUT_DIR = \"~/Desktop/pdf样本\"\nDEFAULT_OUTPUT_XLSX = \"artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx\"\nDEFAULT_OCR = \"auto\"\nDEFAULT_TIMEOUT_SECONDS = 300\nDEFAULT_ORIGIN_ID = \"trello:69c24cd3c1a2359ddd7a1bf8\"\nDEFAULT_TITLE = \"BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)\"\nDEFAULT_DESCRIPTION = (\n    \"Purpose:\\n\"\n    \"Controlled Trello live preview smoke for openclaw-team.\\n\"\n    \"Expected behavior:\\n\"\n    \"- read-only Trello ingest\\n\"\n    \"- preview creation smoke only\\n\"\n    \"- no business execution claim\\n\"\n    \"- no Trello writeback expected in this step\\n\"\n    \"Traceability:\\n\"\n    \"- backlog: BL-20260324-014\\n\"\n    \"- blocker context: BL-20260324-015\\n\"\n    \"- created_by: Oscarling\\n\"\n    \"- created_at: 2026-03-24 Asia/Shanghai\\n\"\n    \"Note:\\n\"\n    \"This card is only for governed smoke verification and should remain open until the smoke is finished.\"\n)\nDEFAULT_LABELS = [\"best_effort\", \"evidence_backed\", \"readonly\", \"reviewable\", \"trello\"]\nDEFAULT_PREFERRED_BASE = \"artifacts/scripts/pdf_to_excel_ocr.py\"\n\n\ndef _expand(path_text: str) -> Path:\n    return Path(os.path.expanduser(path_text)).resolve()\n\n\ndef _repo_root() -> Path:\n    here = Path(__file__).resolve()\n    for candidate in [here.parent, *here.parents]:\n        if (candidate / \"artifacts\").exists():\n            return candidate\n    return here.parent.parent.parent\n\n\ndef _resolve_delegate(preferred: str) -> Path:\n    candidate = Path(preferred)\n    if candidate.is_absolute():\n        return candidate\n    root = _repo_root()\n    from_script_dir = (Path(__file__).resolve().parent / candidate).resolve()\n    from_root = (root / candidate).resolve()\n    if from_root.exists():\n        return from_root\n    return from_script_dir\n\n\ndef _discover_pdfs(input_dir: Path) -> List[Path]:\n    if not input_dir.exists() or not input_dir.is_dir():\n        return []\n    return sorted(\n        [\n            p for p in input_dir.rglob(\"*\")\n            if p.is_file() and p.suffix.lower() == \".pdf\"\n        ],\n        key=lambda p: str(p).lower(),\n    )\n\n\ndef _extract_json_object(text: str) -> Optional[Dict[str, Any]]:\n    text = text.strip()\n    if not text:\n        return None\n    try:\n        value = json.loads(text)\n        if isinstance(value, dict):\n            return value\n    except json.JSONDecodeError:\n        pass\n    start = text.find(\"{\")\n    while start != -1:\n        for end in range(len(text), start, -1):\n            chunk = text[start:end].strip()\n            if not chunk.endswith(\"}\"):\n                continue\n            try:\n                value = json.loads(chunk)\n                if isinstance(value, dict):\n                    return value\n            except json.JSONDecodeError:\n                continue\n        start = text.find(\"{\", start + 1)\n    return None\n\n\ndef _load_json_file(path: Path) -> Optional[Dict[str, Any]]:\n    try:\n        if path.exists():\n            data = json.loads(path.read_text(encoding=\"utf-8\"))\n            if isinstance(data, dict):\n                return data\n    except Exception:\n        return None\n    return None\n\n\ndef _output_attestation(path: Path) -> Dict[str, Any]:\n    exists = path.exists()\n    size = path.stat().st_size if exists and path.is_file() else 0\n    return {\n        \"excel_written\": bool(exists and path.suffix.lower() == \".xlsx\" and size > 0),\n        \"output_exists\": bool(exists),\n        \"output_size_bytes\": int(size),\n        \"output_path\": str(path),\n    }\n\n\ndef _normalize_counter(value: Any) -> Dict[str, int]:\n    if not isinstance(value, dict):\n        return {\"success\": 0, \"partial\": 0, \"failed\": 0}\n    return {\n        \"success\": int(value.get(\"success\", 0) or 0),\n        \"partial\": int(value.get(\"partial\", 0) or 0),\n        \"failed\": int(value.get(\"failed\", 0) or 0),\n    }\n\n\ndef _build_parser() -> argparse.ArgumentParser:\n    parser = argparse.ArgumentParser(description=\"Reviewable PDF-to-Excel OCR inbox runner\")\n    parser.add_argument(\"--input-dir\", default=DEFAULT_INPUT_DIR)\n    parser.add_argument(\"--output-xlsx\", default=DEFAULT_OUTPUT_XLSX)\n    parser.add_argument(\"--ocr\", default=DEFAULT_OCR)\n    parser.add_argument(\"--dry-run\", action=\"store_true\")\n    parser.add_argument(\"--origin-id\", default=DEFAULT_ORIGIN_ID)\n    parser.add_argument(\"--title\", default=DEFAULT_TITLE)\n    parser.add_argument(\"--description\", default=DEFAULT_DESCRIPTION)\n    parser.add_argument(\"--label\", action=\"append\", dest=\"labels\")\n    parser.add_argument(\"--preferred-base-script\", default=DEFAULT_PREFERRED_BASE)\n    parser.add_argument(\"--timeout-seconds\", type=int, default=DEFAULT_TIMEOUT_SECONDS)\n    return parser\n\n\ndef main() -> int:\n    args = _build_parser().parse_args()\n    labels = args.labels if args.labels else list(DEFAULT_LABELS)\n    input_dir = _expand(args.input_dir)\n    output_xlsx = _expand(args.output_xlsx)\n    delegate_path = _resolve_delegate(args.preferred_base_script)\n    discovered_pdfs = _discover_pdfs(input_dir)\n\n    result: Dict[str, Any] = {\n        \"status\": \"failed\",\n        \"summary\": \"\",\n        \"request\": {\n            \"origin_id\": args.origin_id,\n            \"title\": args.title,\n            \"description\": args.description,\n            \"labels\": labels,\n            \"ocr\": args.ocr,\n            \"dry_run\": bool(args.dry_run),\n            \"input_dir\": str(input_dir),\n            \"output_xlsx\": str(output_xlsx),\n        },\n        \"preflight\": {\n            \"delegate_path\": str(delegate_path),\n            \"delegate_exists\": delegate_path.exists(),\n            \"input_dir_exists\": input_dir.exists(),\n            \"input_dir_is_dir\": input_dir.is_dir(),\n            \"pdf_discovery_mode\": \"recursive\",\n            \"discovered_pdf_count\": len(discovered_pdfs),\n            \"discovered_pdfs\": [str(p) for p in discovered_pdfs],\n        },\n        \"execution\": {\n            \"delegated\": False,\n            \"timeout_seconds\": int(args.timeout_seconds),\n        },\n        \"delegate\": None,\n        \"output_attestation\": _output_attestation(output_xlsx),\n        \"limitations\": [],\n        \"next_steps\": [],\n    }\n\n    if output_xlsx.suffix.lower() != \".xlsx\":\n        result[\"status\"] = \"failed\"\n        result[\"summary\"] = \"Requested output path does not end with .xlsx; refusing mismatched output semantics.\"\n        result[\"limitations\"].append(\"Output path must end with .xlsx for workbook semantics.\")\n        print(json.dumps(result, ensure_ascii=False, indent=2))\n        return 1\n\n    if not delegate_path.exists():\n        result[\"status\"] = \"failed\"\n        result[\"summary\"] = \"Reviewed delegate script was not found; wrapper refuses to broaden behavior.\"\n        result[\"limitations\"].append(\"Delegate missing: only reviewed repository delegate is allowed for readonly preview flows.\")\n        result[\"next_steps\"].append(\"Restore or provide artifacts/scripts/pdf_to_excel_ocr.py at the expected repository location.\")\n        print(json.dumps(result, ensure_ascii=False, indent=2))\n        return 1\n\n    if args.dry_run:\n        result[\"status\"] = \"partial\"\n        result[\"summary\"] = \"Dry-run requested; wrapper performed preflight only and did not delegate execution.\"\n        result[\"limitations\"].append(\"No XLSX artifact is produced during wrapper short-circuit dry-run.\")\n        result[\"next_steps\"].append(\"Run without --dry-run to attempt reviewed delegate conversion.\")\n        print(json.dumps(result, ensure_ascii=False, indent=2))\n        return 0\n\n    if len(discovered_pdfs) == 0:\n        result[\"status\"] = \"partial\"\n        result[\"summary\"] = \"No PDF files were discovered under the provided input directory.\"\n        result[\"limitations\"].append(\"No candidate PDFs found for conversion, so no XLSX was produced.\")\n        result[\"next_steps\"].append(\"Place one or more PDF files in the input directory and rerun the helper.\")\n        print(json.dumps(result, ensure_ascii=False, indent=2))\n        return 0\n\n    output_xlsx.parent.mkdir(parents=True, exist_ok=True)\n\n    with tempfile.TemporaryDirectory(prefix=\"pdf_to_excel_delegate_\") as tmp_dir:\n        report_json = Path(tmp_dir) / \"delegate_report.json\"\n        cmd = [\n            sys.executable,\n            str(delegate_path),\n            \"--input-dir\",\n            str(input_dir),\n            \"--output-xlsx\",\n            str(output_xlsx),\n            \"--ocr\",\n            str(args.ocr),\n            \"--report-json\",\n            str(report_json),\n        ]\n\n        result[\"execution\"][\"delegated\"] = True\n        result[\"execution\"][\"command\"] = cmd\n\n        try:\n            completed = subprocess.run(\n                cmd,\n                capture_output=True,\n                text=True,\n                timeout=max(1, int(args.timeout_seconds)),\n                check=False,\n            )\n            stdout_json = _extract_json_object(completed.stdout or \"\")\n            sidecar_json = _load_json_file(report_json)\n            delegate_report = stdout_json or sidecar_json or {}\n            result[\"delegate\"] = {\n                \"returncode\": int(completed.returncode),\n                \"stdout\": completed.stdout,\n                \"stderr\": completed.stderr,\n                \"report_source\": (\n                    \"stdout_json\" if stdout_json is not None else\n                    \"sidecar_json\" if sidecar_json is not None else\n                    \"none\"\n                ),\n                \"report\": delegate_report,\n            }\n        except subprocess.TimeoutExpired as exc:\n            result[\"status\"] = \"failed\"\n            result[\"summary\"] = f\"Delegate execution timed out after {int(args.timeout_seconds)} seconds.\"\n            result[\"delegate\"] = {\n                \"timeout\": True,\n                \"stdout\": exc.stdout,\n                \"stderr\": exc.stderr,\n                \"report_source\": \"none\",\n                \"report\": {},\n            }\n            result[\"limitations\"].append(\"Delegate subprocess did not complete within the explicit timeout.\")\n            result[\"next_steps\"].append(\"Retry with a larger --timeout-seconds value or reduce the input set.\")\n            result[\"output_attestation\"] = _output_attestation(output_xlsx)\n            print(json.dumps(result, ensure_ascii=False, indent=2))\n            return 1\n\n    report = result[\"delegate\"].get(\"report\") if isinstance(result.get(\"delegate\"), dict) else {}\n    if not isinstance(report, dict):\n        report = {}\n\n    delegate_status = report.get(\"status\")\n    delegate_total_files = int(report.get(\"total_files\", 0) or 0)\n    delegate_dry_run = bool(report.get(\"dry_run\", False))\n    status_counter = _normalize_counter(report.get(\"status_counter\"))\n\n    attestation = _output_attestation(output_xlsx)\n    report_excel_written = report.get(\"excel_written\")\n    report_output_exists = report.get(\"output_exists\")\n    report_output_size_bytes = report.get(\"output_size_bytes\")\n    if isinstance(report_excel_written, bool):\n        attestation[\"excel_written\"] = report_excel_written\n    if isinstance(report_output_exists, bool):\n        attestation[\"output_exists\"] = report_output_exists\n    if isinstance(report_output_size_bytes, int):\n        attestation[\"output_size_bytes\"] = report_output_size_bytes\n    result[\"output_attestation\"] = attestation\n\n    success_gates = all([\n        delegate_status == \"success\",\n        delegate_total_files >= 1,\n        delegate_dry_run is False,\n        status_counter.get(\"failed\", 0) == 0,\n        status_counter.get(\"partial\", 0) == 0,\n        attestation.get(\"excel_written\") is True,\n        attestation.get(\"output_exists\") is True,\n        int(attestation.get(\"output_size_bytes\", 0) or 0) > 0,\n    ])\n\n    if success_gates:\n        result[\"status\"] = \"success\"\n        result[\"summary\"] = \"Reviewed delegate reported success with sufficient structured evidence and a real XLSX output attestation.\"\n        print(json.dumps(result, ensure_ascii=False, indent=2))\n        return 0\n\n    if delegate_status == \"partial\":\n        result[\"status\"] = \"partial\"\n        result[\"summary\"] = \"Delegate returned a structured partial outcome; preserving partial status for reviewable best-effort flow.\"\n        result[\"limitations\"].append(\"Success-only evidence gates were not fully satisfied by the delegate report.\")\n        result[\"next_steps\"].append(\"Review delegate stdout/stderr and report details to determine whether OCR support, PDF quality, or dependencies limited extraction.\")\n        result[\"next_steps\"].append(\"If needed, rerun against a smaller known-good sample set or verify the reviewed delegate runtime prerequisites.\")\n        print(json.dumps(result, ensure_ascii=False, indent=2))\n        return 0\n\n    result[\"status\"] = \"failed\"\n    result[\"summary\"] = \"Delegate did not provide sufficient structured evidence for success, and no contract-compliant partial outcome was established.\"\n    result[\"limitations\"].append(\"Wrapper will not treat exit code plus output-file existence alone as sufficient success evidence.\")\n    if delegate_status is None:\n        result[\"limitations\"].append(\"No canonical delegate JSON report was available from stdout or sidecar.\")\n    else:\n        result[\"limitations\"].append(f\"Delegate status was {delegate_status!r}, which did not satisfy success gates.\")\n    result[\"next_steps\"].append(\"Inspect the reviewed delegate CLI compatibility and JSON report fields status/total_files/status_counter/dry_run.\")\n    result[\"next_steps\"].append(\"Ensure the delegate emits or writes contract-compliant JSON via stdout or --report-json sidecar.\")\n    print(json.dumps(result, ensure_ascii=False, indent=2))\n    return 1\n\n\nif __name__ == \"__main__\":\n    raise SystemExit(main())\n",
+            "truncated": false
+          },
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+            "available": true,
+            "content": "#!/usr/bin/env python3\n\"\"\"\nBatch PDF -> Excel extractor with optional OCR fallback.\n\nDesign goals:\n- Batch processing with per-file isolation (single file failure must not stop the batch)\n- OCR mode: auto | on | off\n- Chinese-friendly OCR defaults (chi_sim+eng)\n- Dry-run support for pilot validation when dependencies are unavailable\n\"\"\"\n\nfrom __future__ import annotations\n\nimport argparse\nimport json\nimport shutil\nimport sys\nfrom dataclasses import asdict, dataclass\nfrom pathlib import Path\nfrom typing import Any\n\n\ntry:\n    from pypdf import PdfReader  # type: ignore\nexcept Exception:\n    PdfReader = None\n\ntry:\n    import pandas as pd  # type: ignore\nexcept Exception:\n    pd = None\n\ntry:\n    import pytesseract  # type: ignore\nexcept Exception:\n    pytesseract = None\n\ntry:\n    from pdf2image import convert_from_path  # type: ignore\nexcept Exception:\n    convert_from_path = None\n\n\n@dataclass\nclass FileResult:\n    file_name: str\n    file_path: str\n    status: str\n    extract_method: str\n    page_count: int\n    text_chars: int\n    text_preview: str\n    warnings: str\n    error: str\n\n\ndef parse_args() -> argparse.Namespace:\n    parser = argparse.ArgumentParser(description=\"Batch PDF to Excel extractor with OCR fallback.\")\n    parser.add_argument(\"--input-dir\", required=True, help=\"Directory containing PDF files.\")\n    parser.add_argument(\"--output-xlsx\", required=True, help=\"Output Excel path.\")\n    parser.add_argument(\n        \"--ocr\",\n        choices=(\"auto\", \"on\", \"off\"),\n        default=\"auto\",\n        help=\"OCR mode. auto=use OCR when plain text extraction is weak.\",\n    )\n    parser.add_argument(\n        \"--dry-run\",\n        action=\"store_true\",\n        help=\"Do not write Excel file. Print execution summary only.\",\n    )\n    parser.add_argument(\n        \"--ocr-lang\",\n        default=\"chi_sim+eng\",\n        help=\"OCR language pack for pytesseract, default supports Chinese + English.\",\n    )\n    parser.add_argument(\n        \"--auto-ocr-min-chars\",\n        type=int,\n        default=50,\n        help=\"In auto mode, run OCR when extracted text chars < this threshold.\",\n    )\n    parser.add_argument(\n        \"--report-json\",\n        default=\"\",\n        help=\"Optional sidecar path for writing the same JSON report emitted to stdout.\",\n    )\n    return parser.parse_args()\n\n\ndef discover_pdfs(input_dir: Path) -> list[Path]:\n    if not input_dir.exists():\n        raise FileNotFoundError(f\"Input directory does not exist: {input_dir}\")\n    if not input_dir.is_dir():\n        raise NotADirectoryError(f\"Input path is not a directory: {input_dir}\")\n    files = sorted([p for p in input_dir.rglob(\"*\") if p.is_file() and p.suffix.lower() == \".pdf\"])\n    return files\n\n\ndef detect_ocr_runtime_status() -> tuple[str, list[str]]:\n    missing: list[str] = []\n    present: list[str] = []\n\n    if pytesseract is None:\n        missing.append(\"python module pytesseract\")\n    else:\n        present.append(\"python module pytesseract\")\n    if convert_from_path is None:\n        missing.append(\"python module pdf2image\")\n    else:\n        present.append(\"python module pdf2image\")\n    if shutil.which(\"tesseract\") is None:\n        missing.append(\"binary tesseract\")\n    else:\n        present.append(\"binary tesseract\")\n    if shutil.which(\"pdftoppm\") is None:\n        missing.append(\"binary pdftoppm (poppler)\")\n    else:\n        present.append(\"binary pdftoppm (poppler)\")\n\n    if not missing:\n        return \"available\", []\n    if present:\n        return \"partial\", missing\n    return \"blocked\", missing\n\n\ndef extract_text_pypdf(pdf_path: Path) -> tuple[str, int]:\n    if PdfReader is None:\n        raise RuntimeError(\"pypdf not installed\")\n    reader = PdfReader(str(pdf_path))\n    page_texts: list[str] = []\n    for page in reader.pages:\n        text = page.extract_text() or \"\"\n        page_texts.append(text)\n    return \"\\n\".join(page_texts), len(reader.pages)\n\n\ndef extract_text_ocr(pdf_path: Path, ocr_lang: str) -> str:\n    if pytesseract is None:\n        raise RuntimeError(\"pytesseract not installed\")\n    if convert_from_path is None:\n        raise RuntimeError(\"pdf2image not installed\")\n    if shutil.which(\"tesseract\") is None:\n        raise RuntimeError(\"tesseract binary not found\")\n    if shutil.which(\"pdftoppm\") is None:\n        raise RuntimeError(\"pdftoppm binary not found (install poppler)\")\n\n    images = convert_from_path(str(pdf_path), dpi=220)\n    chunks: list[str] = []\n    for image in images:\n        chunks.append(pytesseract.image_to_string(image, lang=ocr_lang))\n    return \"\\n\".join(chunks)\n\n\ndef compact_preview(text: str, limit: int = 160) -> str:\n    single_line = \" \".join(text.split())\n    if len(single_line) <= limit:\n        return single_line\n    return single_line[: limit - 3] + \"...\"\n\n\ndef process_one_pdf(\n    pdf_path: Path,\n    ocr_mode: str,\n    ocr_lang: str,\n    auto_ocr_min_chars: int,\n) -> FileResult:\n    warnings: list[str] = []\n    errors: list[str] = []\n    method = \"none\"\n    text = \"\"\n    page_count = 0\n\n    try:\n        text, page_count = extract_text_pypdf(pdf_path)\n        method = \"text\"\n    except Exception as e:\n        warnings.append(f\"text extraction unavailable: {e}\")\n\n    needs_ocr = False\n    if ocr_mode == \"on\":\n        needs_ocr = True\n    elif ocr_mode == \"auto\" and len(text.strip()) < auto_ocr_min_chars:\n        needs_ocr = True\n\n    if needs_ocr:\n        try:\n            ocr_text = extract_text_ocr(pdf_path, ocr_lang).strip()\n            if ocr_text:\n                if text.strip():\n                    text = f\"{text.strip()}\\n\\n[OCR Fallback]\\n{ocr_text}\"\n                    method = \"text+ocr\"\n                else:\n                    text = ocr_text\n                    method = \"ocr\"\n            else:\n                warnings.append(\"OCR returned empty text\")\n        except Exception as e:\n            errors.append(f\"OCR failed: {e}\")\n\n    if not text.strip():\n        if errors:\n            status = \"failed\"\n        else:\n            status = \"partial\"\n            warnings.append(\"No extractable text captured\")\n    else:\n        if errors:\n            status = \"partial\"\n            warnings.append(\"Text was extracted, but one or more extraction attempts failed; review errors\")\n        else:\n            status = \"success\"\n\n    return FileResult(\n        file_name=pdf_path.name,\n        file_path=str(pdf_path),\n        status=status,\n        extract_method=method,\n        page_count=page_count,\n        text_chars=len(text),\n        text_preview=compact_preview(text),\n        warnings=\" | \".join(warnings),\n        error=\" | \".join(errors),\n    )\n\n\ndef write_excel(results: list[FileResult], output_xlsx: Path) -> None:\n    if pd is None:\n        raise RuntimeError(\"pandas is required to write Excel output\")\n    output_xlsx.parent.mkdir(parents=True, exist_ok=True)\n\n    rows = [asdict(r) for r in results]\n    detail_df = pd.DataFrame(rows)\n\n    summary_rows: list[dict[str, Any]] = []\n    by_status = detail_df.groupby(\"status\").size().to_dict()\n    by_method = detail_df.groupby(\"extract_method\").size().to_dict()\n    for key, value in sorted(by_status.items()):\n        summary_rows.append({\"metric\": \"status_count\", \"name\": key, \"value\": int(value)})\n    for key, value in sorted(by_method.items()):\n        summary_rows.append({\"metric\": \"method_count\", \"name\": key, \"value\": int(value)})\n    summary_rows.append({\"metric\": \"total_files\", \"name\": \"all\", \"value\": int(len(results))})\n    summary_df = pd.DataFrame(summary_rows)\n\n    with pd.ExcelWriter(output_xlsx) as writer:\n        summary_df.to_excel(writer, sheet_name=\"summary\", index=False)\n        detail_df.to_excel(writer, sheet_name=\"files\", index=False)\n\n\ndef emit_report(report: dict[str, Any], report_json: str) -> None:\n    rendered = json.dumps(report, ensure_ascii=False, indent=2)\n    print(rendered)\n    if not report_json:\n        return\n    out_path = Path(report_json).expanduser().resolve()\n    out_path.parent.mkdir(parents=True, exist_ok=True)\n    out_path.write_text(rendered + \"\\n\", encoding=\"utf-8\")\n\n\ndef main() -> int:\n    args = parse_args()\n    input_dir = Path(args.input_dir).expanduser().resolve()\n    output_xlsx = Path(args.output_xlsx).expanduser().resolve()\n\n    try:\n        pdf_files = discover_pdfs(input_dir)\n    except Exception as e:\n        emit_report({\"status\": \"failed\", \"error\": str(e)}, args.report_json)\n        return 2\n\n    if not pdf_files:\n        emit_report(\n            {\n                \"status\": \"partial\",\n                \"input_dir\": str(input_dir),\n                \"output_xlsx\": str(output_xlsx),\n                \"ocr_mode\": args.ocr,\n                \"total_files\": 0,\n                \"files\": [],\n                \"status_counter\": {},\n                \"dry_run\": bool(args.dry_run),\n                \"excel_written\": False,\n                \"output_exists\": False,\n                \"output_size_bytes\": 0,\n                \"notes\": [f\"No PDF files found under {input_dir}\"],\n                \"next_steps\": [\n                    \"Add one or more .pdf files under the input directory and rerun.\",\n                ],\n            },\n            args.report_json,\n        )\n        return 0\n\n    ocr_runtime, missing = detect_ocr_runtime_status()\n    results: list[FileResult] = []\n    for pdf in pdf_files:\n        try:\n            results.append(\n                process_one_pdf(\n                    pdf,\n                    ocr_mode=args.ocr,\n                    ocr_lang=args.ocr_lang,\n                    auto_ocr_min_chars=args.auto_ocr_min_chars,\n                )\n            )\n        except Exception as e:\n            results.append(\n                FileResult(\n                    file_name=pdf.name,\n                    file_path=str(pdf),\n                    status=\"failed\",\n                    extract_method=\"none\",\n                    page_count=0,\n                    text_chars=0,\n                    text_preview=\"\",\n                    warnings=\"\",\n                    error=f\"Unhandled processing exception: {e}\",\n                )\n            )\n\n    status_counter: dict[str, int] = {}\n    for item in results:\n        status_counter[item.status] = status_counter.get(item.status, 0) + 1\n\n    files_payload = [asdict(item) for item in results]\n    failed_count = status_counter.get(\"failed\", 0)\n    partial_count = status_counter.get(\"partial\", 0)\n    if failed_count == 0 and partial_count == 0:\n        aggregate_status = \"success\"\n    else:\n        aggregate_status = \"partial\"\n\n    notes: list[str] = []\n    next_steps: list[str] = []\n    if ocr_runtime != \"available\":\n        notes.append(f\"OCR runtime status is {ocr_runtime}; missing dependencies: {', '.join(missing) or 'none'}\")\n        next_steps.append(\"Install missing OCR runtime dependencies if OCR fallback is required.\")\n    if partial_count > 0:\n        notes.append(f\"{partial_count} file(s) reported partial status.\")\n        next_steps.append(\"Inspect per-file partial records in `files` and address listed warnings/errors.\")\n    if failed_count > 0:\n        notes.append(f\"{failed_count} file(s) reported failed status.\")\n        next_steps.append(\"Inspect per-file failures in `files` and resolve the extraction or OCR error causes.\")\n\n    report = {\n        \"status\": aggregate_status,\n        \"input_dir\": str(input_dir),\n        \"output_xlsx\": str(output_xlsx),\n        \"ocr_mode\": args.ocr,\n        \"ocr_runtime_status\": ocr_runtime,\n        \"ocr_missing_dependencies\": missing,\n        \"total_files\": len(results),\n        \"files\": files_payload,\n        \"status_counter\": status_counter,\n        \"dry_run\": bool(args.dry_run),\n        \"excel_written\": False,\n        \"output_exists\": False,\n        \"output_size_bytes\": 0,\n        \"notes\": notes,\n        \"next_steps\": next_steps,\n    }\n\n    if args.dry_run:\n        emit_report(report, args.report_json)\n        return 0\n\n    try:\n        write_excel(results, output_xlsx)\n        report[\"output_exists\"] = output_xlsx.exists() and output_xlsx.is_file()\n        if report[\"output_exists\"]:\n            report[\"output_size_bytes\"] = int(output_xlsx.stat().st_size)\n        report[\"excel_written\"] = bool(report[\"output_exists\"] and report[\"output_size_bytes\"] > 0)\n        emit_report(report, args.report_json)\n        return 0\n    except Exception as e:\n        report[\"status\"] = \"failed\"\n        report[\"error\"] = str(e)\n        report[\"output_exists\"] = output_xlsx.exists() and output_xlsx.is_file()\n        if report[\"output_exists\"]:\n            report[\"output_size_bytes\"] = int(output_xlsx.stat().st_size)\n        report[\"excel_written\"] = bool(report[\"output_exists\"] and report[\"output_size_bytes\"] > 0)\n        report[\"notes\"] = report.get(\"notes\", []) + [\"Excel write step failed after extraction.\"]\n        report[\"next_steps\"] = report.get(\"next_steps\", []) + [\"Check pandas/openpyxl availability and output path permissions.\"]\n        emit_report(report, args.report_json)\n        return 3\n\n\nif __name__ == \"__main__\":\n    raise SystemExit(main())\n",
+            "truncated": false
+          }
+        ],
+        "review_contract": {
+          "required_status": [
+            "success",
+            "partial",
+            "failed"
+          ],
+          "required_verdict_values": [
+            "fail",
+            "needs_revision",
+            "pass"
+          ],
+          "required_metadata_key": "verdict",
+          "must_write_review_artifact_to": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "artifact_policy": "Always include either `file_contents` for the review artifact path or `artifacts` referencing that exact path.",
+          "fallback_policy": "If evidence is insufficient, return `status=partial`, include explicit `errors`, still generate review artifact content, and set verdict=needs_revision."
+        },
+        "review_template": {
+          "title": "Review: <artifact name>",
+          "sections": [
+            "Scope",
+            "Findings",
+            "Verdict",
+            "Rationale"
+          ],
+          "verdict_required": true
+        }
+      }
+    },
+    "expected_outputs": [
+      {
+        "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+        "type": "review"
+      }
+    ],
+    "constraints": [
+      "Review must be grounded in produced automation artifact",
+      "When both wrapper and reviewed delegate snapshots are supplied, evaluate them as one end-to-end readonly pair instead of ignoring the delegate evidence.",
+      "Do not invent missing artifact content",
+      "Return a clear verdict: pass, fail, or needs_revision",
+      "Include metadata.verdict in output",
+      "Generate review artifact markdown for expected_outputs[0].path",
+      "Use artifact_snapshots when provided; avoid claiming access problems if snapshot content exists.",
+      "When both the generated wrapper and reviewed delegate snapshots are provided, review them together rather than silently narrowing scope to one file.",
+      "Return metadata.verdict with one of: pass, fail, needs_revision.",
+      "Always generate review artifact content for expected_outputs[0].path.",
+      "If evidence is insufficient, use partial + errors + verdict=needs_revision, but still output review artifact."
+    ],
+    "priority": "medium",
+    "source": {
+      "kind": "local_inbox",
+      "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+      "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl057-001.json",
+      "received_at": "2026-03-25T08:53:07.470167Z",
+      "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "provider": "trello",
+      "mode": "readonly",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "regeneration_token": "regen-20260325-bl057-001"
+    },
+    "acceptance_criteria": [
+      "Produce a review artifact with explicit verdict (pass/fail/needs_revision)"
+    ],
+    "metadata": {
+      "integration_phase": "8B",
+      "pipeline": "inbox->adapter->manager->automation->critic",
+      "request_type": "pdf_to_excel_ocr",
+      "payload_hash": "d472aab5e3bfd5e47ecb7dfc9ffffda4d8721a5ad56b9dd611be066645a67b40",
+      "regeneration_token": "regen-20260325-bl057-001",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "external_metadata": {
+        "source_system": "trello",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "card_short_id": 7,
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "date_last_activity": "2026-03-24T08:35:56.234Z",
+        "readonly_mapped_at": "2026-03-25T08:52:30.351021Z",
+        "contract_profile": "best_effort_evidence_backed",
+        "ocr_claim_policy": "do_not_claim_success_without_evidence",
+        "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+        "regeneration_token": "regen-20260325-bl057-001"
+      }
+    }
+  },
+  "result": {
+    "task_id": "CRITIC-20260325-285",
+    "worker": "critic",
+    "status": "success",
+    "summary": "Reviewed the inbox runner and paired delegate together as an end-to-end readonly smoke path. Verdict: needs_revision due to wrapper/delegate CLI contract mismatch and evidence-loss risk when both stdout JSON and sidecar JSON are present.",
+    "artifacts": [
+      {
+        "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+        "type": "review"
+      }
+    ],
+    "timestamp": "2026-03-25T08:58:46.896406Z",
+    "duration_ms": 34038,
+    "notes": [
+      "Scope included both artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py and artifacts/scripts/pdf_to_excel_ocr.py as a single readonly pair.",
+      "Review is grounded in the supplied artifact snapshots.",
+      "A review artifact markdown file is provided via file_contents for the expected path."
+    ],
+    "metadata": {
+      "verdict": "needs_revision",
+      "task_id": "CRITIC-20260325-285",
+      "worker": "critic",
+      "reviewed_artifacts": [
+        "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "artifacts/scripts/pdf_to_excel_ocr.py"
+      ]
+    }
+  }
+}

--- a/runtime_archives/bl057/runtime/automation-output.json
+++ b/runtime_archives/bl057/runtime/automation-output.json
@@ -1,0 +1,26 @@
+{
+  "task_id": "AUTO-20260325-869",
+  "worker": "automation",
+  "status": "success",
+  "summary": "Generated one runnable helper wrapper script artifact that reuses the reviewed PDF-to-Excel delegate with portable path resolution, structured delegate-report parsing, timeout handling, honest partial/failure outcomes, and success evidence gates aligned to the provided contract.",
+  "artifacts": [
+    {
+      "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+      "type": "script"
+    }
+  ],
+  "timestamp": "2026-03-25T08:58:12.456707Z",
+  "duration_ms": 89619,
+  "notes": [
+    "Produced exactly one script artifact as requested.",
+    "The wrapper is parameter-driven and avoids hardcoded input/output defaults when explicit arguments are provided at runtime.",
+    "It prefers the reviewed delegate artifacts/scripts/pdf_to_excel_ocr.py, resolves relative delegate paths from the repository/script location, uses --report-json for sidecar handoff, parses JSON from stdout when available, and enforces stronger success evidence before claiming success.",
+    "Dry-run short-circuits to partial with execution.delegated=false, and zero-PDF discovery also resolves to partial."
+  ],
+  "metadata": {
+    "task_id": "AUTO-20260325-869",
+    "worker": "automation",
+    "output_contract": "single_json_object",
+    "generated_files": 1
+  }
+}

--- a/runtime_archives/bl057/runtime/automation-produced-pdf_to_excel_ocr_inbox_runner.py
+++ b/runtime_archives/bl057/runtime/automation-produced-pdf_to_excel_ocr_inbox_runner.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Reviewable inbox-style wrapper for the reviewed PDF-to-Excel OCR delegate.
+
+This helper prefers repository reuse over reimplementation. It performs:
+- portable delegate resolution relative to repository/script location
+- honest preflight PDF discovery aligned to recursive semantics
+- dry-run short-circuit as partial without delegate execution
+- bounded delegate execution with explicit timeout
+- delegate JSON report handoff via stdout and --report-json sidecar
+- success gating based on structured evidence, not only exit code/output existence
+
+It is intentionally best-effort and reviewable for readonly smoke usage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+DEFAULT_INPUT_DIR = "~/Desktop/pdf样本"
+DEFAULT_OUTPUT_XLSX = "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx"
+DEFAULT_OCR = "auto"
+DEFAULT_TIMEOUT_SECONDS = 300
+DEFAULT_ORIGIN_ID = "trello:69c24cd3c1a2359ddd7a1bf8"
+DEFAULT_TITLE = "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)"
+DEFAULT_DESCRIPTION = (
+    "Purpose:\n"
+    "Controlled Trello live preview smoke for openclaw-team.\n"
+    "Expected behavior:\n"
+    "- read-only Trello ingest\n"
+    "- preview creation smoke only\n"
+    "- no business execution claim\n"
+    "- no Trello writeback expected in this step\n"
+    "Traceability:\n"
+    "- backlog: BL-20260324-014\n"
+    "- blocker context: BL-20260324-015\n"
+    "- created_by: Oscarling\n"
+    "- created_at: 2026-03-24 Asia/Shanghai\n"
+    "Note:\n"
+    "This card is only for governed smoke verification and should remain open until the smoke is finished."
+)
+DEFAULT_LABELS = ["best_effort", "evidence_backed", "readonly", "reviewable", "trello"]
+DEFAULT_PREFERRED_BASE = "artifacts/scripts/pdf_to_excel_ocr.py"
+
+
+def _expand(path_text: str) -> Path:
+    return Path(os.path.expanduser(path_text)).resolve()
+
+
+def _repo_root() -> Path:
+    here = Path(__file__).resolve()
+    for candidate in [here.parent, *here.parents]:
+        if (candidate / "artifacts").exists():
+            return candidate
+    return here.parent.parent.parent
+
+
+def _resolve_delegate(preferred: str) -> Path:
+    candidate = Path(preferred)
+    if candidate.is_absolute():
+        return candidate
+    root = _repo_root()
+    from_script_dir = (Path(__file__).resolve().parent / candidate).resolve()
+    from_root = (root / candidate).resolve()
+    if from_root.exists():
+        return from_root
+    return from_script_dir
+
+
+def _discover_pdfs(input_dir: Path) -> List[Path]:
+    if not input_dir.exists() or not input_dir.is_dir():
+        return []
+    return sorted(
+        [
+            p for p in input_dir.rglob("*")
+            if p.is_file() and p.suffix.lower() == ".pdf"
+        ],
+        key=lambda p: str(p).lower(),
+    )
+
+
+def _extract_json_object(text: str) -> Optional[Dict[str, Any]]:
+    text = text.strip()
+    if not text:
+        return None
+    try:
+        value = json.loads(text)
+        if isinstance(value, dict):
+            return value
+    except json.JSONDecodeError:
+        pass
+    start = text.find("{")
+    while start != -1:
+        for end in range(len(text), start, -1):
+            chunk = text[start:end].strip()
+            if not chunk.endswith("}"):
+                continue
+            try:
+                value = json.loads(chunk)
+                if isinstance(value, dict):
+                    return value
+            except json.JSONDecodeError:
+                continue
+        start = text.find("{", start + 1)
+    return None
+
+
+def _load_json_file(path: Path) -> Optional[Dict[str, Any]]:
+    try:
+        if path.exists():
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                return data
+    except Exception:
+        return None
+    return None
+
+
+def _output_attestation(path: Path) -> Dict[str, Any]:
+    exists = path.exists()
+    size = path.stat().st_size if exists and path.is_file() else 0
+    return {
+        "excel_written": bool(exists and path.suffix.lower() == ".xlsx" and size > 0),
+        "output_exists": bool(exists),
+        "output_size_bytes": int(size),
+        "output_path": str(path),
+    }
+
+
+def _normalize_counter(value: Any) -> Dict[str, int]:
+    if not isinstance(value, dict):
+        return {"success": 0, "partial": 0, "failed": 0}
+    return {
+        "success": int(value.get("success", 0) or 0),
+        "partial": int(value.get("partial", 0) or 0),
+        "failed": int(value.get("failed", 0) or 0),
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Reviewable PDF-to-Excel OCR inbox runner")
+    parser.add_argument("--input-dir", default=DEFAULT_INPUT_DIR)
+    parser.add_argument("--output-xlsx", default=DEFAULT_OUTPUT_XLSX)
+    parser.add_argument("--ocr", default=DEFAULT_OCR)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--origin-id", default=DEFAULT_ORIGIN_ID)
+    parser.add_argument("--title", default=DEFAULT_TITLE)
+    parser.add_argument("--description", default=DEFAULT_DESCRIPTION)
+    parser.add_argument("--label", action="append", dest="labels")
+    parser.add_argument("--preferred-base-script", default=DEFAULT_PREFERRED_BASE)
+    parser.add_argument("--timeout-seconds", type=int, default=DEFAULT_TIMEOUT_SECONDS)
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    labels = args.labels if args.labels else list(DEFAULT_LABELS)
+    input_dir = _expand(args.input_dir)
+    output_xlsx = _expand(args.output_xlsx)
+    delegate_path = _resolve_delegate(args.preferred_base_script)
+    discovered_pdfs = _discover_pdfs(input_dir)
+
+    result: Dict[str, Any] = {
+        "status": "failed",
+        "summary": "",
+        "request": {
+            "origin_id": args.origin_id,
+            "title": args.title,
+            "description": args.description,
+            "labels": labels,
+            "ocr": args.ocr,
+            "dry_run": bool(args.dry_run),
+            "input_dir": str(input_dir),
+            "output_xlsx": str(output_xlsx),
+        },
+        "preflight": {
+            "delegate_path": str(delegate_path),
+            "delegate_exists": delegate_path.exists(),
+            "input_dir_exists": input_dir.exists(),
+            "input_dir_is_dir": input_dir.is_dir(),
+            "pdf_discovery_mode": "recursive",
+            "discovered_pdf_count": len(discovered_pdfs),
+            "discovered_pdfs": [str(p) for p in discovered_pdfs],
+        },
+        "execution": {
+            "delegated": False,
+            "timeout_seconds": int(args.timeout_seconds),
+        },
+        "delegate": None,
+        "output_attestation": _output_attestation(output_xlsx),
+        "limitations": [],
+        "next_steps": [],
+    }
+
+    if output_xlsx.suffix.lower() != ".xlsx":
+        result["status"] = "failed"
+        result["summary"] = "Requested output path does not end with .xlsx; refusing mismatched output semantics."
+        result["limitations"].append("Output path must end with .xlsx for workbook semantics.")
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 1
+
+    if not delegate_path.exists():
+        result["status"] = "failed"
+        result["summary"] = "Reviewed delegate script was not found; wrapper refuses to broaden behavior."
+        result["limitations"].append("Delegate missing: only reviewed repository delegate is allowed for readonly preview flows.")
+        result["next_steps"].append("Restore or provide artifacts/scripts/pdf_to_excel_ocr.py at the expected repository location.")
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 1
+
+    if args.dry_run:
+        result["status"] = "partial"
+        result["summary"] = "Dry-run requested; wrapper performed preflight only and did not delegate execution."
+        result["limitations"].append("No XLSX artifact is produced during wrapper short-circuit dry-run.")
+        result["next_steps"].append("Run without --dry-run to attempt reviewed delegate conversion.")
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0
+
+    if len(discovered_pdfs) == 0:
+        result["status"] = "partial"
+        result["summary"] = "No PDF files were discovered under the provided input directory."
+        result["limitations"].append("No candidate PDFs found for conversion, so no XLSX was produced.")
+        result["next_steps"].append("Place one or more PDF files in the input directory and rerun the helper.")
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0
+
+    output_xlsx.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="pdf_to_excel_delegate_") as tmp_dir:
+        report_json = Path(tmp_dir) / "delegate_report.json"
+        cmd = [
+            sys.executable,
+            str(delegate_path),
+            "--input-dir",
+            str(input_dir),
+            "--output-xlsx",
+            str(output_xlsx),
+            "--ocr",
+            str(args.ocr),
+            "--report-json",
+            str(report_json),
+        ]
+
+        result["execution"]["delegated"] = True
+        result["execution"]["command"] = cmd
+
+        try:
+            completed = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=max(1, int(args.timeout_seconds)),
+                check=False,
+            )
+            stdout_json = _extract_json_object(completed.stdout or "")
+            sidecar_json = _load_json_file(report_json)
+            delegate_report = stdout_json or sidecar_json or {}
+            result["delegate"] = {
+                "returncode": int(completed.returncode),
+                "stdout": completed.stdout,
+                "stderr": completed.stderr,
+                "report_source": (
+                    "stdout_json" if stdout_json is not None else
+                    "sidecar_json" if sidecar_json is not None else
+                    "none"
+                ),
+                "report": delegate_report,
+            }
+        except subprocess.TimeoutExpired as exc:
+            result["status"] = "failed"
+            result["summary"] = f"Delegate execution timed out after {int(args.timeout_seconds)} seconds."
+            result["delegate"] = {
+                "timeout": True,
+                "stdout": exc.stdout,
+                "stderr": exc.stderr,
+                "report_source": "none",
+                "report": {},
+            }
+            result["limitations"].append("Delegate subprocess did not complete within the explicit timeout.")
+            result["next_steps"].append("Retry with a larger --timeout-seconds value or reduce the input set.")
+            result["output_attestation"] = _output_attestation(output_xlsx)
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 1
+
+    report = result["delegate"].get("report") if isinstance(result.get("delegate"), dict) else {}
+    if not isinstance(report, dict):
+        report = {}
+
+    delegate_status = report.get("status")
+    delegate_total_files = int(report.get("total_files", 0) or 0)
+    delegate_dry_run = bool(report.get("dry_run", False))
+    status_counter = _normalize_counter(report.get("status_counter"))
+
+    attestation = _output_attestation(output_xlsx)
+    report_excel_written = report.get("excel_written")
+    report_output_exists = report.get("output_exists")
+    report_output_size_bytes = report.get("output_size_bytes")
+    if isinstance(report_excel_written, bool):
+        attestation["excel_written"] = report_excel_written
+    if isinstance(report_output_exists, bool):
+        attestation["output_exists"] = report_output_exists
+    if isinstance(report_output_size_bytes, int):
+        attestation["output_size_bytes"] = report_output_size_bytes
+    result["output_attestation"] = attestation
+
+    success_gates = all([
+        delegate_status == "success",
+        delegate_total_files >= 1,
+        delegate_dry_run is False,
+        status_counter.get("failed", 0) == 0,
+        status_counter.get("partial", 0) == 0,
+        attestation.get("excel_written") is True,
+        attestation.get("output_exists") is True,
+        int(attestation.get("output_size_bytes", 0) or 0) > 0,
+    ])
+
+    if success_gates:
+        result["status"] = "success"
+        result["summary"] = "Reviewed delegate reported success with sufficient structured evidence and a real XLSX output attestation."
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0
+
+    if delegate_status == "partial":
+        result["status"] = "partial"
+        result["summary"] = "Delegate returned a structured partial outcome; preserving partial status for reviewable best-effort flow."
+        result["limitations"].append("Success-only evidence gates were not fully satisfied by the delegate report.")
+        result["next_steps"].append("Review delegate stdout/stderr and report details to determine whether OCR support, PDF quality, or dependencies limited extraction.")
+        result["next_steps"].append("If needed, rerun against a smaller known-good sample set or verify the reviewed delegate runtime prerequisites.")
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0
+
+    result["status"] = "failed"
+    result["summary"] = "Delegate did not provide sufficient structured evidence for success, and no contract-compliant partial outcome was established."
+    result["limitations"].append("Wrapper will not treat exit code plus output-file existence alone as sufficient success evidence.")
+    if delegate_status is None:
+        result["limitations"].append("No canonical delegate JSON report was available from stdout or sidecar.")
+    else:
+        result["limitations"].append(f"Delegate status was {delegate_status!r}, which did not satisfy success gates.")
+    result["next_steps"].append("Inspect the reviewed delegate CLI compatibility and JSON report fields status/total_files/status_counter/dry_run.")
+    result["next_steps"].append("Ensure the delegate emits or writes contract-compliant JSON via stdout or --report-json sidecar.")
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runtime_archives/bl057/runtime/automation-runtime.attempt-1.log
+++ b/runtime_archives/bl057/runtime/automation-runtime.attempt-1.log
@@ -1,0 +1,19 @@
+task_id: AUTO-20260325-869
+worker: automation
+attempt: 1
+container_name: argus-automation-auto-20260325-869
+worker_image: argus-worker:latest
+started_at: 2026-03-25T08:56:42.585645Z
+finished_at: 2026-03-25T08:58:12.605551Z
+exit_code: 0
+timed_out: False
+wait_error: 
+
+=== stdout ===
+[2026-03-25T08:56:42.837970Z] [automation] [INFO] Worker started using endpoint https://fast.vpsairobot.com/v1/chat/completions (timeout=120s, attempts=3, timeout_recovery_retries=1)
+[2026-03-25T08:58:12.456099Z] [automation] [INFO] Artifact written: artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
+[2026-03-25T08:58:12.457318Z] [automation] [INFO] Task completed AUTO-20260325-869 with status success
+[2026-03-25T08:58:12.458675Z] [automation] [INFO] Worker exiting from /app/workspaces/automation/AUTO-20260325-869
+
+=== stderr ===
+

--- a/runtime_archives/bl057/runtime/critic-output.json
+++ b/runtime_archives/bl057/runtime/critic-output.json
@@ -1,0 +1,28 @@
+{
+  "task_id": "CRITIC-20260325-285",
+  "worker": "critic",
+  "status": "success",
+  "summary": "Reviewed the inbox runner and paired delegate together as an end-to-end readonly smoke path. Verdict: needs_revision due to wrapper/delegate CLI contract mismatch and evidence-loss risk when both stdout JSON and sidecar JSON are present.",
+  "artifacts": [
+    {
+      "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+      "type": "review"
+    }
+  ],
+  "timestamp": "2026-03-25T08:58:46.896406Z",
+  "duration_ms": 34038,
+  "notes": [
+    "Scope included both artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py and artifacts/scripts/pdf_to_excel_ocr.py as a single readonly pair.",
+    "Review is grounded in the supplied artifact snapshots.",
+    "A review artifact markdown file is provided via file_contents for the expected path."
+  ],
+  "metadata": {
+    "verdict": "needs_revision",
+    "task_id": "CRITIC-20260325-285",
+    "worker": "critic",
+    "reviewed_artifacts": [
+      "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+      "artifacts/scripts/pdf_to_excel_ocr.py"
+    ]
+  }
+}

--- a/runtime_archives/bl057/runtime/critic-produced-pdf_to_excel_ocr_inbox_review.md
+++ b/runtime_archives/bl057/runtime/critic-produced-pdf_to_excel_ocr_inbox_review.md
@@ -1,0 +1,68 @@
+# Review: pdf_to_excel_ocr_inbox_runner.py
+
+## Scope
+- Primary artifact: `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`
+- Paired artifact: `artifacts/scripts/pdf_to_excel_ocr.py`
+- Review goal: audit the wrapper and reviewed delegate together for the end-to-end readonly smoke path.
+
+## Findings
+1. **Wrapper enforces a useful readonly/evidence-backed posture**
+   - The runner resolves the delegate from repository-relative locations instead of reimplementing conversion logic.
+   - It performs recursive PDF discovery, explicit timeout handling, dry-run short-circuiting, and structured JSON result emission.
+   - Its success gate is stronger than simple exit-code checking: it requires delegate status success, at least one file, no partial/failed counts, non-dry-run, and positive XLSX attestation.
+   - This aligns well with the stated contract: do not claim OCR/conversion success without evidence.
+
+2. **Delegate is a reasonable reviewed batch extractor with best-effort semantics**
+   - The delegate supports recursive PDF discovery, OCR modes (`auto|on|off`), dry-run, JSON reporting, and per-file isolation.
+   - It cleanly distinguishes aggregate `success`, `partial`, and `failed` outcomes.
+   - It emits structured notes/next steps when OCR dependencies are missing or files are partial/failed.
+   - It avoids overstating OCR capability and reports missing runtime dependencies explicitly.
+
+3. **Critical end-to-end contract bug: wrapper never forwards `--dry-run` to the delegate**
+   - In the runner, `--dry-run` causes the wrapper itself to return partial before delegation.
+   - However, if the intended behavior is delegate dry-run compatibility, the subprocess command omits `--dry-run` entirely.
+   - This means wrapper-level dry-run and delegate-level dry-run semantics are not aligned; the wrapper cannot verify delegate dry-run behavior and narrows the execution path.
+   - This is not catastrophic for readonly smoke, but it weakens end-to-end fidelity.
+
+4. **More serious integration bug: wrapper prefers stdout JSON over sidecar JSON**
+   - The delegate always prints JSON to stdout and can also write the same JSON to the sidecar path.
+   - The wrapper chooses `stdout_json or sidecar_json or {}`.
+   - Because stdout may contain truncated or contaminated JSON while the sidecar is the stronger contract artifact, preferring stdout can discard the more reliable sidecar report.
+   - For a reviewable evidence-backed pipeline, sidecar JSON should usually be preferred or reconciled, not treated as lower priority than stdout scraping.
+
+5. **Potential parsing fragility in `_extract_json_object`**
+   - The wrapper attempts to recover a JSON object from arbitrary stdout by scanning brace ranges.
+   - This is permissive and can succeed on an unintended substring if stdout ever contains additional brace-like content.
+   - Since the delegate already supports `--report-json`, the wrapper should rely primarily on the sidecar and treat stdout parsing as fallback.
+
+6. **Readonly boundary is mostly respected**
+   - The provided Trello-oriented metadata is only carried in the wrapper request payload and not written back externally.
+   - The pair appears limited to local artifact handling and local subprocess execution.
+   - No Trello writeback behavior is present in the reviewed code.
+
+7. **Delegate behavior is mostly internally coherent**
+   - `discover_pdfs`, OCR runtime detection, per-file processing, and final Excel writing/reporting are consistent.
+   - Aggregate status is `success` only when no file is partial/failed, which matches the wrapper's stricter gating.
+   - The delegate may return aggregate `partial` even after writing an XLSX, which is appropriate for best-effort evidence-backed reporting.
+
+8. **Minor design observations**
+   - The delegate's write step can mark the final report as `failed` if Excel writing fails, even after extraction completed. This is honest and acceptable.
+   - The wrapper's `_repo_root()` heuristic is acceptable for the reviewed repository layout, though somewhat implicit.
+   - The wrapper's attestation merge trusts delegate-reported output booleans/sizes over filesystem observations when types match. Filesystem attestation is generally stronger and should likely remain authoritative.
+
+## Verdict
+**needs_revision**
+
+## Rationale
+The pair is close to acceptable and demonstrates strong intent around readonly, evidence-backed, non-overclaiming behavior. However, the review cannot pass because there is a meaningful end-to-end integration weakness:
+
+- the wrapper/delegate contract is imperfect (`--dry-run` is not forwarded), and
+- the wrapper prioritizes stdout JSON scraping over the explicit `--report-json` sidecar, which can lose or weaken evidence in the exact area where the pipeline is supposed to be reviewable and deterministic.
+
+These are revision-level issues rather than total failure because the overall structure is sound, the delegate is credible, and the wrapper largely enforces honest success criteria. But the evidence handoff path should be corrected before calling the paired implementation fully passable.
+
+### Recommended revisions
+1. Prefer sidecar JSON over stdout-derived JSON when `--report-json` is supplied; use stdout parsing only as fallback.
+2. Forward `--dry-run` to the delegate if the wrapper intends to preserve delegate-compatible dry-run semantics, or explicitly document that wrapper dry-run is preflight-only and not delegated.
+3. Consider keeping filesystem-derived output attestation authoritative, using delegate-reported values only as supplemental evidence.
+4. Tighten `_extract_json_object` usage or reduce dependence on stdout scraping altogether.

--- a/runtime_archives/bl057/runtime/critic-runtime.attempt-1.log
+++ b/runtime_archives/bl057/runtime/critic-runtime.attempt-1.log
@@ -1,0 +1,19 @@
+task_id: CRITIC-20260325-285
+worker: critic
+attempt: 1
+container_name: argus-critic-critic-20260325-285
+worker_image: argus-worker:latest
+started_at: 2026-03-25T08:58:12.646230Z
+finished_at: 2026-03-25T08:58:47.011127Z
+exit_code: 0
+timed_out: False
+wait_error: 
+
+=== stdout ===
+[2026-03-25T08:58:12.858964Z] [critic] [INFO] Worker started using endpoint https://fast.vpsairobot.com/v1/chat/completions (timeout=120s, attempts=3, timeout_recovery_retries=1)
+[2026-03-25T08:58:46.895823Z] [critic] [INFO] Artifact written: artifacts/reviews/pdf_to_excel_ocr_inbox_review.md
+[2026-03-25T08:58:46.896976Z] [critic] [INFO] Task completed CRITIC-20260325-285 with status success
+[2026-03-25T08:58:46.898048Z] [critic] [INFO] Worker exiting from /app/workspaces/critic/CRITIC-20260325-285
+
+=== stderr ===
+

--- a/runtime_archives/bl057/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf.approval.json
+++ b/runtime_archives/bl057/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf.approval.json
@@ -1,0 +1,7 @@
+{
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf",
+  "approved": true,
+  "approved_by": "Oscarling",
+  "approved_at": "2026-03-25T08:53:25Z",
+  "note": "BL-20260325-057 governed validation execute only; no Git finalization; no Trello Done."
+}

--- a/runtime_archives/bl057/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf.approval.result.json
+++ b/runtime_archives/bl057/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf.approval.result.json
@@ -1,0 +1,9 @@
+{
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf",
+  "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf.json",
+  "executed_at": "2026-03-25T08:58:47.041032Z",
+  "status": "rejected",
+  "decision_reason": "critic_verdict=needs_revision",
+  "critic_verdict": "needs_revision",
+  "test_mode": "off"
+}

--- a/runtime_archives/bl057/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf.json
+++ b/runtime_archives/bl057/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf.json
@@ -1,0 +1,398 @@
+{
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf",
+  "created_at": "2026-03-25T08:53:07.470784Z",
+  "approved": true,
+  "source": {
+    "kind": "local_inbox",
+    "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+    "received_at": "2026-03-25T08:53:07.470167Z",
+    "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl057-001.json",
+    "regeneration_token": "regen-20260325-bl057-001"
+  },
+  "external_input": {
+    "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+    "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+    "labels": [
+      "best_effort",
+      "evidence_backed",
+      "readonly",
+      "reviewable",
+      "trello"
+    ],
+    "metadata": {
+      "source_system": "trello",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "card_short_id": 7,
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "date_last_activity": "2026-03-24T08:35:56.234Z",
+      "readonly_mapped_at": "2026-03-25T08:52:30.351021Z",
+      "contract_profile": "best_effort_evidence_backed",
+      "ocr_claim_policy": "do_not_claim_success_without_evidence",
+      "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+      "regeneration_token": "regen-20260325-bl057-001"
+    },
+    "request_type": "pdf_to_excel_ocr",
+    "input": {
+      "input_dir": "~/Desktop/pdf样本",
+      "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+      "ocr": "auto",
+      "dry_run": false
+    }
+  },
+  "task_summary": {
+    "automation": {
+      "task_id": "AUTO-20260325-869",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+      "expected_outputs": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ]
+    },
+    "critic": {
+      "task_id": "CRITIC-20260325-285",
+      "worker": "critic",
+      "task_type": "review_artifact",
+      "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+      "expected_outputs": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ]
+    }
+  },
+  "internal_tasks": {
+    "automation": {
+      "task_id": "AUTO-20260325-869",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+      "inputs": {
+        "params": {
+          "input_dir": "~/Desktop/pdf样本",
+          "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+          "ocr": "auto",
+          "dry_run": false,
+          "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+          "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+          "description": "Purpose: | Controlled Trello live preview smoke for openclaw-team. | Expected behavior: | - read-only Trello ingest | - preview creation smoke only | - no business execution claim | - no Trello writeback expected in this step | Traceability: | - backlog: BL-20260324-014 | - blocker context: BL-20260324-015 | - created_by: Oscarling | - created_at: 2026-03-24 Asia/Shanghai | Note: | This card is only for governed smoke verification and should remain open until the smoke is finished.",
+          "labels": [
+            "best_effort",
+            "evidence_backed",
+            "readonly",
+            "reviewable",
+            "trello"
+          ],
+          "preferred_wrapper_script": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "preferred_base_script": "artifacts/scripts/pdf_to_excel_ocr.py",
+          "reference_docs": [
+            "artifacts/docs/pdf_to_excel_ocr_usage.md",
+            "artifacts/reviews/pdf_to_excel_ocr_review.md"
+          ],
+          "contract_hints": {
+            "output_format_fidelity": "If output_xlsx ends with .xlsx, produce a real XLSX workbook container or fail honestly before writing mismatched text/XML/CSV content to a .xlsx path.",
+            "path_portability": "Use the provided input_dir parameter as runtime input. Do not hardcode a user-home or absolute input path when params already declare the path.",
+            "traceability": "Preserve meaningful description context from the external input; do not collapse it to a heading fragment such as Purpose:.",
+            "reuse_preference": "Prefer reusing artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py as the wrapper baseline and artifacts/scripts/pdf_to_excel_ocr.py as the reviewed delegate when compatible, so workbook semantics and contract behavior stay aligned with repository evidence.",
+            "outcome_status_model": "Use the reviewable status model success/partial/failed. Dry-run requests or zero-PDF discovery should resolve to partial rather than claiming success without an output artifact.",
+            "delegate_resolution": "If preferred_base_script is relative, resolve it from the repository or script location instead of Path.cwd() so behavior stays portable across shells and CI.",
+            "reviewed_delegate_contract": "For readonly reviewable preview flows, delegate only to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py or fail honestly instead of broadening behavior through an arbitrary helper.",
+            "delegate_success_evidence": "Do not treat zero exit code plus output-file existence as sufficient wrapper success evidence on their own. Prefer a structured delegate report that confirms a real success outcome before the wrapper claims success. Require delegate status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, and explicit output attestation fields excel_written=true, output_exists=true, and output_size_bytes>0. Apply these gates only when wrapper status is success.",
+            "delegate_partial_evidence": "For best-effort readonly flows, if delegate status is partial and structured evidence is present, keep wrapper status partial instead of escalating to failed solely because success-only gates are unmet. Surface explicit limitations and next-step guidance in wrapper output.",
+            "delegate_timeout": "Bound delegate subprocess execution with an explicit timeout and report timeout as an honest failed/partial outcome instead of allowing smoke automation to hang indefinitely.",
+            "runtime_summary": "The generated script should emit a structured summary of what it produced so later review can inspect behavior without guessing.",
+            "delegate_report_schema": "Treat delegate JSON report fields status/total_files/status_counter/dry_run as the canonical evidence contract. Do not require undeclared processed_files/succeeded_files/failed_files counters.",
+            "delegate_report_handoff": "When the delegate prints a JSON report to stdout, parse that JSON directly instead of relying only on sidecar-report file path discovery.",
+            "delegate_report_flag_contract": "If wrapper passes a sidecar report path to the reviewed delegate, use the reviewed delegate CLI flag --report-json (or another explicitly supported alias). Do not invent undeclared flags such as --report-file.",
+            "dry_run_semantics": "If wrapper dry-run short-circuits before delegate execution, keep execution.delegated=false and report partial honestly. If wrapper does delegate under dry-run, pass through --dry-run explicitly.",
+            "pdf_discovery_consistency": "Keep wrapper preflight PDF discovery semantics aligned with the reviewed delegate (for example recursive vs non-recursive), so wrapper evidence and delegated execution count the same candidate set."
+          }
+        }
+      },
+      "expected_outputs": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ],
+      "constraints": [
+        "Follow the local inbox normalized request",
+        "Do not claim unsupported runtime dependencies",
+        "Keep output deterministic and executable",
+        "Produce only the expected script artifact",
+        "Prefer honest, reviewable intermediate behavior over unsupported OCR claims",
+        "If the requested output path ends with .xlsx, do not write non-XLSX text/XML/CSV content to that path.",
+        "Do not hardcode an input directory when the task params already provide input_dir.",
+        "Preserve meaningful traceability from the incoming description instead of collapsing it to a heading fragment.",
+        "Prefer wrapping or adapting artifacts/scripts/pdf_to_excel_ocr.py when that existing repo script already matches the requested behavior.",
+        "When artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py already exists, prefer updating that reviewed wrapper baseline instead of rewriting a new control flow from scratch.",
+        "If dry_run is true or no PDFs are discovered, report a reviewable partial outcome instead of claiming success without an XLSX artifact.",
+        "Resolve relative delegate script paths from the repository or script location, not from Path.cwd().",
+        "For readonly reviewable preview flows, only delegate to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py unless failing honestly.",
+        "Do not claim wrapper success from exit code plus output existence alone when the reviewed delegate report does not provide strong enough success evidence.",
+        "When wrapper reports success, enforce delegate evidence gates: status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, excel_written=true, output_exists=true, and output_size_bytes>0.",
+        "If delegate reports partial with structured evidence in readonly best-effort mode, keep wrapper status partial (not failed) and include explicit limitations with next-step guidance.",
+        "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
+        "When delegate emits JSON to stdout, parse that report directly instead of depending only on sidecar report-file discovery.",
+        "When wrapper passes a sidecar report path to the reviewed delegate, use --report-json exactly unless the reviewed delegate explicitly supports another alias.",
+        "If wrapper supports dry-run short-circuit semantics, keep execution.delegated=false and preserve partial status honestly.",
+        "Keep wrapper PDF discovery semantics aligned with reviewed delegate discovery semantics to avoid preflight/execution evidence drift.",
+        "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely."
+      ],
+      "priority": "medium",
+      "source": {
+        "kind": "local_inbox",
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl057-001.json",
+        "received_at": "2026-03-25T08:53:07.470167Z",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "regeneration_token": "regen-20260325-bl057-001"
+      },
+      "acceptance_criteria": [
+        "Produce the expected script artifact at expected_outputs[0].path",
+        "Script behavior remains runnable, deterministic, and reviewable",
+        "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
+        "Artifact behavior remains parameter-driven for input_dir and output_xlsx rather than hardcoding unrelated local defaults.",
+        "Dry-run or zero-input behavior is represented as a reviewable partial outcome instead of artifact-production success.",
+        "Relative preferred_base_script resolution remains portable and does not depend on Path.cwd().",
+        "Wrapper success requires stronger delegate evidence than zero exit code plus a non-empty output file alone.",
+        "Wrapper success attestation requires delegate fields excel_written=true, output_exists=true, output_size_bytes>0, and status_counter.partial/status_counter.failed equal to 0.",
+        "Contract-compliant delegate partial outcomes remain partial with explicit limitations and next-step guidance, rather than being escalated to failed by success-only gates.",
+        "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
+        "Delegate report handoff can consume JSON printed to stdout without relying exclusively on report sidecar file discovery.",
+        "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",
+        "Dry-run semantics remain explicit: short-circuit stays partial with no delegated execution, or delegated dry-run is passed through honestly.",
+        "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
+        "Delegate execution is bounded by an explicit timeout and reports timeout honestly."
+      ],
+      "metadata": {
+        "integration_phase": "8B",
+        "pipeline": "inbox->adapter->manager->automation->critic",
+        "request_type": "pdf_to_excel_ocr",
+        "payload_hash": "d472aab5e3bfd5e47ecb7dfc9ffffda4d8721a5ad56b9dd611be066645a67b40",
+        "regeneration_token": "regen-20260325-bl057-001",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "external_metadata": {
+          "source_system": "trello",
+          "card_id": "69c24cd3c1a2359ddd7a1bf8",
+          "card_short_id": 7,
+          "board_id": "69be462743bfa0038ca10f7a",
+          "list_id": "69be462743bfa0038ca10f8f",
+          "date_last_activity": "2026-03-24T08:35:56.234Z",
+          "readonly_mapped_at": "2026-03-25T08:52:30.351021Z",
+          "contract_profile": "best_effort_evidence_backed",
+          "ocr_claim_policy": "do_not_claim_success_without_evidence",
+          "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+          "regeneration_token": "regen-20260325-bl057-001"
+        },
+        "automation_contract_profile": "narrow_script_artifact_with_repo_reuse_and_reviewable_runner_contract"
+      }
+    },
+    "critic": {
+      "task_id": "CRITIC-20260325-285",
+      "worker": "critic",
+      "task_type": "review_artifact",
+      "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+      "inputs": {
+        "artifacts": [
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "type": "script"
+          },
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+            "type": "script"
+          }
+        ],
+        "params": {
+          "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+          "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+          "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+          "labels": [
+            "best_effort",
+            "evidence_backed",
+            "readonly",
+            "reviewable",
+            "trello"
+          ],
+          "review_scope": {
+            "primary_artifact": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "paired_artifacts": [
+              "artifacts/scripts/pdf_to_excel_ocr.py"
+            ],
+            "goal": "Audit the wrapper and the reviewed delegate together so the review evidence can speak to the end-to-end readonly smoke path."
+          }
+        }
+      },
+      "expected_outputs": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ],
+      "constraints": [
+        "Review must be grounded in produced automation artifact",
+        "When both wrapper and reviewed delegate snapshots are supplied, evaluate them as one end-to-end readonly pair instead of ignoring the delegate evidence.",
+        "Do not invent missing artifact content",
+        "Return a clear verdict: pass, fail, or needs_revision",
+        "Include metadata.verdict in output",
+        "Generate review artifact markdown for expected_outputs[0].path"
+      ],
+      "priority": "medium",
+      "source": {
+        "kind": "local_inbox",
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl057-001.json",
+        "received_at": "2026-03-25T08:53:07.470167Z",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "regeneration_token": "regen-20260325-bl057-001"
+      },
+      "acceptance_criteria": [
+        "Produce a review artifact with explicit verdict (pass/fail/needs_revision)"
+      ],
+      "metadata": {
+        "integration_phase": "8B",
+        "pipeline": "inbox->adapter->manager->automation->critic",
+        "request_type": "pdf_to_excel_ocr",
+        "payload_hash": "d472aab5e3bfd5e47ecb7dfc9ffffda4d8721a5ad56b9dd611be066645a67b40",
+        "regeneration_token": "regen-20260325-bl057-001",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "external_metadata": {
+          "source_system": "trello",
+          "card_id": "69c24cd3c1a2359ddd7a1bf8",
+          "card_short_id": 7,
+          "board_id": "69be462743bfa0038ca10f7a",
+          "list_id": "69be462743bfa0038ca10f8f",
+          "date_last_activity": "2026-03-24T08:35:56.234Z",
+          "readonly_mapped_at": "2026-03-25T08:52:30.351021Z",
+          "contract_profile": "best_effort_evidence_backed",
+          "ocr_claim_policy": "do_not_claim_success_without_evidence",
+          "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+          "regeneration_token": "regen-20260325-bl057-001"
+        }
+      }
+    }
+  },
+  "expected_artifacts": [
+    "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+    "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py"
+  ],
+  "dedupe_keys": [
+    "origin_regeneration:trello:69c24cd3c1a2359ddd7a1bf8:regen-20260325-bl057-001",
+    "hash:d472aab5e3bfd5e47ecb7dfc9ffffda4d8721a5ad56b9dd611be066645a67b40"
+  ],
+  "risk_warnings": [],
+  "execution": {
+    "status": "rejected",
+    "executed": true,
+    "attempts": 2,
+    "executed_at": "2026-03-25T08:58:47.040204Z",
+    "decision_reason": "critic_verdict=needs_revision"
+  },
+  "approval": {
+    "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf.json",
+    "approved_by": "Oscarling",
+    "approved_at": "2026-03-25T08:53:25Z",
+    "note": "BL-20260325-057 governed validation execute only; no Git finalization; no Trello Done."
+  },
+  "last_execution": {
+    "decision": "rejected",
+    "decision_reason": "critic_verdict=needs_revision",
+    "automation_result": {
+      "task_id": "AUTO-20260325-869",
+      "worker": "automation",
+      "status": "success",
+      "summary": "Generated one runnable helper wrapper script artifact that reuses the reviewed PDF-to-Excel delegate with portable path resolution, structured delegate-report parsing, timeout handling, honest partial/failure outcomes, and success evidence gates aligned to the provided contract.",
+      "artifacts": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ],
+      "timestamp": "2026-03-25T08:58:12.456707Z",
+      "duration_ms": 89619,
+      "notes": [
+        "Produced exactly one script artifact as requested.",
+        "The wrapper is parameter-driven and avoids hardcoded input/output defaults when explicit arguments are provided at runtime.",
+        "It prefers the reviewed delegate artifacts/scripts/pdf_to_excel_ocr.py, resolves relative delegate paths from the repository/script location, uses --report-json for sidecar handoff, parses JSON from stdout when available, and enforces stronger success evidence before claiming success.",
+        "Dry-run short-circuits to partial with execution.delegated=false, and zero-PDF discovery also resolves to partial."
+      ],
+      "metadata": {
+        "task_id": "AUTO-20260325-869",
+        "worker": "automation",
+        "output_contract": "single_json_object",
+        "generated_files": 1
+      }
+    },
+    "critic_result": {
+      "task_id": "CRITIC-20260325-285",
+      "worker": "critic",
+      "status": "success",
+      "summary": "Reviewed the inbox runner and paired delegate together as an end-to-end readonly smoke path. Verdict: needs_revision due to wrapper/delegate CLI contract mismatch and evidence-loss risk when both stdout JSON and sidecar JSON are present.",
+      "artifacts": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ],
+      "timestamp": "2026-03-25T08:58:46.896406Z",
+      "duration_ms": 34038,
+      "notes": [
+        "Scope included both artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py and artifacts/scripts/pdf_to_excel_ocr.py as a single readonly pair.",
+        "Review is grounded in the supplied artifact snapshots.",
+        "A review artifact markdown file is provided via file_contents for the expected path."
+      ],
+      "metadata": {
+        "verdict": "needs_revision",
+        "task_id": "CRITIC-20260325-285",
+        "worker": "critic",
+        "reviewed_artifacts": [
+          "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "artifacts/scripts/pdf_to_excel_ocr.py"
+        ]
+      }
+    },
+    "critic_verdict": "needs_revision"
+  }
+}

--- a/runtime_archives/bl057/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl057-001.json
+++ b/runtime_archives/bl057/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl057-001.json
@@ -1,0 +1,41 @@
+{
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "metadata": {
+    "source_system": "trello",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "card_short_id": 7,
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "date_last_activity": "2026-03-24T08:35:56.234Z",
+    "readonly_mapped_at": "2026-03-25T08:52:30.351021Z",
+    "contract_profile": "best_effort_evidence_backed",
+    "ocr_claim_policy": "do_not_claim_success_without_evidence",
+    "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+    "regeneration_token": "regen-20260325-bl057-001"
+  },
+  "source": {
+    "provider": "trello",
+    "mode": "readonly",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "regeneration_token": "regen-20260325-bl057-001"
+  },
+  "request_type": "pdf_to_excel_ocr",
+  "input": {
+    "input_dir": "~/Desktop/pdf样本",
+    "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+    "ocr": "auto",
+    "dry_run": false
+  },
+  "regeneration_token": "regen-20260325-bl057-001"
+}

--- a/runtime_archives/bl057/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl057-001.json.result.json
+++ b/runtime_archives/bl057/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl057-001.json.result.json
@@ -1,0 +1,23 @@
+{
+  "ingested_at": "2026-03-25T08:53:07.473054Z",
+  "status": "processed",
+  "decision": "preview_created_pending_approval",
+  "decision_reason": "preview_created; waiting_for_explicit_approval",
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "payload_hash": "d472aab5e3bfd5e47ecb7dfc9ffffda4d8721a5ad56b9dd611be066645a67b40",
+  "dedupe_keys": [
+    "origin_regeneration:trello:69c24cd3c1a2359ddd7a1bf8:regen-20260325-bl057-001",
+    "hash:d472aab5e3bfd5e47ecb7dfc9ffffda4d8721a5ad56b9dd611be066645a67b40"
+  ],
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf",
+  "preview_file": "/Users/lingguozhong/openclaw-team/preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf.json",
+  "regeneration_token": "regen-20260325-bl057-001"
+}

--- a/runtime_archives/bl057/tmp/bl057_execute_once_elevated.json
+++ b/runtime_archives/bl057/tmp/bl057_execute_once_elevated.json
@@ -1,0 +1,20 @@
+/Users/lingguozhong/Library/Python/3.9/lib/python/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
+  warnings.warn(
+{
+  "status": "done",
+  "processed": 0,
+  "rejected": 1,
+  "skipped": 0,
+  "test_mode": "off",
+  "allow_replay": true,
+  "results": [
+    {
+      "status": "rejected",
+      "decision_reason": "critic_verdict=needs_revision",
+      "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf",
+      "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf.json",
+      "result_sidecar": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf.result.json",
+      "critic_verdict": "needs_revision"
+    }
+  ]
+}

--- a/runtime_archives/bl057/tmp/bl057_execute_once_sandbox.json
+++ b/runtime_archives/bl057/tmp/bl057_execute_once_sandbox.json
@@ -1,0 +1,20 @@
+/Users/lingguozhong/Library/Python/3.9/lib/python/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
+  warnings.warn(
+{
+  "status": "done",
+  "processed": 0,
+  "rejected": 1,
+  "skipped": 0,
+  "test_mode": "off",
+  "allow_replay": false,
+  "results": [
+    {
+      "status": "rejected",
+      "decision_reason": "Failed to initialize docker client from environment. Ensure Docker access is available or pass docker_client explicitly.",
+      "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf",
+      "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf.json",
+      "result_sidecar": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf.result.json",
+      "critic_verdict": "needs_revision"
+    }
+  ]
+}

--- a/runtime_archives/bl057/tmp/bl057_ingest_once.json
+++ b/runtime_archives/bl057/tmp/bl057_ingest_once.json
@@ -1,0 +1,23 @@
+/Users/lingguozhong/Library/Python/3.9/lib/python/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
+  warnings.warn(
+{
+  "status": "done",
+  "processed": 1,
+  "rejected": 0,
+  "duplicate_skipped": 0,
+  "preview_created": 1,
+  "inbox_claimed": 1,
+  "processing_recovered": 0,
+  "test_mode": "success",
+  "results": [
+    {
+      "status": "processed",
+      "decision": "preview_created_pending_approval",
+      "decision_reason": "preview_created; waiting_for_explicit_approval",
+      "file": "/Users/lingguozhong/openclaw-team/processed/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl057-001.json",
+      "result_sidecar": "/Users/lingguozhong/openclaw-team/processed/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl057-001.json.result.json",
+      "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf",
+      "preview_file": "/Users/lingguozhong/openclaw-team/preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf.json"
+    }
+  ]
+}

--- a/runtime_archives/bl057/tmp/bl057_live_mapped_preview.json
+++ b/runtime_archives/bl057/tmp/bl057_live_mapped_preview.json
@@ -1,0 +1,38 @@
+{
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "metadata": {
+    "source_system": "trello",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "card_short_id": 7,
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "date_last_activity": "2026-03-24T08:35:56.234Z",
+    "readonly_mapped_at": "2026-03-25T08:52:30.351021Z",
+    "contract_profile": "best_effort_evidence_backed",
+    "ocr_claim_policy": "do_not_claim_success_without_evidence",
+    "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable"
+  },
+  "source": {
+    "provider": "trello",
+    "mode": "readonly",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f"
+  },
+  "request_type": "pdf_to_excel_ocr",
+  "input": {
+    "input_dir": "~/Desktop/pdf样本",
+    "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+    "ocr": "auto",
+    "dry_run": false
+  }
+}

--- a/runtime_archives/bl057/tmp/bl057_preview_state_pre_execute.json
+++ b/runtime_archives/bl057/tmp/bl057_preview_state_pre_execute.json
@@ -1,0 +1,331 @@
+{
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-d472aab5e3bf",
+  "created_at": "2026-03-25T08:53:07.470784Z",
+  "approved": false,
+  "source": {
+    "kind": "local_inbox",
+    "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+    "received_at": "2026-03-25T08:53:07.470167Z",
+    "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl057-001.json",
+    "regeneration_token": "regen-20260325-bl057-001"
+  },
+  "external_input": {
+    "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+    "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+    "labels": [
+      "best_effort",
+      "evidence_backed",
+      "readonly",
+      "reviewable",
+      "trello"
+    ],
+    "metadata": {
+      "source_system": "trello",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "card_short_id": 7,
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "date_last_activity": "2026-03-24T08:35:56.234Z",
+      "readonly_mapped_at": "2026-03-25T08:52:30.351021Z",
+      "contract_profile": "best_effort_evidence_backed",
+      "ocr_claim_policy": "do_not_claim_success_without_evidence",
+      "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+      "regeneration_token": "regen-20260325-bl057-001"
+    },
+    "request_type": "pdf_to_excel_ocr",
+    "input": {
+      "input_dir": "~/Desktop/pdf样本",
+      "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+      "ocr": "auto",
+      "dry_run": false
+    }
+  },
+  "task_summary": {
+    "automation": {
+      "task_id": "AUTO-20260325-869",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+      "expected_outputs": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ]
+    },
+    "critic": {
+      "task_id": "CRITIC-20260325-285",
+      "worker": "critic",
+      "task_type": "review_artifact",
+      "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+      "expected_outputs": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ]
+    }
+  },
+  "internal_tasks": {
+    "automation": {
+      "task_id": "AUTO-20260325-869",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+      "inputs": {
+        "params": {
+          "input_dir": "~/Desktop/pdf样本",
+          "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+          "ocr": "auto",
+          "dry_run": false,
+          "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+          "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+          "description": "Purpose: | Controlled Trello live preview smoke for openclaw-team. | Expected behavior: | - read-only Trello ingest | - preview creation smoke only | - no business execution claim | - no Trello writeback expected in this step | Traceability: | - backlog: BL-20260324-014 | - blocker context: BL-20260324-015 | - created_by: Oscarling | - created_at: 2026-03-24 Asia/Shanghai | Note: | This card is only for governed smoke verification and should remain open until the smoke is finished.",
+          "labels": [
+            "best_effort",
+            "evidence_backed",
+            "readonly",
+            "reviewable",
+            "trello"
+          ],
+          "preferred_wrapper_script": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "preferred_base_script": "artifacts/scripts/pdf_to_excel_ocr.py",
+          "reference_docs": [
+            "artifacts/docs/pdf_to_excel_ocr_usage.md",
+            "artifacts/reviews/pdf_to_excel_ocr_review.md"
+          ],
+          "contract_hints": {
+            "output_format_fidelity": "If output_xlsx ends with .xlsx, produce a real XLSX workbook container or fail honestly before writing mismatched text/XML/CSV content to a .xlsx path.",
+            "path_portability": "Use the provided input_dir parameter as runtime input. Do not hardcode a user-home or absolute input path when params already declare the path.",
+            "traceability": "Preserve meaningful description context from the external input; do not collapse it to a heading fragment such as Purpose:.",
+            "reuse_preference": "Prefer reusing artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py as the wrapper baseline and artifacts/scripts/pdf_to_excel_ocr.py as the reviewed delegate when compatible, so workbook semantics and contract behavior stay aligned with repository evidence.",
+            "outcome_status_model": "Use the reviewable status model success/partial/failed. Dry-run requests or zero-PDF discovery should resolve to partial rather than claiming success without an output artifact.",
+            "delegate_resolution": "If preferred_base_script is relative, resolve it from the repository or script location instead of Path.cwd() so behavior stays portable across shells and CI.",
+            "reviewed_delegate_contract": "For readonly reviewable preview flows, delegate only to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py or fail honestly instead of broadening behavior through an arbitrary helper.",
+            "delegate_success_evidence": "Do not treat zero exit code plus output-file existence as sufficient wrapper success evidence on their own. Prefer a structured delegate report that confirms a real success outcome before the wrapper claims success. Require delegate status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, and explicit output attestation fields excel_written=true, output_exists=true, and output_size_bytes>0. Apply these gates only when wrapper status is success.",
+            "delegate_partial_evidence": "For best-effort readonly flows, if delegate status is partial and structured evidence is present, keep wrapper status partial instead of escalating to failed solely because success-only gates are unmet. Surface explicit limitations and next-step guidance in wrapper output.",
+            "delegate_timeout": "Bound delegate subprocess execution with an explicit timeout and report timeout as an honest failed/partial outcome instead of allowing smoke automation to hang indefinitely.",
+            "runtime_summary": "The generated script should emit a structured summary of what it produced so later review can inspect behavior without guessing.",
+            "delegate_report_schema": "Treat delegate JSON report fields status/total_files/status_counter/dry_run as the canonical evidence contract. Do not require undeclared processed_files/succeeded_files/failed_files counters.",
+            "delegate_report_handoff": "When the delegate prints a JSON report to stdout, parse that JSON directly instead of relying only on sidecar-report file path discovery.",
+            "delegate_report_flag_contract": "If wrapper passes a sidecar report path to the reviewed delegate, use the reviewed delegate CLI flag --report-json (or another explicitly supported alias). Do not invent undeclared flags such as --report-file.",
+            "dry_run_semantics": "If wrapper dry-run short-circuits before delegate execution, keep execution.delegated=false and report partial honestly. If wrapper does delegate under dry-run, pass through --dry-run explicitly.",
+            "pdf_discovery_consistency": "Keep wrapper preflight PDF discovery semantics aligned with the reviewed delegate (for example recursive vs non-recursive), so wrapper evidence and delegated execution count the same candidate set."
+          }
+        }
+      },
+      "expected_outputs": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ],
+      "constraints": [
+        "Follow the local inbox normalized request",
+        "Do not claim unsupported runtime dependencies",
+        "Keep output deterministic and executable",
+        "Produce only the expected script artifact",
+        "Prefer honest, reviewable intermediate behavior over unsupported OCR claims",
+        "If the requested output path ends with .xlsx, do not write non-XLSX text/XML/CSV content to that path.",
+        "Do not hardcode an input directory when the task params already provide input_dir.",
+        "Preserve meaningful traceability from the incoming description instead of collapsing it to a heading fragment.",
+        "Prefer wrapping or adapting artifacts/scripts/pdf_to_excel_ocr.py when that existing repo script already matches the requested behavior.",
+        "When artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py already exists, prefer updating that reviewed wrapper baseline instead of rewriting a new control flow from scratch.",
+        "If dry_run is true or no PDFs are discovered, report a reviewable partial outcome instead of claiming success without an XLSX artifact.",
+        "Resolve relative delegate script paths from the repository or script location, not from Path.cwd().",
+        "For readonly reviewable preview flows, only delegate to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py unless failing honestly.",
+        "Do not claim wrapper success from exit code plus output existence alone when the reviewed delegate report does not provide strong enough success evidence.",
+        "When wrapper reports success, enforce delegate evidence gates: status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, excel_written=true, output_exists=true, and output_size_bytes>0.",
+        "If delegate reports partial with structured evidence in readonly best-effort mode, keep wrapper status partial (not failed) and include explicit limitations with next-step guidance.",
+        "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
+        "When delegate emits JSON to stdout, parse that report directly instead of depending only on sidecar report-file discovery.",
+        "When wrapper passes a sidecar report path to the reviewed delegate, use --report-json exactly unless the reviewed delegate explicitly supports another alias.",
+        "If wrapper supports dry-run short-circuit semantics, keep execution.delegated=false and preserve partial status honestly.",
+        "Keep wrapper PDF discovery semantics aligned with reviewed delegate discovery semantics to avoid preflight/execution evidence drift.",
+        "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely."
+      ],
+      "priority": "medium",
+      "source": {
+        "kind": "local_inbox",
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl057-001.json",
+        "received_at": "2026-03-25T08:53:07.470167Z",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "regeneration_token": "regen-20260325-bl057-001"
+      },
+      "acceptance_criteria": [
+        "Produce the expected script artifact at expected_outputs[0].path",
+        "Script behavior remains runnable, deterministic, and reviewable",
+        "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
+        "Artifact behavior remains parameter-driven for input_dir and output_xlsx rather than hardcoding unrelated local defaults.",
+        "Dry-run or zero-input behavior is represented as a reviewable partial outcome instead of artifact-production success.",
+        "Relative preferred_base_script resolution remains portable and does not depend on Path.cwd().",
+        "Wrapper success requires stronger delegate evidence than zero exit code plus a non-empty output file alone.",
+        "Wrapper success attestation requires delegate fields excel_written=true, output_exists=true, output_size_bytes>0, and status_counter.partial/status_counter.failed equal to 0.",
+        "Contract-compliant delegate partial outcomes remain partial with explicit limitations and next-step guidance, rather than being escalated to failed by success-only gates.",
+        "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
+        "Delegate report handoff can consume JSON printed to stdout without relying exclusively on report sidecar file discovery.",
+        "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",
+        "Dry-run semantics remain explicit: short-circuit stays partial with no delegated execution, or delegated dry-run is passed through honestly.",
+        "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
+        "Delegate execution is bounded by an explicit timeout and reports timeout honestly."
+      ],
+      "metadata": {
+        "integration_phase": "8B",
+        "pipeline": "inbox->adapter->manager->automation->critic",
+        "request_type": "pdf_to_excel_ocr",
+        "payload_hash": "d472aab5e3bfd5e47ecb7dfc9ffffda4d8721a5ad56b9dd611be066645a67b40",
+        "regeneration_token": "regen-20260325-bl057-001",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "external_metadata": {
+          "source_system": "trello",
+          "card_id": "69c24cd3c1a2359ddd7a1bf8",
+          "card_short_id": 7,
+          "board_id": "69be462743bfa0038ca10f7a",
+          "list_id": "69be462743bfa0038ca10f8f",
+          "date_last_activity": "2026-03-24T08:35:56.234Z",
+          "readonly_mapped_at": "2026-03-25T08:52:30.351021Z",
+          "contract_profile": "best_effort_evidence_backed",
+          "ocr_claim_policy": "do_not_claim_success_without_evidence",
+          "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+          "regeneration_token": "regen-20260325-bl057-001"
+        },
+        "automation_contract_profile": "narrow_script_artifact_with_repo_reuse_and_reviewable_runner_contract"
+      }
+    },
+    "critic": {
+      "task_id": "CRITIC-20260325-285",
+      "worker": "critic",
+      "task_type": "review_artifact",
+      "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+      "inputs": {
+        "artifacts": [
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "type": "script"
+          },
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+            "type": "script"
+          }
+        ],
+        "params": {
+          "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+          "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+          "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+          "labels": [
+            "best_effort",
+            "evidence_backed",
+            "readonly",
+            "reviewable",
+            "trello"
+          ],
+          "review_scope": {
+            "primary_artifact": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "paired_artifacts": [
+              "artifacts/scripts/pdf_to_excel_ocr.py"
+            ],
+            "goal": "Audit the wrapper and the reviewed delegate together so the review evidence can speak to the end-to-end readonly smoke path."
+          }
+        }
+      },
+      "expected_outputs": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ],
+      "constraints": [
+        "Review must be grounded in produced automation artifact",
+        "When both wrapper and reviewed delegate snapshots are supplied, evaluate them as one end-to-end readonly pair instead of ignoring the delegate evidence.",
+        "Do not invent missing artifact content",
+        "Return a clear verdict: pass, fail, or needs_revision",
+        "Include metadata.verdict in output",
+        "Generate review artifact markdown for expected_outputs[0].path"
+      ],
+      "priority": "medium",
+      "source": {
+        "kind": "local_inbox",
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl057-001.json",
+        "received_at": "2026-03-25T08:53:07.470167Z",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "regeneration_token": "regen-20260325-bl057-001"
+      },
+      "acceptance_criteria": [
+        "Produce a review artifact with explicit verdict (pass/fail/needs_revision)"
+      ],
+      "metadata": {
+        "integration_phase": "8B",
+        "pipeline": "inbox->adapter->manager->automation->critic",
+        "request_type": "pdf_to_excel_ocr",
+        "payload_hash": "d472aab5e3bfd5e47ecb7dfc9ffffda4d8721a5ad56b9dd611be066645a67b40",
+        "regeneration_token": "regen-20260325-bl057-001",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "external_metadata": {
+          "source_system": "trello",
+          "card_id": "69c24cd3c1a2359ddd7a1bf8",
+          "card_short_id": 7,
+          "board_id": "69be462743bfa0038ca10f7a",
+          "list_id": "69be462743bfa0038ca10f8f",
+          "date_last_activity": "2026-03-24T08:35:56.234Z",
+          "readonly_mapped_at": "2026-03-25T08:52:30.351021Z",
+          "contract_profile": "best_effort_evidence_backed",
+          "ocr_claim_policy": "do_not_claim_success_without_evidence",
+          "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+          "regeneration_token": "regen-20260325-bl057-001"
+        }
+      }
+    }
+  },
+  "expected_artifacts": [
+    "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+    "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py"
+  ],
+  "dedupe_keys": [
+    "origin_regeneration:trello:69c24cd3c1a2359ddd7a1bf8:regen-20260325-bl057-001",
+    "hash:d472aab5e3bfd5e47ecb7dfc9ffffda4d8721a5ad56b9dd611be066645a67b40"
+  ],
+  "risk_warnings": [],
+  "execution": {
+    "status": "pending_approval",
+    "executed": false,
+    "attempts": 0
+  }
+}

--- a/runtime_archives/bl057/tmp/bl057_smoke_elevated.json
+++ b/runtime_archives/bl057/tmp/bl057_smoke_elevated.json
@@ -1,0 +1,92 @@
+/Users/lingguozhong/Library/Python/3.9/lib/python/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
+  warnings.warn(
+{
+  "status": "done",
+  "fixture": "/Users/lingguozhong/openclaw-team/adapters/samples/trello_card_fixture.json",
+  "mapped_output": "/Users/lingguozhong/openclaw-team/artifacts/trello_readonly_prep/trello_readonly_mapped_sample.json",
+  "required_env": {
+    "credentials": [
+      "TRELLO_API_KEY",
+      "TRELLO_API_TOKEN"
+    ],
+    "credentials_aliases": [
+      "TRELLO_KEY",
+      "TRELLO_TOKEN"
+    ],
+    "credentials_priority": [
+      "TRELLO_API_KEY/TRELLO_API_TOKEN",
+      "TRELLO_KEY/TRELLO_TOKEN"
+    ],
+    "scope": [
+      "TRELLO_BOARD_ID",
+      "TRELLO_LIST_ID"
+    ],
+    "scope_rule": [
+      "TRELLO_BOARD_ID or TRELLO_LIST_ID (either one)"
+    ]
+  },
+  "smoke_read": {
+    "status": "pass",
+    "read_count": 1,
+    "scope": {
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": null
+    },
+    "scope_kind": "board",
+    "mapped_preview": {
+      "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+      "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+      "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "metadata": {
+        "source_system": "trello",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "card_short_id": 7,
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "date_last_activity": "2026-03-24T08:35:56.234Z",
+        "readonly_mapped_at": "2026-03-25T08:52:30.351021Z",
+        "contract_profile": "best_effort_evidence_backed",
+        "ocr_claim_policy": "do_not_claim_success_without_evidence",
+        "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable"
+      },
+      "source": {
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f"
+      },
+      "request_type": "pdf_to_excel_ocr",
+      "input": {
+        "input_dir": "~/Desktop/pdf样本",
+        "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+        "ocr": "auto",
+        "dry_run": false
+      }
+    },
+    "auth_env": {
+      "selected_names": {
+        "key": "TRELLO_API_KEY",
+        "token": "TRELLO_API_TOKEN"
+      },
+      "priority": "TRELLO_API_* first, fallback to TRELLO_*",
+      "presence": {
+        "TRELLO_API_KEY": "set",
+        "TRELLO_KEY": "set",
+        "TRELLO_API_TOKEN": "set",
+        "TRELLO_TOKEN": "set",
+        "TRELLO_BOARD_ID": "set",
+        "TRELLO_LIST_ID": "missing"
+      }
+    },
+    "note": "Read-only GET only. No write operations performed."
+  },
+  "mode": "trello_readonly_prep"
+}

--- a/runtime_archives/bl057/tmp/bl057_smoke_sandbox.json
+++ b/runtime_archives/bl057/tmp/bl057_smoke_sandbox.json
@@ -1,0 +1,50 @@
+/Users/lingguozhong/Library/Python/3.9/lib/python/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
+  warnings.warn(
+{
+  "status": "done",
+  "fixture": "/Users/lingguozhong/openclaw-team/adapters/samples/trello_card_fixture.json",
+  "mapped_output": "/Users/lingguozhong/openclaw-team/artifacts/trello_readonly_prep/trello_readonly_mapped_sample.json",
+  "required_env": {
+    "credentials": [
+      "TRELLO_API_KEY",
+      "TRELLO_API_TOKEN"
+    ],
+    "credentials_aliases": [
+      "TRELLO_KEY",
+      "TRELLO_TOKEN"
+    ],
+    "credentials_priority": [
+      "TRELLO_API_KEY/TRELLO_API_TOKEN",
+      "TRELLO_KEY/TRELLO_TOKEN"
+    ],
+    "scope": [
+      "TRELLO_BOARD_ID",
+      "TRELLO_LIST_ID"
+    ],
+    "scope_rule": [
+      "TRELLO_BOARD_ID or TRELLO_LIST_ID (either one)"
+    ]
+  },
+  "smoke_read": {
+    "status": "blocked",
+    "reason": "Read-only Trello request failed before HTTP response: ConnectionError",
+    "error_type": "ConnectionError",
+    "response_preview": "HTTPSConnectionPool(host='api.trello.com', port=443): Max retries exceeded with url: /1/boards/69be462743bfa0038ca10f7a/cards?key=***redacted_key***&token=***redacted_token***&fields=id%2CidShort%2Cname%2Cdesc%2CidList%2CidBoard%2CdateLastActivity%2Clabels&limit=1 (Caused by NameResolutionError(\"HTT",
+    "auth_env": {
+      "selected_names": {
+        "key": "TRELLO_API_KEY",
+        "token": "TRELLO_API_TOKEN"
+      },
+      "priority": "TRELLO_API_* first, fallback to TRELLO_*",
+      "presence": {
+        "TRELLO_API_KEY": "set",
+        "TRELLO_KEY": "set",
+        "TRELLO_API_TOKEN": "set",
+        "TRELLO_TOKEN": "set",
+        "TRELLO_BOARD_ID": "set",
+        "TRELLO_LIST_ID": "missing"
+      }
+    }
+  },
+  "mode": "trello_readonly_prep"
+}


### PR DESCRIPTION
## Summary
- close BL-20260325-057 with one fresh same-origin governed validation run
- archive smoke/ingest/approval/execute evidence under runtime_archives/bl057
- record that critic still reports needs_revision on wrapper/delegate contract gaps
- queue BL-058 for dry-run recurrence and sidecar precedence hardening

## Verification
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh

Closes #107