### PR TITLE
fix: harden delegate report schema and diagnostic surfacing (BL-062)

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -1098,8 +1098,8 @@ Allowed enum values:
 ### BL-20260325-062
 - title: Harden wrapper/delegate report-schema robustness and delegate-error surfacing after BL-20260325-061 critic findings
 - type: blocker
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-061
@@ -1107,7 +1107,24 @@ Allowed enum values:
 - done_when: Source-side hardening normalizes delegate report schema across failure paths and ensures wrapper evidence/notes surface delegate error context explicitly, with focused tests and one blocker report
 - source: `POST_WRAPPER_DELEGATE_READONLY_OCR_SUFFICIENCY_CONTRACT_VALIDATION_REPORT.md` on 2026-03-25 records the next blocker as wrapper/delegate report-schema robustness and diagnostic evidence surfacing
 - link: /Users/lingguozhong/openclaw-team/WRAPPER_DELEGATE_REPORT_SCHEMA_DIAGNOSTIC_ROBUSTNESS_HARDENING_REPORT.md
-- issue: deferred:phase=next until BL-20260325-062 activation
+- issue: https://github.com/Oscarling/openclaw-team/issues/117
+- evidence: `WRAPPER_DELEGATE_REPORT_SCHEMA_DIAGNOSTIC_ROBUSTNESS_HARDENING_REPORT.md` records schema normalization in `artifacts/scripts/pdf_to_excel_ocr.py` via shared report template across failure/no-input/normal exits and explicit delegate-error surfacing in `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`, with focused regressions in `tests/test_pdf_to_excel_ocr_script.py` and `tests/test_pdf_to_excel_ocr_inbox_runner.py`
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-063
+- title: Validate BL-20260325-062 report-schema diagnostic robustness hardening on a fresh same-origin governed candidate
+- type: mainline
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-062
+- start_when: `BL-20260325-062` is merged so one fresh governed candidate can verify critic findings move away from report-schema consistency and delegate-error surfacing gaps
+- done_when: One governed validation run (smoke -> regeneration -> preview -> approval -> real execute) records whether critic findings no longer cite wrapper/delegate report-schema robustness and delegate-error diagnostic surfacing concerns
+- source: `WRAPPER_DELEGATE_REPORT_SCHEMA_DIAGNOSTIC_ROBUSTNESS_HARDENING_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation
+- link: /Users/lingguozhong/openclaw-team/POST_WRAPPER_DELEGATE_REPORT_SCHEMA_DIAGNOSTIC_ROBUSTNESS_VALIDATION_REPORT.md
+- issue: -
 - evidence: -
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -3571,3 +3571,50 @@ Verification snapshot on 2026-03-25:
   - `execution.status = rejected`
   - `execution.executed = true`
   - `execution.attempts = 2`
+
+### 71. Wrapper/Delegate Report-Schema + Delegate-Error Diagnostic Hardening After BL-061 Findings
+
+User objective:
+
+- continue strict backlog mainline without drift
+- close blocker on wrapper/delegate report-schema consistency and diagnostic
+  error surfacing
+
+Main work areas:
+
+- implemented delegate schema normalization in
+  `artifacts/scripts/pdf_to_excel_ocr.py`:
+  - added shared `build_report_template(...)`
+  - made discovery-failure and no-input exits emit full normalized report keys
+  - aligned normal run report construction to the same schema template
+- implemented wrapper diagnostic surfacing in
+  `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`:
+  - added `extract_delegate_error(...)`
+  - surfaced `Delegate reported error: ...` in wrapper `notes` when present
+- expanded focused regressions:
+  - `tests/test_pdf_to_excel_ocr_script.py`
+    - `test_main_discovery_failure_emits_normalized_failed_schema`
+  - `tests/test_pdf_to_excel_ocr_inbox_runner.py`
+    - `test_surfaces_delegate_error_context_in_wrapper_notes`
+- produced blocker hardening report and advanced backlog tracking:
+  - `BL-20260325-062` moved to `done`
+  - added next validation item `BL-20260325-063` (`planned` / `next`)
+
+Primary output:
+
+- [WRAPPER_DELEGATE_REPORT_SCHEMA_DIAGNOSTIC_ROBUSTNESS_HARDENING_REPORT.md](/Users/lingguozhong/openclaw-team/WRAPPER_DELEGATE_REPORT_SCHEMA_DIAGNOSTIC_ROBUSTNESS_HARDENING_REPORT.md)
+
+Key result:
+
+- `BL-20260325-062` is complete as a source-side blocker-hardening phase
+- delegate reports now keep a stable schema across failure/sparse paths
+- wrapper summary now preserves explicit delegate error context for diagnostics
+- governance docs and next-step backlog item are synchronized
+
+Verification snapshot on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_script.py tests/test_pdf_to_excel_ocr_inbox_runner.py`
+  passed (`17/17`)
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed
+- `bash scripts/premerge_check.sh` passed (`Warnings: 0`, `Failures: 0`)

