### PR TITLE
fix: harden wrapper readonly + OCR sufficiency contract for BL-060

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -1064,8 +1064,8 @@ Allowed enum values:
 ### BL-20260325-060
 - title: Harden wrapper/delegate readonly semantics and OCR sufficiency contract after BL-20260325-059 critic findings
 - type: blocker
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-059
@@ -1073,7 +1073,24 @@ Allowed enum values:
 - done_when: Source-side contract hardening aligns wrapper/delegate readonly semantics and runtime-summary wording with actual behavior, strengthens OCR sufficiency disclosure/gating expectations for best-effort readonly flows, and one blocker report records mitigation with focused tests
 - source: `POST_WRAPPER_DELEGATE_EVIDENCE_HANDOFF_CONTRACT_VALIDATION_REPORT.md` on 2026-03-25 records critic focus moved from dry-run/sidecar gaps to readonly/OCR-sufficiency contract concerns
 - link: /Users/lingguozhong/openclaw-team/WRAPPER_DELEGATE_READONLY_OCR_SUFFICIENCY_CONTRACT_HARDENING_REPORT.md
-- issue: deferred:phase=next until BL-20260325-060 activation
+- issue: https://github.com/Oscarling/openclaw-team/issues/113
+- evidence: `WRAPPER_DELEGATE_READONLY_OCR_SUFFICIENCY_CONTRACT_HARDENING_REPORT.md` records source-side hardening in `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py` and `adapters/local_inbox_adapter.py` that clarifies readonly semantics as no-external-writeback scope and enforces conservative partial handling when delegate reports `ocr_runtime_status=blocked|partial` under `ocr=auto|on`, with focused regressions in `tests/test_pdf_to_excel_ocr_inbox_runner.py` and `tests/test_local_inbox_adapter.py`
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-061
+- title: Validate BL-20260325-060 readonly/OCR sufficiency contract hardening on a fresh same-origin governed candidate
+- type: mainline
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-060
+- start_when: `BL-20260325-060` is merged so a fresh same-origin governed run can verify whether critic findings move away from readonly-semantics and OCR-sufficiency contract concerns
+- done_when: One governed validation creates a fresh same-origin preview candidate after BL-20260325-060, runs one explicit approval plus one real execute, and records whether critic findings no longer cite readonly/OCR sufficiency contract gaps
+- source: `WRAPPER_DELEGATE_READONLY_OCR_SUFFICIENCY_CONTRACT_HARDENING_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation under real execute conditions
+- link: /Users/lingguozhong/openclaw-team/POST_WRAPPER_DELEGATE_READONLY_OCR_SUFFICIENCY_CONTRACT_VALIDATION_REPORT.md
+- issue: deferred:phase=next until BL-20260325-061 activation
 - evidence: -
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -3461,3 +3461,52 @@ Verification snapshot on 2026-03-25:
   - `execution.status = rejected`
   - `execution.executed = true`
   - `execution.attempts = 2`
+
+### 69. Wrapper/Delegate Readonly + OCR Sufficiency Contract Hardening After BL-059 Findings
+
+User objective:
+
+- continue next blocker phase without drift
+- harden wrapper/delegate contract after BL-059 critic findings shifted to
+  readonly semantics ambiguity and OCR sufficiency concerns
+
+Main work areas:
+
+- activated `BL-20260325-060` and mirrored it to issue `#113`
+- updated `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`:
+  - made readonly scope explicit as `no_external_writeback`
+  - added `local_filesystem_writes_allowed` to avoid overstating strict
+    filesystem readonly semantics
+  - added explicit readonly semantics note in runtime summary
+  - hardened success gates so when `ocr=auto|on` and delegate reports
+    `ocr_runtime_status=blocked|partial`, wrapper keeps `partial`
+- updated `adapters/local_inbox_adapter.py` contract text:
+  - added `readonly_semantics` hint
+  - added `ocr_sufficiency` hint
+  - extended constraints/acceptance criteria for readonly wording and OCR
+    sufficiency partial behavior
+- expanded focused regressions:
+  - new runner test
+    `test_ocr_runtime_blocked_keeps_wrapper_partial_even_with_success_attestation`
+  - updated runner readonly attestation assertions
+  - updated adapter contract assertions for new hints/constraints/acceptance
+    criteria
+- produced blocker hardening report and prepared next governed validation item
+  (`BL-20260325-061`)
+
+Primary output:
+
+- [WRAPPER_DELEGATE_READONLY_OCR_SUFFICIENCY_CONTRACT_HARDENING_REPORT.md](/Users/lingguozhong/openclaw-team/WRAPPER_DELEGATE_READONLY_OCR_SUFFICIENCY_CONTRACT_HARDENING_REPORT.md)
+
+Key result:
+
+- `BL-20260325-060` is complete as a source-side blocker-hardening phase
+- readonly semantics are now explicit and bounded as no-external-writeback
+- wrapper success policy now avoids OCR completeness overclaim under blocked/
+  partial OCR runtime in OCR-relevant modes
+- next phase `BL-20260325-061` is defined as fresh governed validation
+
+Verification snapshot on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py tests/test_local_inbox_adapter.py`
+  passed `16/16`

--- a/WRAPPER_DELEGATE_READONLY_OCR_SUFFICIENCY_CONTRACT_HARDENING_REPORT.md
+++ b/WRAPPER_DELEGATE_READONLY_OCR_SUFFICIENCY_CONTRACT_HARDENING_REPORT.md
@@ -1,0 +1,71 @@
+# Wrapper/Delegate Readonly + OCR Sufficiency Contract Hardening Report
+
+## Objective
+
+Close `BL-20260325-060` by hardening wrapper/delegate contract semantics after
+BL-059 critic findings:
+
+- make readonly scope explicit and non-misleading
+- keep no-external-writeback guarantees clear
+- prevent wrapper success overclaim when OCR runtime is not fully available in
+  OCR-relevant modes (`auto`/`on`)
+
+## Changes
+
+### 1) Wrapper readonly semantics were made explicit
+
+Updated `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py` summary payload:
+
+- `readonly_attestation.readonly_scope = "no_external_writeback"`
+- `readonly_attestation.local_filesystem_writes_allowed = not dry_run`
+- clarified readonly statement text so it no longer implies strict filesystem
+  readonly when `dry_run=false`
+- added explicit note: readonly here means no external writeback; local output
+  writes may still happen in non-dry-run mode
+
+### 2) OCR sufficiency was added to wrapper success gating
+
+Updated `has_strong_delegate_success_evidence(...)` in
+`artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`:
+
+- when `ocr_mode` is `auto` or `on`
+- and delegate report says `ocr_runtime_status` is `partial` or `blocked`
+- wrapper now refuses `success` and keeps `partial` with explicit rationale
+
+This avoids overclaiming OCR completeness when runtime dependencies are
+incomplete, even if output files exist.
+
+### 3) Generation contract was tightened to reduce recurrence
+
+Updated `adapters/local_inbox_adapter.py` contract text:
+
+- added `contract_hints.readonly_semantics`
+- added `contract_hints.ocr_sufficiency`
+- extended automation constraints and acceptance criteria to require:
+  - explicit no-external-writeback readonly wording
+  - conservative partial status when OCR runtime is `blocked/partial` in
+    `auto`/`on` modes
+
+## Tests
+
+Updated tests:
+
+- `tests/test_pdf_to_excel_ocr_inbox_runner.py`
+  - added `test_ocr_runtime_blocked_keeps_wrapper_partial_even_with_success_attestation`
+  - extended readonly attestation assertions for new fields
+- `tests/test_local_inbox_adapter.py`
+  - added assertions for new contract hints, constraints, and acceptance criteria
+
+Validation run:
+
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py tests/test_local_inbox_adapter.py`
+  - passed (`16/16`)
+
+## Outcome
+
+`BL-20260325-060` source-side hardening is complete:
+
+- readonly semantics are explicit and bounded
+- OCR sufficiency risk is now captured in wrapper success policy
+- generation-side contract text enforces the same semantics for future
+  automation output stability

