### PR TITLE
fix: harden wrapper delegate evidence handoff contract for BL-058

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -1030,8 +1030,8 @@ Allowed enum values:
 ### BL-20260325-058
 - title: Harden wrapper/delegate evidence handoff contract to eliminate dry-run propagation recurrence and sidecar precedence risk
 - type: blocker
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-057
@@ -1039,7 +1039,24 @@ Allowed enum values:
 - done_when: Source-side hardening ensures reviewed wrapper behavior is preserved under governed generation (dry-run delegate propagation and sidecar-first evidence handoff), and one blocker report records mitigation with focused tests
 - source: `POST_WRAPPER_DRYRUN_DELEGATE_PROPAGATION_VALIDATION_REPORT.md` on 2026-03-25 records critic `needs_revision` persisted on wrapper/delegate contract handling despite BL-056 source merge
 - link: /Users/lingguozhong/openclaw-team/WRAPPER_DELEGATE_EVIDENCE_HANDOFF_CONTRACT_HARDENING_REPORT.md
-- issue: deferred:phase=next until BL-20260325-057 lands on main
+- issue: https://github.com/Oscarling/openclaw-team/issues/109
+- evidence: `WRAPPER_DELEGATE_EVIDENCE_HANDOFF_CONTRACT_HARDENING_REPORT.md` records source-side hardening in `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py` and `adapters/local_inbox_adapter.py` to enforce dry-run delegation and sidecar-first report truth, with focused regressions in `tests/test_pdf_to_excel_ocr_inbox_runner.py` and updated adapter contract coverage in `tests/test_local_inbox_adapter.py`
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-059
+- title: Validate BL-20260325-058 wrapper/delegate evidence handoff contract hardening on a fresh same-origin governed candidate
+- type: mainline
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-058
+- start_when: `BL-20260325-058` is merged so a fresh same-origin governed run can verify whether critic findings move away from dry-run recurrence and sidecar precedence concerns
+- done_when: One governed validation creates a fresh same-origin preview candidate after BL-20260325-058, runs one explicit approval plus one real execute, and records whether critic findings no longer report wrapper/delegate evidence-handoff contract gaps
+- source: `WRAPPER_DELEGATE_EVIDENCE_HANDOFF_CONTRACT_HARDENING_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation under real execute conditions
+- link: /Users/lingguozhong/openclaw-team/POST_WRAPPER_DELEGATE_EVIDENCE_HANDOFF_CONTRACT_VALIDATION_REPORT.md
+- issue: deferred:phase=next until BL-20260325-058 lands on main
 - evidence: -
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -2316,6 +2316,55 @@ Verification snapshot on 2026-03-25:
   - `execution.executed = true`
   - `execution.attempts = 2`
 
+### 66. Wrapper Delegate Evidence-Handoff Contract Hardening After BL-057 Blocker
+
+User objective:
+
+- continue next blocker phase without drift
+- harden wrapper/delegate contract handling after BL-057 critic
+  `needs_revision` (dry-run recurrence + stdout-over-sidecar risk)
+
+Main work areas:
+
+- activated `BL-20260325-058` and mirrored it to issue `#109`
+- updated `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`:
+  - passes `--report-json` sidecar path to delegate on execution
+  - prefers sidecar JSON as canonical delegate evidence
+  - falls back to stdout JSON only when sidecar is unavailable
+  - records delegate report source/path in execution summary
+  - adds divergence note when stdout and sidecar disagree
+- updated `adapters/local_inbox_adapter.py` contract guidance:
+  - dry-run semantics now require delegated pass-through for readonly governed
+    flows
+  - delegate report handoff now mandates sidecar-first truth with stdout
+    fallback
+- expanded focused tests:
+  - new wrapper regression
+    `test_sidecar_report_is_canonical_when_stdout_diverges`
+  - updated fake delegates to accept `--report-json`
+  - aligned adapter contract expectation coverage
+- produced blocker hardening report and prepared next governed validation item
+  (`BL-20260325-059`)
+
+Primary output:
+
+- [WRAPPER_DELEGATE_EVIDENCE_HANDOFF_CONTRACT_HARDENING_REPORT.md](/Users/lingguozhong/openclaw-team/WRAPPER_DELEGATE_EVIDENCE_HANDOFF_CONTRACT_HARDENING_REPORT.md)
+
+Key result:
+
+- `BL-20260325-058` is complete as a source-side blocker-hardening phase
+- wrapper evidence handoff now enforces sidecar-first contract truth
+- generation-side dry-run/report guidance is tightened to reduce recurrence
+  under governed execution
+- next phase `BL-20260325-059` is defined as fresh governed validation
+
+Verification snapshot on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py tests/test_local_inbox_adapter.py`
+  passed `15/15`
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed with BL-058 issue mirror to `#109`
+
 ### 64. Wrapper Dry-Run Delegate Propagation Hardening After BL-055 Critic Blocker
 
 User objective:

--- a/WRAPPER_DELEGATE_EVIDENCE_HANDOFF_CONTRACT_HARDENING_REPORT.md
+++ b/WRAPPER_DELEGATE_EVIDENCE_HANDOFF_CONTRACT_HARDENING_REPORT.md
@@ -1,0 +1,92 @@
+# Wrapper Delegate Evidence Handoff Contract Hardening Report
+
+## Objective
+
+Complete `BL-20260325-058` by hardening wrapper/delegate contract behavior
+after `BL-20260325-057` critic findings persisted on:
+
+- dry-run propagation recurrence
+- stdout-over-sidecar evidence precedence risk
+
+## Scope
+
+In scope:
+
+- harden `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py` delegate report
+  handoff and source-truth precedence
+- tighten generation-side contract guidance in
+  `adapters/local_inbox_adapter.py`
+- add focused regressions and align adapter contract tests
+
+Out of scope:
+
+- governed live rerun in this phase
+- Trello ingest/approval workflow redesign
+- unrelated runtime/retry hardening
+
+## Changes
+
+### 1) Sidecar-first delegate report truth in wrapper runtime
+
+Updated `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`:
+
+- always passes delegate sidecar path via `--report-json`
+- adds sidecar file loader and treats sidecar JSON as canonical evidence
+- falls back to stdout JSON only when sidecar evidence is missing
+- records report source in summary:
+  - `execution.delegate_report_source` (`sidecar|stdout|none`)
+  - `execution.delegate_report_sidecar_path`
+- emits explicit note when stdout JSON diverges from sidecar and sidecar is
+  selected
+
+Effect:
+
+- closes evidence-loss risk from stdout-first parsing when sidecar is available.
+
+### 2) Contract-level hardening for governed generation prompts
+
+Updated `adapters/local_inbox_adapter.py` contract hints/constraints:
+
+- `delegate_report_handoff` now requires sidecar-first canonical behavior with
+  stdout fallback only
+- `dry_run_semantics` now requires delegated dry-run pass-through for readonly
+  governed flows (no pre-delegate short-circuit)
+- synchronized matching constraint and acceptance-criteria language
+
+Effect:
+
+- reduces recurrence risk where generated wrapper regresses into ambiguous
+  dry-run behavior or weak evidence precedence.
+
+## Test Coverage
+
+Updated `tests/test_pdf_to_excel_ocr_inbox_runner.py`:
+
+- extended fake delegate scripts to accept `--report-json`
+- added `test_sidecar_report_is_canonical_when_stdout_diverges`
+  to assert sidecar precedence and divergence note
+- preserved dry-run delegation regression:
+  `test_dry_run_forwards_flag_to_delegate_and_returns_partial`
+
+Updated `tests/test_local_inbox_adapter.py`:
+
+- aligned expectations with sidecar-first and delegated dry-run contract text
+
+## Verification
+
+Passed on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py tests/test_local_inbox_adapter.py`
+- `python3 scripts/backlog_lint.py`
+- `python3 scripts/backlog_sync.py`
+
+## Conclusion
+
+`BL-20260325-058` is complete as a source-side blocker-hardening phase.
+
+Wrapper evidence handoff now prefers sidecar truth and generation-side contract
+guidance is tightened to keep dry-run delegation and report precedence behavior
+consistent under governed runtime.
+
+Next required step: run one fresh same-origin governed validation to verify
+critic findings move away from these contract gaps.

--- a/adapters/local_inbox_adapter.py
+++ b/adapters/local_inbox_adapter.py
@@ -354,8 +354,8 @@ def normalize_local_inbox_payload(
                         "processed_files/succeeded_files/failed_files counters."
                     ),
                     "delegate_report_handoff": (
-                        "When the delegate prints a JSON report to stdout, parse that JSON "
-                        "directly instead of relying only on sidecar-report file path discovery."
+                        "When a sidecar report file is available, treat it as canonical evidence. "
+                        "Use stdout JSON parsing only as fallback when sidecar evidence is missing."
                     ),
                     "delegate_report_flag_contract": (
                         "If wrapper passes a sidecar report path to the reviewed delegate, "
@@ -364,9 +364,9 @@ def normalize_local_inbox_payload(
                         "as --report-file."
                     ),
                     "dry_run_semantics": (
-                        "If wrapper dry-run short-circuits before delegate execution, keep "
-                        "execution.delegated=false and report partial honestly. If wrapper "
-                        "does delegate under dry-run, pass through --dry-run explicitly."
+                        "For readonly governed flows, do not short-circuit dry-run before "
+                        "delegate execution. Delegate under dry-run and pass through "
+                        "--dry-run explicitly so wrapper/delegate semantics remain aligned."
                     ),
                     "pdf_discovery_consistency": (
                         "Keep wrapper preflight PDF discovery semantics aligned with the "
@@ -397,9 +397,9 @@ def normalize_local_inbox_payload(
             "When wrapper reports success, enforce delegate evidence gates: status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, excel_written=true, output_exists=true, and output_size_bytes>0.",
             "If delegate reports partial with structured evidence in readonly best-effort mode, keep wrapper status partial (not failed) and include explicit limitations with next-step guidance.",
             "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
-            "When delegate emits JSON to stdout, parse that report directly instead of depending only on sidecar report-file discovery.",
+            "When a delegate sidecar report is present, treat sidecar JSON as canonical evidence and use stdout JSON only as fallback.",
             "When wrapper passes a sidecar report path to the reviewed delegate, use --report-json exactly unless the reviewed delegate explicitly supports another alias.",
-            "If wrapper supports dry-run short-circuit semantics, keep execution.delegated=false and preserve partial status honestly.",
+            "For readonly governed flows, do not short-circuit dry-run before delegate execution; pass --dry-run through delegate and preserve partial status honestly.",
             "Keep wrapper PDF discovery semantics aligned with reviewed delegate discovery semantics to avoid preflight/execution evidence drift.",
             "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely.",
         ],
@@ -416,9 +416,9 @@ def normalize_local_inbox_payload(
             "Wrapper success attestation requires delegate fields excel_written=true, output_exists=true, output_size_bytes>0, and status_counter.partial/status_counter.failed equal to 0.",
             "Contract-compliant delegate partial outcomes remain partial with explicit limitations and next-step guidance, rather than being escalated to failed by success-only gates.",
             "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
-            "Delegate report handoff can consume JSON printed to stdout without relying exclusively on report sidecar file discovery.",
+            "Delegate report handoff prefers sidecar JSON as canonical evidence and only falls back to stdout JSON when sidecar evidence is unavailable.",
             "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",
-            "Dry-run semantics remain explicit: short-circuit stays partial with no delegated execution, or delegated dry-run is passed through honestly.",
+            "Dry-run semantics remain explicit and delegated for readonly governed flows: pass --dry-run through delegate and preserve partial outcome honestly.",
             "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
             "Delegate execution is bounded by an explicit timeout and reports timeout honestly.",
         ],

--- a/artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
+++ b/artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
@@ -5,6 +5,7 @@ import argparse
 import json
 import subprocess
 import sys
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -122,6 +123,18 @@ def parse_delegate_report(stdout_text: str) -> dict[str, Any] | None:
             continue
         if isinstance(candidate, dict):
             return candidate
+    return None
+
+
+def load_delegate_report_file(path: Path) -> dict[str, Any] | None:
+    if not path.exists() or not path.is_file():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    if isinstance(payload, dict):
+        return payload
     return None
 
 
@@ -267,6 +280,8 @@ def main() -> int:
             "stdout": "",
             "stderr": "",
             "delegate_report": None,
+            "delegate_report_source": "none",
+            "delegate_report_sidecar_path": "",
         },
         "output": {
             "exists": False,
@@ -304,6 +319,15 @@ def main() -> int:
         return 3
 
     output_xlsx.parent.mkdir(parents=True, exist_ok=True)
+    delegate_report_sidecar = Path(
+        tempfile.NamedTemporaryFile(
+            prefix="argus-delegate-report-",
+            suffix=".json",
+            delete=False,
+        ).name
+    )
+    delegate_report_sidecar.unlink(missing_ok=True)
+    summary["execution"]["delegate_report_sidecar_path"] = str(delegate_report_sidecar)
 
     cmd = [
         sys.executable,
@@ -312,6 +336,8 @@ def main() -> int:
         str(input_dir),
         "--output-xlsx",
         str(output_xlsx),
+        "--report-json",
+        str(delegate_report_sidecar),
     ]
     if args.ocr:
         cmd.extend(["--ocr", args.ocr])
@@ -342,18 +368,30 @@ def main() -> int:
             f"Delegate timed out after {max(int(args.delegate_timeout_seconds), 1)} seconds."
         )
         emit_summary(summary, args.summary_json)
+        delegate_report_sidecar.unlink(missing_ok=True)
         return 124
     except Exception as exc:
         summary["execution"]["stderr"] = f"delegate invocation error: {exc}"
         emit_summary(summary, args.summary_json)
+        delegate_report_sidecar.unlink(missing_ok=True)
         return 4
 
     summary["execution"]["returncode"] = completed.returncode
     summary["execution"]["stdout"] = completed.stdout
     summary["execution"]["stderr"] = completed.stderr
 
-    delegate_report = parse_delegate_report(completed.stdout)
+    sidecar_report = load_delegate_report_file(delegate_report_sidecar)
+    stdout_report = parse_delegate_report(completed.stdout)
+    delegate_report = sidecar_report or stdout_report
     summary["execution"]["delegate_report"] = delegate_report
+    if isinstance(sidecar_report, dict):
+        summary["execution"]["delegate_report_source"] = "sidecar"
+        if isinstance(stdout_report, dict) and stdout_report != sidecar_report:
+            summary["notes"].append("Delegate stdout report diverged from sidecar; using sidecar as canonical evidence.")
+    elif isinstance(stdout_report, dict):
+        summary["execution"]["delegate_report_source"] = "stdout"
+    else:
+        summary["execution"]["delegate_report_source"] = "none"
 
     output_exists = output_xlsx.exists() and output_xlsx.is_file()
     summary["output"]["exists"] = output_exists
@@ -402,6 +440,7 @@ def main() -> int:
             summary["notes"].append("Delegate script returned a non-zero exit code.")
 
     emit_summary(summary, args.summary_json)
+    delegate_report_sidecar.unlink(missing_ok=True)
     return 0 if summary["status"] in {"success", "partial"} else 1
 
 

--- a/tests/test_local_inbox_adapter.py
+++ b/tests/test_local_inbox_adapter.py
@@ -116,7 +116,7 @@ Execution contract: treat this as a best-effort, evidence-backed PDF extraction/
             contract_hints["delegate_report_schema"],
         )
         self.assertIn(
-            "prints a JSON report to stdout",
+            "sidecar report file is available",
             contract_hints["delegate_report_handoff"],
         )
         self.assertIn(
@@ -128,7 +128,7 @@ Execution contract: treat this as a best-effort, evidence-backed PDF extraction/
             contract_hints["delegate_report_flag_contract"],
         )
         self.assertIn(
-            "execution.delegated=false",
+            "do not short-circuit dry-run",
             contract_hints["dry_run_semantics"],
         )
         self.assertIn(
@@ -173,7 +173,7 @@ Execution contract: treat this as a best-effort, evidence-backed PDF extraction/
         )
         self.assertTrue(
             any(
-                "emits JSON to stdout" in item
+                "sidecar report is present" in item
                 for item in auto_task["constraints"]
             )
         )
@@ -185,7 +185,7 @@ Execution contract: treat this as a best-effort, evidence-backed PDF extraction/
         )
         self.assertTrue(
             any(
-                "execution.delegated=false" in item
+                "do not short-circuit dry-run" in item
                 for item in auto_task["constraints"]
             )
         )
@@ -220,7 +220,7 @@ Execution contract: treat this as a best-effort, evidence-backed PDF extraction/
             auto_task["acceptance_criteria"],
         )
         self.assertIn(
-            "Delegate report handoff can consume JSON printed to stdout without relying exclusively on report sidecar file discovery.",
+            "Delegate report handoff prefers sidecar JSON as canonical evidence and only falls back to stdout JSON when sidecar evidence is unavailable.",
             auto_task["acceptance_criteria"],
         )
         self.assertIn(
@@ -228,7 +228,7 @@ Execution contract: treat this as a best-effort, evidence-backed PDF extraction/
             auto_task["acceptance_criteria"],
         )
         self.assertIn(
-            "Dry-run semantics remain explicit: short-circuit stays partial with no delegated execution, or delegated dry-run is passed through honestly.",
+            "Dry-run semantics remain explicit and delegated for readonly governed flows: pass --dry-run through delegate and preserve partial outcome honestly.",
             auto_task["acceptance_criteria"],
         )
         self.assertIn(

--- a/tests/test_pdf_to_excel_ocr_inbox_runner.py
+++ b/tests/test_pdf_to_excel_ocr_inbox_runner.py
@@ -91,15 +91,20 @@ class PdfToExcelOcrInboxRunnerTests(unittest.TestCase):
                 #!/usr/bin/env python3
                 import argparse
                 import json
+                from pathlib import Path
 
                 parser = argparse.ArgumentParser()
                 parser.add_argument("--input-dir", required=True)
                 parser.add_argument("--output-xlsx", required=True)
                 parser.add_argument("--ocr", default="auto")
                 parser.add_argument("--dry-run", action="store_true")
+                parser.add_argument("--report-json", default="")
                 args = parser.parse_args()
 
-                print(json.dumps({"status": "partial", "dry_run": bool(args.dry_run), "total_files": 1}))
+                payload = {"status": "partial", "dry_run": bool(args.dry_run), "total_files": 1}
+                if args.report_json:
+                    Path(args.report_json).write_text(json.dumps(payload), encoding="utf-8")
+                print(json.dumps(payload))
                 """
             ),
             encoding="utf-8",
@@ -207,12 +212,16 @@ class PdfToExcelOcrInboxRunnerTests(unittest.TestCase):
                 parser.add_argument("--input-dir", required=True)
                 parser.add_argument("--output-xlsx", required=True)
                 parser.add_argument("--ocr", default="auto")
+                parser.add_argument("--report-json", default="")
                 args = parser.parse_args()
 
                 output = Path(args.output_xlsx)
                 output.parent.mkdir(parents=True, exist_ok=True)
                 output.write_bytes(b"fake-xlsx")
-                print(json.dumps({"status": "partial", "total_files": 1}))
+                payload = {"status": "partial", "total_files": 1}
+                if args.report_json:
+                    Path(args.report_json).write_text(json.dumps(payload), encoding="utf-8")
+                print(json.dumps(payload))
                 """
             ),
             encoding="utf-8",
@@ -229,6 +238,62 @@ class PdfToExcelOcrInboxRunnerTests(unittest.TestCase):
         self.assertTrue(summary["execution"]["delegated"])
         self.assertEqual(summary["execution"]["delegate_report"]["status"], "partial")
         self.assertTrue(summary["output"]["exists"])
+        self.assertEqual(summary["execution"]["delegate_report_source"], "sidecar")
+
+    def test_sidecar_report_is_canonical_when_stdout_diverges(self) -> None:
+        input_dir = self._make_input_dir(with_pdf=True)
+        fake_base = self.tmpdir / "fake_pdf_to_excel_ocr_sidecar_priority.py"
+        fake_base.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env python3
+                import argparse
+                import json
+                from pathlib import Path
+
+                parser = argparse.ArgumentParser()
+                parser.add_argument("--input-dir", required=True)
+                parser.add_argument("--output-xlsx", required=True)
+                parser.add_argument("--ocr", default="auto")
+                parser.add_argument("--report-json", default="")
+                args = parser.parse_args()
+
+                output = Path(args.output_xlsx)
+                output.parent.mkdir(parents=True, exist_ok=True)
+                output.write_bytes(b"fake-xlsx")
+
+                sidecar_payload = {"status": "partial", "total_files": 1}
+                if args.report_json:
+                    Path(args.report_json).write_text(json.dumps(sidecar_payload), encoding="utf-8")
+
+                stdout_payload = {
+                    "status": "success",
+                    "total_files": 1,
+                    "status_counter": {"failed": 0, "partial": 0},
+                    "dry_run": False,
+                    "excel_written": True,
+                    "output_exists": True,
+                    "output_size_bytes": 9,
+                }
+                print(json.dumps(stdout_payload))
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        exit_code, summary, _ = self._invoke_main(
+            input_dir=input_dir,
+            extra_args=["--preferred-base-script", str(fake_base)],
+            reviewed_base_script=fake_base,
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(summary["status"], "partial")
+        self.assertEqual(summary["execution"]["delegate_report_source"], "sidecar")
+        self.assertEqual(summary["execution"]["delegate_report"]["status"], "partial")
+        self.assertTrue(
+            any("using sidecar as canonical evidence" in note for note in summary["notes"])
+        )
 
     def test_success_requires_strong_delegate_evidence(self) -> None:
         input_dir = self._make_input_dir(with_pdf=True)
@@ -245,12 +310,16 @@ class PdfToExcelOcrInboxRunnerTests(unittest.TestCase):
                 parser.add_argument("--input-dir", required=True)
                 parser.add_argument("--output-xlsx", required=True)
                 parser.add_argument("--ocr", default="auto")
+                parser.add_argument("--report-json", default="")
                 args = parser.parse_args()
 
                 output = Path(args.output_xlsx)
                 output.parent.mkdir(parents=True, exist_ok=True)
                 output.write_bytes(b"fake-xlsx")
-                print(json.dumps({"status": "success"}))
+                payload = {"status": "success"}
+                if args.report_json:
+                    Path(args.report_json).write_text(json.dumps(payload), encoding="utf-8")
+                print(json.dumps(payload))
                 """
             ),
             encoding="utf-8",


### PR DESCRIPTION
## Summary
- make sidecar JSON report canonical when delegate stdout JSON diverges
- keep stdout JSON as fallback only and emit explicit report-source diagnostics
- tighten local inbox adapter contract text so dry-run delegation and sidecar-first evidence are hard requirements
- extend regression tests for wrapper sidecar precedence and adapter contract wording

## Verification
- python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py tests/test_local_inbox_adapter.py
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh

Closes #109