--- a/WRAPPER_DELEGATE_REPORT_SCHEMA_DIAGNOSTIC_ROBUSTNESS_HARDENING_REPORT.md
+++ b/WRAPPER_DELEGATE_REPORT_SCHEMA_DIAGNOSTIC_ROBUSTNESS_HARDENING_REPORT.md
@@ -1,0 +1,77 @@
+# Wrapper/Delegate Report-Schema Diagnostic Robustness Hardening Report
+
+## Objective
+
+Close `BL-20260325-062` by hardening wrapper/delegate diagnostics after
+`BL-20260325-061` critic findings:
+
+- normalize delegate JSON report schema across sparse failure paths
+- ensure wrapper notes surface delegate `error` context explicitly instead of
+  only generic evidence-gate messages
+
+## Scope
+
+In scope:
+
+- `artifacts/scripts/pdf_to_excel_ocr.py` report-schema normalization
+- `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py` diagnostic surfacing
+- focused regression tests for the two hardening targets
+
+Out of scope:
+
+- governed live rerun/critic validation in this blocker phase
+- Trello workflow changes
+- unrelated OCR extraction logic changes
+
+## Changes
+
+### 1) Delegate report schema was normalized for failure exits
+
+Updated `artifacts/scripts/pdf_to_excel_ocr.py`:
+
+- added a shared `build_report_template(...)` used by all report exits
+- discovery-failure exit now emits full schema with:
+  - `status`, `total_files`, `status_counter`, `dry_run`
+  - `excel_written`, `output_exists`, `output_size_bytes`
+  - `ocr_runtime_status`, `notes`, `next_steps`, `error`
+- no-PDF and normal execution exits now share the same schema baseline
+
+Effect:
+
+- wrapper/delegate contract no longer depends on sparse-field failure payloads.
+
+### 2) Wrapper now surfaces delegate error context explicitly
+
+Updated `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`:
+
+- added `extract_delegate_error(...)`
+- when delegate report includes `error`, wrapper appends explicit diagnostic
+  note:
+  - `Delegate reported error: ...`
+
+Effect:
+
+- review artifacts keep the delegate’s concrete failure reason visible even when
+  evidence gates also fail.
+
+## Tests
+
+Updated tests:
+
+- `tests/test_pdf_to_excel_ocr_script.py`
+  - added `test_main_discovery_failure_emits_normalized_failed_schema`
+- `tests/test_pdf_to_excel_ocr_inbox_runner.py`
+  - added `test_surfaces_delegate_error_context_in_wrapper_notes`
+
+Validation run:
+
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_script.py tests/test_pdf_to_excel_ocr_inbox_runner.py`
+  - passed (`17/17`)
+
+## Outcome
+
+`BL-20260325-062` source-side hardening is complete:
+
+- delegate report schema is consistent across success/partial/failure exits
+- wrapper diagnostics now preserve delegate `error` context explicitly
+- regression coverage exists for both hardening points

--- a/artifacts/scripts/pdf_to_excel_ocr.py
+++ b/artifacts/scripts/pdf_to_excel_ocr.py
@@ -258,6 +258,33 @@ def emit_report(report: dict[str, Any], report_json: str) -> None:
     out_path.write_text(rendered + "\n", encoding="utf-8")
 
 
+def build_report_template(
+    *,
+    input_dir: Path,
+    output_xlsx: Path,
+    ocr_mode: str,
+    dry_run: bool,
+) -> dict[str, Any]:
+    return {
+        "status": "failed",
+        "input_dir": str(input_dir),
+        "output_xlsx": str(output_xlsx),
+        "ocr_mode": ocr_mode,
+        "ocr_runtime_status": "unknown",
+        "ocr_missing_dependencies": [],
+        "total_files": 0,
+        "files": [],
+        "status_counter": {},
+        "dry_run": bool(dry_run),
+        "excel_written": False,
+        "output_exists": False,
+        "output_size_bytes": 0,
+        "notes": [],
+        "next_steps": [],
+        "error": "",
+    }
+
+
 def main() -> int:
     args = parse_args()
     input_dir = Path(args.input_dir).expanduser().resolve()
@@ -266,30 +293,31 @@ def main() -> int:
     try:
         pdf_files = discover_pdfs(input_dir)
     except Exception as e:
-        emit_report({"status": "failed", "error": str(e)}, args.report_json)
+        report = build_report_template(
+            input_dir=input_dir,
+            output_xlsx=output_xlsx,
+            ocr_mode=args.ocr,
+            dry_run=args.dry_run,
+        )
+        report["error"] = str(e)
+        report["notes"].append("Input discovery failed before extraction could start.")
+        report["next_steps"].append("Verify input directory exists and is readable, then rerun.")
+        emit_report(report, args.report_json)
         return 2
 
     if not pdf_files:
-        emit_report(
-            {
-                "status": "partial",
-                "input_dir": str(input_dir),
-                "output_xlsx": str(output_xlsx),
-                "ocr_mode": args.ocr,
-                "total_files": 0,
-                "files": [],
-                "status_counter": {},
-                "dry_run": bool(args.dry_run),
-                "excel_written": False,
-                "output_exists": False,
-                "output_size_bytes": 0,
-                "notes": [f"No PDF files found under {input_dir}"],
-                "next_steps": [
-                    "Add one or more .pdf files under the input directory and rerun.",
-                ],
-            },
-            args.report_json,
+        report = build_report_template(
+            input_dir=input_dir,
+            output_xlsx=output_xlsx,
+            ocr_mode=args.ocr,
+            dry_run=args.dry_run,
         )
+        report["status"] = "partial"
+        report["notes"] = [f"No PDF files found under {input_dir}"]
+        report["next_steps"] = [
+            "Add one or more .pdf files under the input directory and rerun.",
+        ]
+        emit_report(report, args.report_json)
         return 0
 
     ocr_runtime, missing = detect_ocr_runtime_status()
@@ -343,23 +371,24 @@ def main() -> int:
         notes.append(f"{failed_count} file(s) reported failed status.")
         next_steps.append("Inspect per-file failures in `files` and resolve the extraction or OCR error causes.")
 
-    report = {
-        "status": aggregate_status,
-        "input_dir": str(input_dir),
-        "output_xlsx": str(output_xlsx),
-        "ocr_mode": args.ocr,
-        "ocr_runtime_status": ocr_runtime,
-        "ocr_missing_dependencies": missing,
-        "total_files": len(results),
-        "files": files_payload,
-        "status_counter": status_counter,
-        "dry_run": bool(args.dry_run),
-        "excel_written": False,
-        "output_exists": False,
-        "output_size_bytes": 0,
-        "notes": notes,
-        "next_steps": next_steps,
-    }
+    report = build_report_template(
+        input_dir=input_dir,
+        output_xlsx=output_xlsx,
+        ocr_mode=args.ocr,
+        dry_run=args.dry_run,
+    )
+    report.update(
+        {
+            "status": aggregate_status,
+            "ocr_runtime_status": ocr_runtime,
+            "ocr_missing_dependencies": missing,
+            "total_files": len(results),
+            "files": files_payload,
+            "status_counter": status_counter,
+            "notes": notes,
+            "next_steps": next_steps,
+        }
+    )
 
     if args.dry_run:
         emit_report(report, args.report_json)

--- a/artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
+++ b/artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
@@ -190,6 +190,19 @@ def has_strong_delegate_success_evidence(
     return True, None
 
 
+def extract_delegate_error(delegate_report: dict[str, Any] | None) -> str | None:
+    if not isinstance(delegate_report, dict):
+        return None
+    raw_error = delegate_report.get("error")
+    if raw_error is None:
+        return None
+    if isinstance(raw_error, str):
+        cleaned = raw_error.strip()
+        return cleaned or None
+    cleaned = str(raw_error).strip()
+    return cleaned or None
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Best-effort inbox runner that reuses the repository PDF-to-Excel OCR script."
@@ -405,6 +418,9 @@ def main() -> int:
     stdout_report = parse_delegate_report(completed.stdout)
     delegate_report = sidecar_report or stdout_report
     summary["execution"]["delegate_report"] = delegate_report
+    delegate_error = extract_delegate_error(delegate_report)
+    if delegate_error:
+        summary["notes"].append(f"Delegate reported error: {delegate_error}")
     if isinstance(sidecar_report, dict):
         summary["execution"]["delegate_report_source"] = "sidecar"
         if isinstance(stdout_report, dict) and stdout_report != sidecar_report:

--- a/tests/test_pdf_to_excel_ocr_inbox_runner.py
+++ b/tests/test_pdf_to_excel_ocr_inbox_runner.py
@@ -336,6 +336,58 @@ class PdfToExcelOcrInboxRunnerTests(unittest.TestCase):
         self.assertTrue(summary["output"]["exists"])
         self.assertTrue(any("at least one processed PDF file" in note for note in summary["notes"]))
 
+    def test_surfaces_delegate_error_context_in_wrapper_notes(self) -> None:
+        input_dir = self._make_input_dir(with_pdf=True)
+        fake_base = self.tmpdir / "fake_pdf_to_excel_ocr_failed_with_error.py"
+        fake_base.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env python3
+                import argparse
+                import json
+                from pathlib import Path
+
+                parser = argparse.ArgumentParser()
+                parser.add_argument("--input-dir", required=True)
+                parser.add_argument("--output-xlsx", required=True)
+                parser.add_argument("--ocr", default="auto")
+                parser.add_argument("--report-json", default="")
+                args = parser.parse_args()
+
+                payload = {
+                    "status": "failed",
+                    "total_files": 0,
+                    "status_counter": {},
+                    "dry_run": False,
+                    "excel_written": False,
+                    "output_exists": False,
+                    "output_size_bytes": 0,
+                    "ocr_runtime_status": "unknown",
+                    "notes": ["Input discovery failed before extraction could start."],
+                    "next_steps": ["Verify input directory exists and is readable, then rerun."],
+                    "error": "Input directory does not exist: /tmp/missing-input",
+                }
+                if args.report_json:
+                    Path(args.report_json).write_text(json.dumps(payload), encoding="utf-8")
+                print(json.dumps(payload))
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        exit_code, summary, _ = self._invoke_main(
+            input_dir=input_dir,
+            extra_args=["--preferred-base-script", str(fake_base)],
+            reviewed_base_script=fake_base,
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(summary["status"], "failed")
+        self.assertEqual(summary["execution"]["delegate_report_source"], "sidecar")
+        self.assertTrue(
+            any("Delegate reported error: Input directory does not exist" in note for note in summary["notes"])
+        )
+
     def test_ocr_runtime_blocked_keeps_wrapper_partial_even_with_success_attestation(self) -> None:
         input_dir = self._make_input_dir(with_pdf=True)
         fake_base = self.tmpdir / "fake_pdf_to_excel_ocr_ocr_blocked.py"

--- a/tests/test_pdf_to_excel_ocr_script.py
+++ b/tests/test_pdf_to_excel_ocr_script.py
@@ -104,6 +104,43 @@ class PdfToExcelOcrScriptTests(unittest.TestCase):
         self.assertTrue(any("OCR runtime status" in note for note in report["notes"]))
         self.assertTrue(any("Inspect per-file partial records" in step for step in report["next_steps"]))
 
+    def test_main_discovery_failure_emits_normalized_failed_schema(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="pdf-to-excel-ocr-script-discovery-failed-") as tmp:
+            tmpdir = Path(tmp)
+            output_xlsx = tmpdir / "output.xlsx"
+            args = SimpleNamespace(
+                input_dir=str(tmpdir / "missing-input"),
+                output_xlsx=str(output_xlsx),
+                ocr="auto",
+                dry_run=False,
+                ocr_lang="chi_sim+eng",
+                auto_ocr_min_chars=50,
+                report_json="",
+            )
+
+            stdout = io.StringIO()
+            with mock.patch.object(self.script, "parse_args", return_value=args):
+                with mock.patch.object(
+                    self.script,
+                    "discover_pdfs",
+                    side_effect=FileNotFoundError("Input directory does not exist: /tmp/missing-input"),
+                ):
+                    with contextlib.redirect_stdout(stdout):
+                        exit_code = self.script.main()
+
+        self.assertEqual(exit_code, 2)
+        report = json.loads(stdout.getvalue())
+        self.assertEqual(report["status"], "failed")
+        self.assertEqual(report["total_files"], 0)
+        self.assertEqual(report["status_counter"], {})
+        self.assertFalse(report["excel_written"])
+        self.assertFalse(report["output_exists"])
+        self.assertEqual(report["output_size_bytes"], 0)
+        self.assertEqual(report["ocr_runtime_status"], "unknown")
+        self.assertIn("Input discovery failed", report["notes"][0])
+        self.assertTrue(any("Verify input directory exists" in step for step in report["next_steps"]))
+        self.assertIn("Input directory does not exist", report["error"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- normalize delegate report schema across sparse failure/no-input/normal exits via shared template
- surface delegate error explicitly in wrapper notes for stronger diagnostic evidence
- add focused regressions for failure-schema normalization and delegate-error surfacing
- complete BL-062 report/log updates and queue BL-063 as next validation item

## Verification
- python3 -m unittest -v tests/test_pdf_to_excel_ocr_script.py tests/test_pdf_to_excel_ocr_inbox_runner.py
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh

Closes #117