--- a/adapters/local_inbox_adapter.py
+++ b/adapters/local_inbox_adapter.py
@@ -344,6 +344,17 @@ def normalize_local_inbox_payload(
                         "report timeout as an honest failed/partial outcome instead of "
                         "allowing smoke automation to hang indefinitely."
                     ),
+                    "readonly_semantics": (
+                        "Readonly semantics must be explicit: no external/Trello writeback "
+                        "is required, but local filesystem output writes may still occur when "
+                        "dry_run=false. Runtime summary fields must not overstate readonly "
+                        "scope."
+                    ),
+                    "ocr_sufficiency": (
+                        "When OCR mode is auto/on and delegate reports ocr_runtime_status "
+                        "as blocked/partial, do not claim wrapper success even if an output "
+                        "file exists; keep partial status with explicit OCR sufficiency notes."
+                    ),
                     "runtime_summary": (
                         "The generated script should emit a structured summary of what it "
                         "produced so later review can inspect behavior without guessing."
@@ -401,6 +412,8 @@ def normalize_local_inbox_payload(
             "When wrapper passes a sidecar report path to the reviewed delegate, use --report-json exactly unless the reviewed delegate explicitly supports another alias.",
             "For readonly governed flows, do not short-circuit dry-run before delegate execution; pass --dry-run through delegate and preserve partial status honestly.",
             "Keep wrapper PDF discovery semantics aligned with reviewed delegate discovery semantics to avoid preflight/execution evidence drift.",
+            "Readonly semantics must be explicit as no external writeback; avoid claiming strict filesystem readonly when dry_run=false can write local outputs.",
+            "When OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial, keep wrapper status partial and surface OCR sufficiency limitations.",
             "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely.",
         ],
         "priority": priority,
@@ -420,6 +433,8 @@ def normalize_local_inbox_payload(
             "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",
             "Dry-run semantics remain explicit and delegated for readonly governed flows: pass --dry-run through delegate and preserve partial outcome honestly.",
             "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
+            "Readonly semantics are explicit as no external writeback, and runtime summary wording does not overclaim strict filesystem readonly when dry_run=false.",
+            "Wrapper success is conservative when OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial.",
             "Delegate execution is bounded by an explicit timeout and reports timeout honestly.",
         ],
         "metadata": {

--- a/artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
+++ b/artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
@@ -138,7 +138,11 @@ def load_delegate_report_file(path: Path) -> dict[str, Any] | None:
     return None
 
 
-def has_strong_delegate_success_evidence(delegate_report: dict[str, Any] | None) -> tuple[bool, str | None]:
+def has_strong_delegate_success_evidence(
+    delegate_report: dict[str, Any] | None,
+    *,
+    ocr_mode: str,
+) -> tuple[bool, str | None]:
     if not isinstance(delegate_report, dict):
         return False, "Delegate did not emit a structured JSON report for success evidence."
 
@@ -170,6 +174,18 @@ def has_strong_delegate_success_evidence(delegate_report: dict[str, Any] | None)
     output_size_bytes = delegate_report.get("output_size_bytes")
     if not isinstance(output_size_bytes, int) or output_size_bytes < 1:
         return False, "Delegate report did not attest a non-empty output_size_bytes value."
+
+    normalized_ocr_mode = str(ocr_mode).strip().lower()
+    delegate_ocr_runtime_status = str(delegate_report.get("ocr_runtime_status", "")).strip().lower()
+    if normalized_ocr_mode in {"auto", "on"} and delegate_ocr_runtime_status in {"partial", "blocked"}:
+        return (
+            False,
+            (
+                "Delegate OCR runtime is not fully available "
+                f"(ocr_runtime_status={delegate_ocr_runtime_status}); "
+                "wrapper keeps partial status to avoid overclaiming OCR completeness."
+            ),
+        )
 
     return True, None
 
@@ -258,13 +274,15 @@ def main() -> int:
         },
         "readonly_attestation": {
             "mode": "local_filesystem_delegate_only",
+            "readonly_scope": "no_external_writeback",
             "network_calls_performed": False,
             "trello_write_performed": False,
+            "local_filesystem_writes_allowed": not args.dry_run,
             "readonly_label_present": readonly_labels_present,
             "delegate_restricted_to_reviewed_script": delegate_contract_error is None,
             "statement": (
-                "Wrapper performs local file discovery and local delegate execution only; "
-                "it performs no Trello writeback and no direct network calls."
+                "Readonly semantics in this wrapper mean no external/Trello writeback. "
+                "When dry_run=false, local filesystem artifacts may still be written."
             ),
         },
         "discovery": {
@@ -296,6 +314,9 @@ def main() -> int:
 
     if not readonly_labels_present:
         summary["notes"].append("Readonly label is missing; preserving conservative local-only execution contract.")
+    summary["notes"].append(
+        "Readonly semantics here mean no external writeback; local filesystem outputs may be written when dry_run=false."
+    )
 
     if output_xlsx.suffix.lower() != ".xlsx":
         summary["notes"].append("Requested output path does not end with .xlsx; refusing mismatched workbook contract.")
@@ -416,7 +437,10 @@ def main() -> int:
         else:
             summary["notes"].append("Delegate script returned a non-zero exit code during dry-run mode.")
     elif completed.returncode == 0 and output_exists:
-        success_evidence_ok, success_evidence_note = has_strong_delegate_success_evidence(delegate_report)
+        success_evidence_ok, success_evidence_note = has_strong_delegate_success_evidence(
+            delegate_report,
+            ocr_mode=args.ocr,
+        )
         if delegate_status == "partial":
             summary["status"] = "partial"
             summary["notes"].append("Delegate reported a reviewable partial outcome; preserving partial status.")

--- a/tests/test_local_inbox_adapter.py
+++ b/tests/test_local_inbox_adapter.py
@@ -111,6 +111,10 @@ Execution contract: treat this as a best-effort, evidence-backed PDF extraction/
         self.assertIn("status partial instead of escalating to failed", contract_hints["delegate_partial_evidence"])
         self.assertIn("next-step guidance", contract_hints["delegate_partial_evidence"])
         self.assertIn("explicit timeout", contract_hints["delegate_timeout"])
+        self.assertIn("no external/Trello writeback", contract_hints["readonly_semantics"])
+        self.assertIn("dry_run=false", contract_hints["readonly_semantics"])
+        self.assertIn("ocr_runtime_status", contract_hints["ocr_sufficiency"])
+        self.assertIn("blocked/partial", contract_hints["ocr_sufficiency"])
         self.assertIn(
             "status/total_files/status_counter/dry_run",
             contract_hints["delegate_report_schema"],
@@ -195,6 +199,18 @@ Execution contract: treat this as a best-effort, evidence-backed PDF extraction/
                 for item in auto_task["constraints"]
             )
         )
+        self.assertTrue(
+            any(
+                "no external writeback" in item
+                for item in auto_task["constraints"]
+            )
+        )
+        self.assertTrue(
+            any(
+                "ocr_runtime_status as blocked/partial" in item
+                for item in auto_task["constraints"]
+            )
+        )
         self.assertIn(
             "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
             auto_task["acceptance_criteria"],
@@ -233,6 +249,14 @@ Execution contract: treat this as a best-effort, evidence-backed PDF extraction/
         )
         self.assertIn(
             "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
+            auto_task["acceptance_criteria"],
+        )
+        self.assertIn(
+            "Readonly semantics are explicit as no external writeback, and runtime summary wording does not overclaim strict filesystem readonly when dry_run=false.",
+            auto_task["acceptance_criteria"],
+        )
+        self.assertIn(
+            "Wrapper success is conservative when OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial.",
             auto_task["acceptance_criteria"],
         )
         self.assertIn(

--- a/tests/test_pdf_to_excel_ocr_inbox_runner.py
+++ b/tests/test_pdf_to_excel_ocr_inbox_runner.py
@@ -336,6 +336,57 @@ class PdfToExcelOcrInboxRunnerTests(unittest.TestCase):
         self.assertTrue(summary["output"]["exists"])
         self.assertTrue(any("at least one processed PDF file" in note for note in summary["notes"]))
 
+    def test_ocr_runtime_blocked_keeps_wrapper_partial_even_with_success_attestation(self) -> None:
+        input_dir = self._make_input_dir(with_pdf=True)
+        fake_base = self.tmpdir / "fake_pdf_to_excel_ocr_ocr_blocked.py"
+        fake_base.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env python3
+                import argparse
+                import json
+                from pathlib import Path
+
+                parser = argparse.ArgumentParser()
+                parser.add_argument("--input-dir", required=True)
+                parser.add_argument("--output-xlsx", required=True)
+                parser.add_argument("--ocr", default="auto")
+                parser.add_argument("--report-json", default="")
+                args = parser.parse_args()
+
+                output = Path(args.output_xlsx)
+                output.parent.mkdir(parents=True, exist_ok=True)
+                output.write_bytes(b"fake-xlsx")
+                payload = {
+                    "status": "success",
+                    "total_files": 1,
+                    "status_counter": {"failed": 0, "partial": 0},
+                    "dry_run": False,
+                    "excel_written": True,
+                    "output_exists": True,
+                    "output_size_bytes": 9,
+                    "ocr_runtime_status": "blocked",
+                }
+                if args.report_json:
+                    Path(args.report_json).write_text(json.dumps(payload), encoding="utf-8")
+                print(json.dumps(payload))
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        exit_code, summary, _ = self._invoke_main(
+            input_dir=input_dir,
+            extra_args=["--preferred-base-script", str(fake_base)],
+            reviewed_base_script=fake_base,
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(summary["status"], "partial")
+        self.assertTrue(
+            any("ocr_runtime_status=blocked" in note for note in summary["notes"])
+        )
+
     def test_timeout_returns_failed_with_explicit_note(self) -> None:
         input_dir = self._make_input_dir(with_pdf=True)
         fake_base = self.tmpdir / "fake_pdf_to_excel_ocr_timeout.py"
@@ -370,8 +421,10 @@ class PdfToExcelOcrInboxRunnerTests(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         self.assertIn("run_id", summary)
         self.assertEqual(summary["readonly_attestation"]["mode"], "local_filesystem_delegate_only")
+        self.assertEqual(summary["readonly_attestation"]["readonly_scope"], "no_external_writeback")
         self.assertFalse(summary["readonly_attestation"]["network_calls_performed"])
         self.assertFalse(summary["readonly_attestation"]["trello_write_performed"])
+        self.assertTrue(summary["readonly_attestation"]["local_filesystem_writes_allowed"])
         self.assertTrue(summary["readonly_attestation"]["readonly_label_present"])
         self.assertIn("delegate_path_resolution", summary["provenance"])
         self.assertIn("input_dir_resolution", summary["provenance"])


### PR DESCRIPTION
## Summary
- clarify wrapper readonly semantics as no-external-writeback and make local filesystem write scope explicit
- add conservative success gating: when ocr=auto|on and delegate reports ocr_runtime_status=blocked|partial, wrapper keeps partial instead of claiming success
- tighten local inbox adapter generation contract with readonly semantics and OCR sufficiency requirements
- extend focused regressions for runner and adapter contract coverage
- close BL-060 with hardening report and queue BL-061 validation item

## Verification
- python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py tests/test_local_inbox_adapter.py
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh

Closes #113
