### PR TITLE
chore: validate BL-063 governed run and archive runtime evidence

### DIFF
--- a/POST_WRAPPER_DELEGATE_REPORT_SCHEMA_DIAGNOSTIC_ROBUSTNESS_VALIDATION_REPORT.md
+++ b/POST_WRAPPER_DELEGATE_REPORT_SCHEMA_DIAGNOSTIC_ROBUSTNESS_VALIDATION_REPORT.md
@@ -1,0 +1,166 @@
+# Post-Report-Schema Diagnostic Robustness Validation Report
+
+## Objective
+
+Validate `BL-20260325-062` on one fresh same-origin governed candidate by
+running:
+
+- one live Trello read-only smoke
+- one explicit same-origin regeneration
+- one preview creation
+- one explicit approval
+- one real execute (`test_mode=off`)
+
+This phase objective is validation truth, not forcing a `pass` verdict.
+
+## Scope
+
+In scope:
+
+- one governed run against origin `trello:69c24cd3c1a2359ddd7a1bf8`
+- one regeneration token and one fresh preview candidate
+- runtime evidence capture for automation/critic progression
+- explicit recording of whether critic findings moved away from BL-062 target
+  gaps (report-schema consistency and delegate-error surfacing)
+
+Out of scope:
+
+- source-code hardening in this validation phase
+- git finalization and Trello Done writeback
+- additional live reruns beyond this governed candidate
+
+## Pre-Run Checks
+
+- branch: `phase9o/validate-bl063-report-schema-diagnostic-robustness`
+- Trello env loaded from `/tmp/trello_env.sh`
+- execute replay used explicit fallback endpoint env:
+  - `ARGUS_LLM_FALLBACK_CHAT_URLS=https://api.openai.com/v1/chat/completions`
+
+## Run Summary
+
+Target origin:
+
+- `trello:69c24cd3c1a2359ddd7a1bf8`
+
+Regeneration token:
+
+- `regen-20260325-bl063-001`
+
+### 1) Live Trello read-only smoke
+
+First sandboxed read:
+
+- blocked by DNS / sandbox network policy
+- error: `ConnectionError` / `NameResolutionError`
+- archive snapshot:
+  - `runtime_archives/bl063/tmp/bl063_smoke_sandbox.json`
+
+Elevated rerun:
+
+- `status = pass`
+- `read_count = 1`
+- archive snapshots:
+  - `runtime_archives/bl063/tmp/bl063_smoke_elevated.json`
+  - `runtime_archives/bl063/tmp/bl063_live_mapped_preview.json`
+
+### 2) Regenerated payload and preview ingest
+
+- generated inbox payload from elevated `smoke_read.mapped_preview` with token
+  `regen-20260325-bl063-001`
+- ingest decision:
+  - `status = processed`
+  - `decision = preview_created_pending_approval`
+  - `preview_id = preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609`
+- archive snapshot:
+  - `runtime_archives/bl063/tmp/bl063_ingest_once.json`
+
+### 3) Preview candidate and approval
+
+Generated preview:
+
+- `preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609`
+
+Pre-execute state:
+
+- `approved = false`
+- `execution.status = pending_approval`
+- `execution.executed = false`
+- `execution.attempts = 0`
+- `source.regeneration_token = regen-20260325-bl063-001`
+
+Approval file:
+
+- `approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609.json`
+
+### 4) Real execute (`test_mode=off`)
+
+First sandboxed execute:
+
+- rejected before worker dispatch
+- reason:
+  `Failed to initialize docker client from environment. Ensure Docker access is available or pass docker_client explicitly.`
+- archive snapshot:
+  - `runtime_archives/bl063/tmp/bl063_execute_once_sandbox.json`
+
+Elevated replay execute (`--preview-id ... --allow-replay`):
+
+- automation task created and completed:
+  - `AUTO-20260325-872`
+- critic task created and completed:
+  - `CRITIC-20260325-288`
+- run reached critic dispatch
+- final execute decision:
+  - `status = rejected`
+  - `decision_reason = critic_verdict=needs_revision`
+  - `critic_verdict = needs_revision`
+- archive snapshots:
+  - `runtime_archives/bl063/tmp/bl063_execute_once_elevated.json`
+  - `runtime_archives/bl063/runtime/automation-runtime.attempt-1.log`
+  - `runtime_archives/bl063/runtime/critic-runtime.attempt-1.log`
+  - `runtime_archives/bl063/runtime/automation-output.json`
+  - `runtime_archives/bl063/runtime/critic-output.json`
+  - `runtime_archives/bl063/runtime/critic-produced-pdf_to_excel_ocr_inbox_review.md`
+
+Final preview execution state:
+
+- `approved = true`
+- `execution.status = rejected`
+- `execution.executed = true`
+- `execution.attempts = 3`
+
+## Critical Findings
+
+This validation confirms critic focus moved away from the BL-062 target concerns:
+
+- no dominant finding remained on sparse failure report-schema normalization
+- no dominant finding remained on delegate `error` surfacing gaps
+
+Current critic `needs_revision` focus is now:
+
+- wrapper output-path policy is broader than tightly declared-artifact bounds
+- wrapper/delegate aggregate outcome contract remains partially implicit
+  (extraction-centric vs workbook-centric semantics)
+- extraction-vs-export failure distinction can be surfaced more explicitly
+
+Inference from this run:
+
+- BL-062 hardening is active and shifted reviewer focus away from report-schema
+  and delegate-error diagnostic gaps
+- the next blocker class is output-boundary and aggregate outcome-contract
+  clarity
+
+## Validation Conclusion
+
+`BL-20260325-063` is complete as a governed validation phase.
+
+It answers the intended question with runtime evidence: critic findings moved
+away from BL-062 target gaps, while a new `needs_revision` blocker class
+remains.
+
+## Archive Preservation
+
+This phase archived outputs under:
+
+- `runtime_archives/bl063/runtime/`
+- `runtime_archives/bl063/state/`
+- `runtime_archives/bl063/tmp/`

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -1115,8 +1115,8 @@ Allowed enum values:
 ### BL-20260325-063
 - title: Validate BL-20260325-062 report-schema diagnostic robustness hardening on a fresh same-origin governed candidate
 - type: mainline
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-062
@@ -1124,6 +1124,23 @@ Allowed enum values:
 - done_when: One governed validation run (smoke -> regeneration -> preview -> approval -> real execute) records whether critic findings no longer cite wrapper/delegate report-schema robustness and delegate-error diagnostic surfacing concerns
 - source: `WRAPPER_DELEGATE_REPORT_SCHEMA_DIAGNOSTIC_ROBUSTNESS_HARDENING_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation
 - link: /Users/lingguozhong/openclaw-team/POST_WRAPPER_DELEGATE_REPORT_SCHEMA_DIAGNOSTIC_ROBUSTNESS_VALIDATION_REPORT.md
+- issue: https://github.com/Oscarling/openclaw-team/issues/119
+- evidence: `POST_WRAPPER_DELEGATE_REPORT_SCHEMA_DIAGNOSTIC_ROBUSTNESS_VALIDATION_REPORT.md` records one fresh same-origin governed run (`regen-20260325-bl063-001`) to preview `preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609`; runtime reached automation (`AUTO-20260325-872`) and critic (`CRITIC-20260325-288`) with final verdict `needs_revision`, while critic focus moved away from BL-062 report-schema/error-surfacing concerns toward output-boundary and aggregate outcome-contract clarity gaps
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-064
+- title: Harden wrapper/delegate output-boundary policy and aggregate outcome-contract clarity after BL-20260325-063 critic findings
+- type: blocker
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-063
+- start_when: `BL-20260325-063` confirms critic focus has shifted away from report-schema/error-surfacing gaps to output-boundary and aggregate outcome-contract clarity concerns
+- done_when: Source-side hardening constrains wrapper output destination policy for governed readonly runs, clarifies extraction-vs-export outcome semantics across wrapper/delegate reports, and records one blocker report with focused tests
+- source: `POST_WRAPPER_DELEGATE_REPORT_SCHEMA_DIAGNOSTIC_ROBUSTNESS_VALIDATION_REPORT.md` on 2026-03-25 records the next blocker class as output-boundary and aggregate outcome-contract clarity
+- link: /Users/lingguozhong/openclaw-team/WRAPPER_DELEGATE_OUTPUT_BOUNDARY_OUTCOME_CONTRACT_HARDENING_REPORT.md
 - issue: -
 - evidence: -
 - last_reviewed_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -3618,3 +3618,63 @@ Verification snapshot on 2026-03-25:
 - `python3 scripts/backlog_lint.py` passed
 - `python3 scripts/backlog_sync.py` passed
 - `bash scripts/premerge_check.sh` passed (`Warnings: 0`, `Failures: 0`)
+
+### 72. Fresh Governed Validation After BL-062 Report-Schema Diagnostic Hardening
+
+User objective:
+
+- continue strict backlog mainline without drift
+- validate BL-062 hardening on one fresh same-origin governed candidate
+
+Main work areas:
+
+- activated `BL-20260325-063` and mirrored it to issue `#119`
+- executed governed validation pipeline with token
+  `regen-20260325-bl063-001`:
+  - sandbox Trello smoke (captured network-policy block evidence)
+  - elevated Trello smoke (live pass + mapped preview)
+  - generated regeneration payload and ingest once -> fresh preview
+    `preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609`
+  - explicit approval write
+  - sandbox execute (captured Docker init block evidence)
+  - elevated replay with runtime env injection reached automation and critic
+- captured and archived runtime evidence:
+  - automation task completed (`AUTO-20260325-872`)
+  - critic task completed (`CRITIC-20260325-288`)
+  - final execute remained `rejected` on critic `needs_revision`
+- produced validation report and queued next blocker phase
+  (`BL-20260325-064`)
+
+Primary output:
+
+- [POST_WRAPPER_DELEGATE_REPORT_SCHEMA_DIAGNOSTIC_ROBUSTNESS_VALIDATION_REPORT.md](/Users/lingguozhong/openclaw-team/POST_WRAPPER_DELEGATE_REPORT_SCHEMA_DIAGNOSTIC_ROBUSTNESS_VALIDATION_REPORT.md)
+
+Key result:
+
+- `BL-20260325-063` is complete as a governed validation phase
+- critic findings moved away from BL-062 target concerns:
+  - sparse report-schema consistency gaps no longer dominant
+  - delegate-error surfacing gaps no longer dominant
+- new blocker focus shifted to wrapper output-boundary policy and aggregate
+  outcome-contract clarity (`BL-20260325-064`)
+
+Verification snapshot on 2026-03-25:
+
+- `python3 scripts/backlog_lint.py` passed after BL-063 activation
+- `python3 scripts/backlog_sync.py` passed with BL-063 issue mirror to `#119`
+- sandbox smoke evidence captured as blocked (`ConnectionError` /
+  `NameResolutionError`)
+- elevated smoke passed with `read_count = 1`
+- `python3 skills/ingest_tasks.py --once --test-mode success` returned:
+  - `processed = 1`
+  - `duplicate_skipped = 0`
+  - `preview_created = 1`
+- elevated execute replay returned:
+  - `status = rejected`
+  - `decision_reason = critic_verdict=needs_revision`
+  - `critic_verdict = needs_revision`
+- final preview state:
+  - `approved = true`
+  - `execution.status = rejected`
+  - `execution.executed = true`
+  - `execution.attempts = 3`

--- a/runtime_archives/bl063/runtime/AUTO-20260325-872.json
+++ b/runtime_archives/bl063/runtime/AUTO-20260325-872.json
@@ -1,0 +1,200 @@
+{
+  "task_id": "AUTO-20260325-872",
+  "worker": "automation",
+  "status": "success",
+  "created_at": "2026-03-25T10:06:04.677302Z",
+  "updated_at": "2026-03-25T10:07:24.242919Z",
+  "retries": 0,
+  "max_retries": 0,
+  "attempts": [
+    {
+      "attempt": 1,
+      "status": "success",
+      "retryable": false,
+      "error": null,
+      "runtime_log": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-872/runtime.attempt-1.log",
+      "exit_code": 0,
+      "timed_out": false,
+      "wait_error": null,
+      "output_path": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-872/output.json",
+      "started_at": "2026-03-25T10:06:04.678243Z",
+      "finished_at": "2026-03-25T10:07:24.214117Z"
+    }
+  ],
+  "task_dir": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-872",
+  "payload": {
+    "task_id": "AUTO-20260325-872",
+    "worker": "automation",
+    "task_type": "generate_script",
+    "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+    "inputs": {
+      "params": {
+        "input_dir": "~/Desktop/pdf样本",
+        "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+        "ocr": "auto",
+        "dry_run": false,
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "description": "Purpose: | Controlled Trello live preview smoke for openclaw-team. | Expected behavior: | - read-only Trello ingest | - preview creation smoke only | - no business execution claim | - no Trello writeback expected in this step | Traceability: | - backlog: BL-20260324-014 | - blocker context: BL-20260324-015 | - created_by: Oscarling | - created_at: 2026-03-24 Asia/Shanghai | Note: | This card is only for governed smoke verification and should remain open until the smoke is finished.",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "preferred_wrapper_script": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "preferred_base_script": "artifacts/scripts/pdf_to_excel_ocr.py",
+        "reference_docs": [
+          "artifacts/docs/pdf_to_excel_ocr_usage.md",
+          "artifacts/reviews/pdf_to_excel_ocr_review.md"
+        ],
+        "contract_hints": {
+          "output_format_fidelity": "If output_xlsx ends with .xlsx, produce a real XLSX workbook container or fail honestly before writing mismatched text/XML/CSV content to a .xlsx path.",
+          "path_portability": "Use the provided input_dir parameter as runtime input. Do not hardcode a user-home or absolute input path when params already declare the path.",
+          "traceability": "Preserve meaningful description context from the external input; do not collapse it to a heading fragment such as Purpose:.",
+          "reuse_preference": "Prefer reusing artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py as the wrapper baseline and artifacts/scripts/pdf_to_excel_ocr.py as the reviewed delegate when compatible, so workbook semantics and contract behavior stay aligned with repository evidence.",
+          "outcome_status_model": "Use the reviewable status model success/partial/failed. Dry-run requests or zero-PDF discovery should resolve to partial rather than claiming success without an output artifact.",
+          "delegate_resolution": "If preferred_base_script is relative, resolve it from the repository or script location instead of Path.cwd() so behavior stays portable across shells and CI.",
+          "reviewed_delegate_contract": "For readonly reviewable preview flows, delegate only to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py or fail honestly instead of broadening behavior through an arbitrary helper.",
+          "delegate_success_evidence": "Do not treat zero exit code plus output-file existence as sufficient wrapper success evidence on their own. Prefer a structured delegate report that confirms a real success outcome before the wrapper claims success. Require delegate status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, and explicit output attestation fields excel_written=true, output_exists=true, and output_size_bytes>0. Apply these gates only when wrapper status is success.",
+          "delegate_partial_evidence": "For best-effort readonly flows, if delegate status is partial and structured evidence is present, keep wrapper status partial instead of escalating to failed solely because success-only gates are unmet. Surface explicit limitations and next-step guidance in wrapper output.",
+          "delegate_timeout": "Bound delegate subprocess execution with an explicit timeout and report timeout as an honest failed/partial outcome instead of allowing smoke automation to hang indefinitely.",
+          "readonly_semantics": "Readonly semantics must be explicit: no external/Trello writeback is required, but local filesystem output writes may still occur when dry_run=false. Runtime summary fields must not overstate readonly scope.",
+          "ocr_sufficiency": "When OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial, do not claim wrapper success even if an output file exists; keep partial status with explicit OCR sufficiency notes.",
+          "runtime_summary": "The generated script should emit a structured summary of what it produced so later review can inspect behavior without guessing.",
+          "delegate_report_schema": "Treat delegate JSON report fields status/total_files/status_counter/dry_run as the canonical evidence contract. Do not require undeclared processed_files/succeeded_files/failed_files counters.",
+          "delegate_report_handoff": "When a sidecar report file is available, treat it as canonical evidence. Use stdout JSON parsing only as fallback when sidecar evidence is missing.",
+          "delegate_report_flag_contract": "If wrapper passes a sidecar report path to the reviewed delegate, use the reviewed delegate CLI flag --report-json (or another explicitly supported alias). Do not invent undeclared flags such as --report-file.",
+          "dry_run_semantics": "For readonly governed flows, do not short-circuit dry-run before delegate execution. Delegate under dry-run and pass through --dry-run explicitly so wrapper/delegate semantics remain aligned.",
+          "pdf_discovery_consistency": "Keep wrapper preflight PDF discovery semantics aligned with the reviewed delegate (for example recursive vs non-recursive), so wrapper evidence and delegated execution count the same candidate set."
+        }
+      }
+    },
+    "expected_outputs": [
+      {
+        "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "type": "script"
+      }
+    ],
+    "constraints": [
+      "Follow the local inbox normalized request",
+      "Do not claim unsupported runtime dependencies",
+      "Keep output deterministic and executable",
+      "Produce only the expected script artifact",
+      "Prefer honest, reviewable intermediate behavior over unsupported OCR claims",
+      "If the requested output path ends with .xlsx, do not write non-XLSX text/XML/CSV content to that path.",
+      "Do not hardcode an input directory when the task params already provide input_dir.",
+      "Preserve meaningful traceability from the incoming description instead of collapsing it to a heading fragment.",
+      "Prefer wrapping or adapting artifacts/scripts/pdf_to_excel_ocr.py when that existing repo script already matches the requested behavior.",
+      "When artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py already exists, prefer updating that reviewed wrapper baseline instead of rewriting a new control flow from scratch.",
+      "If dry_run is true or no PDFs are discovered, report a reviewable partial outcome instead of claiming success without an XLSX artifact.",
+      "Resolve relative delegate script paths from the repository or script location, not from Path.cwd().",
+      "For readonly reviewable preview flows, only delegate to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py unless failing honestly.",
+      "Do not claim wrapper success from exit code plus output existence alone when the reviewed delegate report does not provide strong enough success evidence.",
+      "When wrapper reports success, enforce delegate evidence gates: status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, excel_written=true, output_exists=true, and output_size_bytes>0.",
+      "If delegate reports partial with structured evidence in readonly best-effort mode, keep wrapper status partial (not failed) and include explicit limitations with next-step guidance.",
+      "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
+      "When a delegate sidecar report is present, treat sidecar JSON as canonical evidence and use stdout JSON only as fallback.",
+      "When wrapper passes a sidecar report path to the reviewed delegate, use --report-json exactly unless the reviewed delegate explicitly supports another alias.",
+      "For readonly governed flows, do not short-circuit dry-run before delegate execution; pass --dry-run through delegate and preserve partial status honestly.",
+      "Keep wrapper PDF discovery semantics aligned with reviewed delegate discovery semantics to avoid preflight/execution evidence drift.",
+      "Readonly semantics must be explicit as no external writeback; avoid claiming strict filesystem readonly when dry_run=false can write local outputs.",
+      "When OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial, keep wrapper status partial and surface OCR sufficiency limitations.",
+      "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely."
+    ],
+    "priority": "medium",
+    "source": {
+      "kind": "local_inbox",
+      "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+      "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl063-001.json",
+      "received_at": "2026-03-25T10:04:56.056950Z",
+      "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "provider": "trello",
+      "mode": "readonly",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "regeneration_token": "regen-20260325-bl063-001"
+    },
+    "acceptance_criteria": [
+      "Produce the expected script artifact at expected_outputs[0].path",
+      "Script behavior remains runnable, deterministic, and reviewable",
+      "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
+      "Artifact behavior remains parameter-driven for input_dir and output_xlsx rather than hardcoding unrelated local defaults.",
+      "Dry-run or zero-input behavior is represented as a reviewable partial outcome instead of artifact-production success.",
+      "Relative preferred_base_script resolution remains portable and does not depend on Path.cwd().",
+      "Wrapper success requires stronger delegate evidence than zero exit code plus a non-empty output file alone.",
+      "Wrapper success attestation requires delegate fields excel_written=true, output_exists=true, output_size_bytes>0, and status_counter.partial/status_counter.failed equal to 0.",
+      "Contract-compliant delegate partial outcomes remain partial with explicit limitations and next-step guidance, rather than being escalated to failed by success-only gates.",
+      "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
+      "Delegate report handoff prefers sidecar JSON as canonical evidence and only falls back to stdout JSON when sidecar evidence is unavailable.",
+      "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",
+      "Dry-run semantics remain explicit and delegated for readonly governed flows: pass --dry-run through delegate and preserve partial outcome honestly.",
+      "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
+      "Readonly semantics are explicit as no external writeback, and runtime summary wording does not overclaim strict filesystem readonly when dry_run=false.",
+      "Wrapper success is conservative when OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial.",
+      "Delegate execution is bounded by an explicit timeout and reports timeout honestly."
+    ],
+    "metadata": {
+      "integration_phase": "8B",
+      "pipeline": "inbox->adapter->manager->automation->critic",
+      "request_type": "pdf_to_excel_ocr",
+      "payload_hash": "6b1d3f0946097f965d6d55116edb8bc665d0c5a5e9ff4524c569844262305772",
+      "regeneration_token": "regen-20260325-bl063-001",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "external_metadata": {
+        "source_system": "trello",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "card_short_id": 7,
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "date_last_activity": "2026-03-24T08:35:56.234Z",
+        "readonly_mapped_at": "2026-03-25T10:04:35.724632Z",
+        "contract_profile": "best_effort_evidence_backed",
+        "ocr_claim_policy": "do_not_claim_success_without_evidence",
+        "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+        "regeneration_token": "regen-20260325-bl063-001"
+      },
+      "automation_contract_profile": "narrow_script_artifact_with_repo_reuse_and_reviewable_runner_contract"
+    }
+  },
+  "result": {
+    "task_id": "AUTO-20260325-872",
+    "worker": "automation",
+    "status": "success",
+    "summary": "Generated exactly one runnable wrapper script artifact that reuses the reviewed pdf_to_excel_ocr.py delegate, prefers sidecar JSON evidence via --report-json, preserves parameter-driven input/output behavior, enforces conservative success gates, keeps dry-run/zero-PDF/OCR-blocked outcomes reviewable as partial, and bounds delegate execution with an explicit timeout.",
+    "artifacts": [
+      {
+        "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "type": "script"
+      }
+    ],
+    "timestamp": "2026-03-25T10:07:24.051613Z",
+    "duration_ms": 79131,
+    "notes": [
+      "Only the expected script artifact was produced.",
+      "The script is deterministic and repository-relative for delegate resolution, avoiding Path.cwd()-dependent behavior.",
+      "The wrapper is designed to be parameter-driven and to preserve meaningful traceability from the request description.",
+      "Readonly semantics are explicit as no external/Trello writeback; local filesystem writes may still occur when dry_run=false."
+    ],
+    "metadata": {
+      "task_id": "AUTO-20260325-872",
+      "worker": "automation",
+      "created_artifact_count": 1
+    }
+  }
+}

--- a/runtime_archives/bl063/runtime/CRITIC-20260325-288.json
+++ b/runtime_archives/bl063/runtime/CRITIC-20260325-288.json
@@ -1,0 +1,201 @@
+{
+  "task_id": "CRITIC-20260325-288",
+  "worker": "critic",
+  "status": "success",
+  "created_at": "2026-03-25T10:07:24.250476Z",
+  "updated_at": "2026-03-25T10:08:08.810757Z",
+  "retries": 0,
+  "max_retries": 0,
+  "attempts": [
+    {
+      "attempt": 1,
+      "status": "success",
+      "retryable": false,
+      "error": null,
+      "runtime_log": "/Users/lingguozhong/openclaw-team/workspaces/critic/CRITIC-20260325-288/runtime.attempt-1.log",
+      "exit_code": 0,
+      "timed_out": false,
+      "wait_error": null,
+      "output_path": "/Users/lingguozhong/openclaw-team/workspaces/critic/CRITIC-20260325-288/output.json",
+      "started_at": "2026-03-25T10:07:24.255269Z",
+      "finished_at": "2026-03-25T10:08:08.776609Z"
+    }
+  ],
+  "task_dir": "/Users/lingguozhong/openclaw-team/workspaces/critic/CRITIC-20260325-288",
+  "payload": {
+    "task_id": "CRITIC-20260325-288",
+    "worker": "critic",
+    "task_type": "review_artifact",
+    "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+    "inputs": {
+      "artifacts": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        },
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+          "type": "script"
+        }
+      ],
+      "params": {
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "review_scope": {
+          "primary_artifact": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "paired_artifacts": [
+            "artifacts/scripts/pdf_to_excel_ocr.py"
+          ],
+          "goal": "Audit the wrapper and the reviewed delegate together so the review evidence can speak to the end-to-end readonly smoke path."
+        },
+        "artifact_snapshots": [
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "available": true,
+            "content": "#!/usr/bin/env python3\nfrom __future__ import annotations\n\nimport argparse\nimport json\nimport os\nimport subprocess\nimport sys\nimport tempfile\nfrom pathlib import Path\nfrom typing import Any\n\nDEFAULT_TIMEOUT_SECONDS = 900\nREQUEST_PAYLOAD = {\n    \"origin_id\": \"trello:69c24cd3c1a2359ddd7a1bf8\",\n    \"title\": \"BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)\",\n    \"description\": \"Purpose: | Controlled Trello live preview smoke for openclaw-team. | Expected behavior: | - read-only Trello ingest | - preview creation smoke only | - no business execution claim | - no Trello writeback expected in this step | Traceability: | - backlog: BL-20260324-014 | - blocker context: BL-20260324-015 | - created_by: Oscarling | - created_at: 2026-03-24 Asia/Shanghai | Note: | This card is only for governed smoke verification and should remain open until the smoke is finished.\",\n    \"labels\": [\"best_effort\", \"evidence_backed\", \"readonly\", \"reviewable\", \"trello\"],\n    \"source\": {\n        \"kind\": \"local_inbox\",\n        \"provider\": \"trello\",\n        \"mode\": \"readonly\",\n        \"card_id\": \"69c24cd3c1a2359ddd7a1bf8\",\n        \"board_id\": \"69be462743bfa0038ca10f7a\",\n        \"list_id\": \"69be462743bfa0038ca10f8f\",\n        \"inbox_file\": \"trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl063-001.json\",\n        \"regeneration_token\": \"regen-20260325-bl063-001\"\n    }\n}\n\n\ndef _repo_root() -> Path:\n    return Path(__file__).resolve().parents[2]\n\n\ndef _expand_path(raw: str) -> Path:\n    return Path(os.path.expanduser(raw)).resolve()\n\n\ndef _discover_pdfs(input_dir: Path) -> list[Path]:\n    if not input_dir.exists() or not input_dir.is_dir():\n        return []\n    return sorted(p for p in input_dir.rglob(\"*\") if p.is_file() and p.suffix.lower() == \".pdf\")\n\n\ndef _parse_json_text(raw: str) -> dict[str, Any] | None:\n    raw = (raw or \"\").strip()\n    if not raw:\n        return None\n    try:\n        parsed = json.loads(raw)\n    except json.JSONDecodeError:\n        return None\n    return parsed if isinstance(parsed, dict) else None\n\n\ndef _load_report(sidecar: Path, stdout_text: str) -> tuple[dict[str, Any] | None, str]:\n    if sidecar.exists():\n        try:\n            data = json.loads(sidecar.read_text(encoding=\"utf-8\"))\n            if isinstance(data, dict):\n                return data, \"sidecar\"\n        except Exception:\n            pass\n    parsed = _parse_json_text(stdout_text)\n    if parsed is not None:\n        return parsed, \"stdout\"\n    return None, \"missing\"\n\n\ndef _as_int(value: Any, default: int = 0) -> int:\n    try:\n        return int(value)\n    except Exception:\n        return default\n\n\ndef _status_counter(report: dict[str, Any] | None) -> dict[str, int]:\n    counter = report.get(\"status_counter\") if isinstance(report, dict) else {}\n    if not isinstance(counter, dict):\n        counter = {}\n    return {\n        \"success\": _as_int(counter.get(\"success\", 0)),\n        \"partial\": _as_int(counter.get(\"partial\", 0)),\n        \"failed\": _as_int(counter.get(\"failed\", 0)),\n    }\n\n\ndef _build_summary(status: str, message: str, **extra: Any) -> dict[str, Any]:\n    summary = {\n        \"status\": status,\n        \"message\": message,\n        \"origin_id\": REQUEST_PAYLOAD[\"origin_id\"],\n        \"title\": REQUEST_PAYLOAD[\"title\"],\n        \"description\": REQUEST_PAYLOAD[\"description\"],\n        \"labels\": REQUEST_PAYLOAD[\"labels\"],\n        \"readonly_scope\": {\n            \"external_writeback\": False,\n            \"trello_writeback\": False,\n            \"local_filesystem_writes_possible\": True,\n        },\n    }\n    summary.update(extra)\n    return summary\n\n\ndef main() -> int:\n    parser = argparse.ArgumentParser(description=\"Readonly reviewable inbox runner for reviewed PDF-to-Excel delegate.\")\n    parser.add_argument(\"--input-dir\", default=\"~/Desktop/pdf样本\", help=\"Directory containing input PDFs.\")\n    parser.add_argument(\"--output-xlsx\", default=\"artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx\", help=\"Target XLSX output path.\")\n    parser.add_argument(\"--ocr\", default=\"auto\", choices=[\"auto\", \"on\", \"off\"], help=\"OCR mode passed through to delegate.\")\n    parser.add_argument(\"--dry-run\", action=\"store_true\", help=\"Delegate dry-run mode; remains a reviewable partial outcome.\")\n    parser.add_argument(\"--timeout-seconds\", type=int, default=DEFAULT_TIMEOUT_SECONDS, help=\"Timeout for delegate subprocess execution.\")\n    args = parser.parse_args()\n\n    repo_root = _repo_root()\n    script_path = Path(__file__).resolve()\n    delegate_path = (repo_root / \"artifacts/scripts/pdf_to_excel_ocr.py\").resolve()\n    input_dir = _expand_path(args.input_dir)\n    output_xlsx = _expand_path(args.output_xlsx) if os.path.isabs(os.path.expanduser(args.output_xlsx)) else (repo_root / args.output_xlsx).resolve()\n\n    if output_xlsx.suffix.lower() != \".xlsx\":\n        print(json.dumps(_build_summary(\n            \"failed\",\n            \"Refusing to run because output_xlsx must end with .xlsx for true workbook semantics.\",\n            runtime_summary={\n                \"script\": str(script_path),\n                \"delegate\": str(delegate_path),\n                \"input_dir\": str(input_dir),\n                \"output_xlsx\": str(output_xlsx),\n                \"ocr\": args.ocr,\n                \"dry_run\": args.dry_run,\n                \"timeout_seconds\": args.timeout_seconds,\n            },\n        ), ensure_ascii=False, indent=2))\n        return 2\n\n    discovered_pdfs = _discover_pdfs(input_dir)\n    preflight = {\n        \"input_dir\": str(input_dir),\n        \"output_xlsx\": str(output_xlsx),\n        \"ocr\": args.ocr,\n        \"dry_run\": args.dry_run,\n        \"timeout_seconds\": args.timeout_seconds,\n        \"delegate_path\": str(delegate_path),\n        \"discovered_pdf_count\": len(discovered_pdfs),\n        \"discovered_pdfs_sample\": [str(p) for p in discovered_pdfs[:20]],\n        \"readonly_semantics\": \"No external or Trello writeback. Local output files may be written when dry_run=false.\",\n    }\n\n    if not delegate_path.exists():\n        print(json.dumps(_build_summary(\n            \"failed\",\n            \"Reviewed delegate script was not found; refusing to broaden behavior with an arbitrary helper.\",\n            runtime_summary=preflight,\n            limitations=[\"Missing reviewed delegate artifacts/scripts/pdf_to_excel_ocr.py\"],\n            next_steps=[\"Restore the reviewed delegate script and rerun the wrapper.\"],\n        ), ensure_ascii=False, indent=2))\n        return 2\n\n    with tempfile.TemporaryDirectory(prefix=\"pdf_to_excel_runner_\") as tmpdir:\n        report_path = Path(tmpdir) / \"delegate_report.json\"\n        cmd = [\n            sys.executable,\n            str(delegate_path),\n            \"--input-dir\", str(input_dir),\n            \"--output-xlsx\", str(output_xlsx),\n            \"--ocr\", args.ocr,\n            \"--report-json\", str(report_path),\n        ]\n        if args.dry_run:\n            cmd.append(\"--dry-run\")\n\n        try:\n            proc = subprocess.run(\n                cmd,\n                capture_output=True,\n                text=True,\n                timeout=max(1, args.timeout_seconds),\n                cwd=str(repo_root),\n                check=False,\n            )\n        except subprocess.TimeoutExpired as exc:\n            print(json.dumps(_build_summary(\n                \"failed\",\n                \"Delegate execution timed out.\",\n                runtime_summary={\n                    **preflight,\n                    \"delegate_command\": cmd,\n                    \"timeout_seconds\": args.timeout_seconds,\n                    \"stdout_excerpt\": (exc.stdout or \"\")[:4000],\n                    \"stderr_excerpt\": (exc.stderr or \"\")[:4000],\n                },\n                limitations=[\"Delegate subprocess exceeded the configured timeout.\"],\n                next_steps=[\"Inspect the input PDFs and delegate runtime dependencies.\", \"Retry with a larger --timeout-seconds value if appropriate.\"],\n            ), ensure_ascii=False, indent=2))\n            return 2\n\n        report, report_source = _load_report(report_path, proc.stdout)\n        delegate_status = report.get(\"status\") if isinstance(report, dict) else None\n        total_files = _as_int(report.get(\"total_files\"), 0) if isinstance(report, dict) else 0\n        delegate_dry_run = bool(report.get(\"dry_run\")) if isinstance(report, dict) else args.dry_run\n        counter = _status_counter(report)\n        excel_written = bool(report.get(\"excel_written\")) if isinstance(report, dict) else False\n        output_exists = bool(report.get(\"output_exists\")) if isinstance(report, dict) else output_xlsx.exists()\n        output_size_bytes = _as_int(report.get(\"output_size_bytes\"), 0) if isinstance(report, dict) else (output_xlsx.stat().st_size if output_xlsx.exists() else 0)\n        ocr_runtime_status = report.get(\"ocr_runtime_status\") if isinstance(report, dict) else None\n\n        runtime_summary = {\n            **preflight,\n            \"delegate_command\": cmd,\n            \"delegate_exit_code\": proc.returncode,\n            \"delegate_report_source\": report_source,\n            \"delegate_status\": delegate_status,\n            \"delegate_total_files\": total_files,\n            \"delegate_dry_run\": delegate_dry_run,\n            \"delegate_status_counter\": counter,\n            \"excel_written\": excel_written,\n            \"output_exists\": output_exists,\n            \"output_size_bytes\": output_size_bytes,\n            \"ocr_runtime_status\": ocr_runtime_status,\n            \"stdout_excerpt\": (proc.stdout or \"\")[:4000],\n            \"stderr_excerpt\": (proc.stderr or \"\")[:4000],\n        }\n\n        success_gates = all([\n            delegate_status == \"success\",\n            total_files >= 1,\n            delegate_dry_run is False,\n            counter.get(\"failed\", 0) == 0,\n            counter.get(\"partial\", 0) == 0,\n            excel_written is True,\n            output_exists is True,\n            output_size_bytes > 0,\n        ])\n\n        if args.ocr in {\"auto\", \"on\"} and ocr_runtime_status in {\"blocked\", \"partial\"}:\n            print(json.dumps(_build_summary(\n                \"partial\",\n                \"Delegate reported limited OCR sufficiency; not claiming success.\",\n                runtime_summary=runtime_summary,\n                limitations=[\"OCR runtime status was reported as blocked/partial.\"],\n                next_steps=[\"Review OCR/runtime dependencies and inspect the generated evidence before rerunning.\"],\n                delegate_report=report,\n            ), ensure_ascii=False, indent=2))\n            return 0\n\n        if success_gates:\n            print(json.dumps(_build_summary(\n                \"success\",\n                \"Reviewed delegate reported a strong success outcome and attested a real XLSX output.\",\n                runtime_summary=runtime_summary,\n                delegate_report=report,\n            ), ensure_ascii=False, indent=2))\n            return 0\n\n        if delegate_status == \"partial\":\n            limitations = []\n            if delegate_dry_run:\n                limitations.append(\"Dry-run was requested; no final XLSX success claim is appropriate.\")\n            if total_files == 0:\n                limitations.append(\"No PDF inputs were discovered or processed.\")\n            if counter.get(\"partial\", 0) > 0 or counter.get(\"failed\", 0) > 0:\n                limitations.append(\"Delegate reported partial/failed file-level outcomes.\")\n            if args.ocr in {\"auto\", \"on\"} and ocr_runtime_status:\n                limitations.append(f\"OCR runtime status: {ocr_runtime_status}.\")\n            if not limitations:\n                limitations.append(\"Delegate provided a reviewable partial outcome.\")\n            print(json.dumps(_build_summary(\n                \"partial\",\n                \"Best-effort delegate outcome remained partial; preserving that status with explicit limitations.\",\n                runtime_summary=runtime_summary,\n                limitations=limitations,\n                next_steps=[\n                    \"Inspect the delegate report and stdout/stderr excerpts.\",\n                    \"Verify PDF inputs and OCR/runtime dependencies.\",\n                    \"Rerun without --dry-run once the environment is ready for a real workbook write.\"\n                ],\n                delegate_report=report,\n            ), ensure_ascii=False, indent=2))\n            return 0\n\n        if args.dry_run or len(discovered_pdfs) == 0:\n            limitations = []\n            if args.dry_run:\n                limitations.append(\"Dry-run requests are reviewable-only and do not justify success.\")\n            if len(discovered_pdfs) == 0:\n                limitations.append(\"Zero PDFs discovered during wrapper preflight.\")\n            if report is None:\n                limitations.append(\"Delegate did not provide canonical structured evidence.\")\n            print(json.dumps(_build_summary(\n                \"partial\",\n                \"Reviewable partial outcome due to dry-run and/or zero-PDF discovery.\",\n                runtime_summary=runtime_summary,\n                limitations=limitations,\n                next_steps=[\n                    \"Add or verify input PDFs under the provided input directory.\",\n                    \"Run again without --dry-run when ready to produce a workbook.\"\n                ],\n                delegate_report=report,\n            ), ensure_ascii=False, indent=2))\n            return 0\n\n        print(json.dumps(_build_summary(\n            \"failed\",\n            \"Delegate did not provide strong enough evidence for success, and no contract-compliant partial outcome was established.\",\n            runtime_summary=runtime_summary,\n            limitations=[\n                \"Wrapper does not treat exit code plus output-file existence alone as sufficient success evidence.\",\n                \"Required delegate evidence gates were not all satisfied.\"\n            ],\n            next_steps=[\n                \"Inspect the delegate JSON report for missing attestation fields.\",\n                \"Confirm the reviewed delegate supports --report-json and emits canonical status/total_files/status_counter/dry_run fields.\"\n            ],\n            delegate_report=report,\n        ), ensure_ascii=False, indent=2))\n        return 2\n\n\nif __name__ == \"__main__\":\n    raise SystemExit(main())\n",
+            "truncated": false
+          },
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+            "available": true,
+            "content": "#!/usr/bin/env python3\n\"\"\"\nBatch PDF -> Excel extractor with optional OCR fallback.\n\nDesign goals:\n- Batch processing with per-file isolation (single file failure must not stop the batch)\n- OCR mode: auto | on | off\n- Chinese-friendly OCR defaults (chi_sim+eng)\n- Dry-run support for pilot validation when dependencies are unavailable\n\"\"\"\n\nfrom __future__ import annotations\n\nimport argparse\nimport json\nimport shutil\nimport sys\nfrom dataclasses import asdict, dataclass\nfrom pathlib import Path\nfrom typing import Any\n\n\ntry:\n    from pypdf import PdfReader  # type: ignore\nexcept Exception:\n    PdfReader = None\n\ntry:\n    import pandas as pd  # type: ignore\nexcept Exception:\n    pd = None\n\ntry:\n    import pytesseract  # type: ignore\nexcept Exception:\n    pytesseract = None\n\ntry:\n    from pdf2image import convert_from_path  # type: ignore\nexcept Exception:\n    convert_from_path = None\n\n\n@dataclass\nclass FileResult:\n    file_name: str\n    file_path: str\n    status: str\n    extract_method: str\n    page_count: int\n    text_chars: int\n    text_preview: str\n    warnings: str\n    error: str\n\n\ndef parse_args() -> argparse.Namespace:\n    parser = argparse.ArgumentParser(description=\"Batch PDF to Excel extractor with OCR fallback.\")\n    parser.add_argument(\"--input-dir\", required=True, help=\"Directory containing PDF files.\")\n    parser.add_argument(\"--output-xlsx\", required=True, help=\"Output Excel path.\")\n    parser.add_argument(\n        \"--ocr\",\n        choices=(\"auto\", \"on\", \"off\"),\n        default=\"auto\",\n        help=\"OCR mode. auto=use OCR when plain text extraction is weak.\",\n    )\n    parser.add_argument(\n        \"--dry-run\",\n        action=\"store_true\",\n        help=\"Do not write Excel file. Print execution summary only.\",\n    )\n    parser.add_argument(\n        \"--ocr-lang\",\n        default=\"chi_sim+eng\",\n        help=\"OCR language pack for pytesseract, default supports Chinese + English.\",\n    )\n    parser.add_argument(\n        \"--auto-ocr-min-chars\",\n        type=int,\n        default=50,\n        help=\"In auto mode, run OCR when extracted text chars < this threshold.\",\n    )\n    parser.add_argument(\n        \"--report-json\",\n        default=\"\",\n        help=\"Optional sidecar path for writing the same JSON report emitted to stdout.\",\n    )\n    return parser.parse_args()\n\n\ndef discover_pdfs(input_dir: Path) -> list[Path]:\n    if not input_dir.exists():\n        raise FileNotFoundError(f\"Input directory does not exist: {input_dir}\")\n    if not input_dir.is_dir():\n        raise NotADirectoryError(f\"Input path is not a directory: {input_dir}\")\n    files = sorted([p for p in input_dir.rglob(\"*\") if p.is_file() and p.suffix.lower() == \".pdf\"])\n    return files\n\n\ndef detect_ocr_runtime_status() -> tuple[str, list[str]]:\n    missing: list[str] = []\n    present: list[str] = []\n\n    if pytesseract is None:\n        missing.append(\"python module pytesseract\")\n    else:\n        present.append(\"python module pytesseract\")\n    if convert_from_path is None:\n        missing.append(\"python module pdf2image\")\n    else:\n        present.append(\"python module pdf2image\")\n    if shutil.which(\"tesseract\") is None:\n        missing.append(\"binary tesseract\")\n    else:\n        present.append(\"binary tesseract\")\n    if shutil.which(\"pdftoppm\") is None:\n        missing.append(\"binary pdftoppm (poppler)\")\n    else:\n        present.append(\"binary pdftoppm (poppler)\")\n\n    if not missing:\n        return \"available\", []\n    if present:\n        return \"partial\", missing\n    return \"blocked\", missing\n\n\ndef extract_text_pypdf(pdf_path: Path) -> tuple[str, int]:\n    if PdfReader is None:\n        raise RuntimeError(\"pypdf not installed\")\n    reader = PdfReader(str(pdf_path))\n    page_texts: list[str] = []\n    for page in reader.pages:\n        text = page.extract_text() or \"\"\n        page_texts.append(text)\n    return \"\\n\".join(page_texts), len(reader.pages)\n\n\ndef extract_text_ocr(pdf_path: Path, ocr_lang: str) -> str:\n    if pytesseract is None:\n        raise RuntimeError(\"pytesseract not installed\")\n    if convert_from_path is None:\n        raise RuntimeError(\"pdf2image not installed\")\n    if shutil.which(\"tesseract\") is None:\n        raise RuntimeError(\"tesseract binary not found\")\n    if shutil.which(\"pdftoppm\") is None:\n        raise RuntimeError(\"pdftoppm binary not found (install poppler)\")\n\n    images = convert_from_path(str(pdf_path), dpi=220)\n    chunks: list[str] = []\n    for image in images:\n        chunks.append(pytesseract.image_to_string(image, lang=ocr_lang))\n    return \"\\n\".join(chunks)\n\n\ndef compact_preview(text: str, limit: int = 160) -> str:\n    single_line = \" \".join(text.split())\n    if len(single_line) <= limit:\n        return single_line\n    return single_line[: limit - 3] + \"...\"\n\n\ndef process_one_pdf(\n    pdf_path: Path,\n    ocr_mode: str,\n    ocr_lang: str,\n    auto_ocr_min_chars: int,\n) -> FileResult:\n    warnings: list[str] = []\n    errors: list[str] = []\n    method = \"none\"\n    text = \"\"\n    page_count = 0\n\n    try:\n        text, page_count = extract_text_pypdf(pdf_path)\n        method = \"text\"\n    except Exception as e:\n        warnings.append(f\"text extraction unavailable: {e}\")\n\n    needs_ocr = False\n    if ocr_mode == \"on\":\n        needs_ocr = True\n    elif ocr_mode == \"auto\" and len(text.strip()) < auto_ocr_min_chars:\n        needs_ocr = True\n\n    if needs_ocr:\n        try:\n            ocr_text = extract_text_ocr(pdf_path, ocr_lang).strip()\n            if ocr_text:\n                if text.strip():\n                    text = f\"{text.strip()}\\n\\n[OCR Fallback]\\n{ocr_text}\"\n                    method = \"text+ocr\"\n                else:\n                    text = ocr_text\n                    method = \"ocr\"\n            else:\n                warnings.append(\"OCR returned empty text\")\n        except Exception as e:\n            errors.append(f\"OCR failed: {e}\")\n\n    if not text.strip():\n        if errors:\n            status = \"failed\"\n        else:\n            status = \"partial\"\n            warnings.append(\"No extractable text captured\")\n    else:\n        if errors:\n            status = \"partial\"\n            warnings.append(\"Text was extracted, but one or more extraction attempts failed; review errors\")\n        else:\n            status = \"success\"\n\n    return FileResult(\n        file_name=pdf_path.name,\n        file_path=str(pdf_path),\n        status=status,\n        extract_method=method,\n        page_count=page_count,\n        text_chars=len(text),\n        text_preview=compact_preview(text),\n        warnings=\" | \".join(warnings),\n        error=\" | \".join(errors),\n    )\n\n\ndef write_excel(results: list[FileResult], output_xlsx: Path) -> None:\n    if pd is None:\n        raise RuntimeError(\"pandas is required to write Excel output\")\n    output_xlsx.parent.mkdir(parents=True, exist_ok=True)\n\n    rows = [asdict(r) for r in results]\n    detail_df = pd.DataFrame(rows)\n\n    summary_rows: list[dict[str, Any]] = []\n    by_status = detail_df.groupby(\"status\").size().to_dict()\n    by_method = detail_df.groupby(\"extract_method\").size().to_dict()\n    for key, value in sorted(by_status.items()):\n        summary_rows.append({\"metric\": \"status_count\", \"name\": key, \"value\": int(value)})\n    for key, value in sorted(by_method.items()):\n        summary_rows.append({\"metric\": \"method_count\", \"name\": key, \"value\": int(value)})\n    summary_rows.append({\"metric\": \"total_files\", \"name\": \"all\", \"value\": int(len(results))})\n    summary_df = pd.DataFrame(summary_rows)\n\n    with pd.ExcelWriter(output_xlsx) as writer:\n        summary_df.to_excel(writer, sheet_name=\"summary\", index=False)\n        detail_df.to_excel(writer, sheet_name=\"files\", index=False)\n\n\ndef emit_report(report: dict[str, Any], report_json: str) -> None:\n    rendered = json.dumps(report, ensure_ascii=False, indent=2)\n    print(rendered)\n    if not report_json:\n        return\n    out_path = Path(report_json).expanduser().resolve()\n    out_path.parent.mkdir(parents=True, exist_ok=True)\n    out_path.write_text(rendered + \"\\n\", encoding=\"utf-8\")\n\n\ndef build_report_template(\n    *,\n    input_dir: Path,\n    output_xlsx: Path,\n    ocr_mode: str,\n    dry_run: bool,\n) -> dict[str, Any]:\n    return {\n        \"status\": \"failed\",\n        \"input_dir\": str(input_dir),\n        \"output_xlsx\": str(output_xlsx),\n        \"ocr_mode\": ocr_mode,\n        \"ocr_runtime_status\": \"unknown\",\n        \"ocr_missing_dependencies\": [],\n        \"total_files\": 0,\n        \"files\": [],\n        \"status_counter\": {},\n        \"dry_run\": bool(dry_run),\n        \"excel_written\": False,\n        \"output_exists\": False,\n        \"output_size_bytes\": 0,\n        \"notes\": [],\n        \"next_steps\": [],\n        \"error\": \"\",\n    }\n\n\ndef main() -> int:\n    args = parse_args()\n    input_dir = Path(args.input_dir).expanduser().resolve()\n    output_xlsx = Path(args.output_xlsx).expanduser().resolve()\n\n    try:\n        pdf_files = discover_pdfs(input_dir)\n    except Exception as e:\n        report = build_report_template(\n            input_dir=input_dir,\n            output_xlsx=output_xlsx,\n            ocr_mode=args.ocr,\n            dry_run=args.dry_run,\n        )\n        report[\"error\"] = str(e)\n        report[\"notes\"].append(\"Input discovery failed before extraction could start.\")\n        report[\"next_steps\"].append(\"Verify input directory exists and is readable, then rerun.\")\n        emit_report(report, args.report_json)\n        return 2\n\n    if not pdf_files:\n        report = build_report_template(\n            input_dir=input_dir,\n            output_xlsx=output_xlsx,\n            ocr_mode=args.ocr,\n            dry_run=args.dry_run,\n        )\n        report[\"status\"] = \"partial\"\n        report[\"notes\"] = [f\"No PDF files found under {input_dir}\"]\n        report[\"next_steps\"] = [\n            \"Add one or more .pdf files under the input directory and rerun.\",\n        ]\n        emit_report(report, args.report_json)\n        return 0\n\n    ocr_runtime, missing = detect_ocr_runtime_status()\n    results: list[FileResult] = []\n    for pdf in pdf_files:\n        try:\n            results.append(\n                process_one_pdf(\n                    pdf,\n                    ocr_mode=args.ocr,\n                    ocr_lang=args.ocr_lang,\n                    auto_ocr_min_chars=args.auto_ocr_min_chars,\n                )\n            )\n        except Exception as e:\n            results.append(\n                FileResult(\n                    file_name=pdf.name,\n                    file_path=str(pdf),\n                    status=\"failed\",\n                    extract_method=\"none\",\n                    page_count=0,\n                    text_chars=0,\n                    text_preview=\"\",\n                    warnings=\"\",\n                    error=f\"Unhandled processing exception: {e}\",\n                )\n            )\n\n    status_counter: dict[str, int] = {}\n    for item in results:\n        status_counter[item.status] = status_counter.get(item.status, 0) + 1\n\n    files_payload = [asdict(item) for item in results]\n    failed_count = status_counter.get(\"failed\", 0)\n    partial_count = status_counter.get(\"partial\", 0)\n    if failed_count == 0 and partial_count == 0:\n        aggregate_status = \"success\"\n    else:\n        aggregate_status = \"partial\"\n\n    notes: list[str] = []\n    next_steps: list[str] = []\n    if ocr_runtime != \"available\":\n        notes.append(f\"OCR runtime status is {ocr_runtime}; missing dependencies: {', '.join(missing) or 'none'}\")\n        next_steps.append(\"Install missing OCR runtime dependencies if OCR fallback is required.\")\n    if partial_count > 0:\n        notes.append(f\"{partial_count} file(s) reported partial status.\")\n        next_steps.append(\"Inspect per-file partial records in `files` and address listed warnings/errors.\")\n    if failed_count > 0:\n        notes.append(f\"{failed_count} file(s) reported failed status.\")\n        next_steps.append(\"Inspect per-file failures in `files` and resolve the extraction or OCR error causes.\")\n\n    report = build_report_template(\n        input_dir=input_dir,\n        output_xlsx=output_xlsx,\n        ocr_mode=args.ocr,\n        dry_run=args.dry_run,\n    )\n    report.update(\n        {\n            \"status\": aggregate_status,\n            \"ocr_runtime_status\": ocr_runtime,\n            \"ocr_missing_dependencies\": missing,\n            \"total_files\": len(results),\n            \"files\": files_payload,\n            \"status_counter\": status_counter,\n            \"notes\": notes,\n            \"next_steps\": next_steps,\n        }\n    )\n\n    if args.dry_run:\n        emit_report(report, args.report_json)\n        return 0\n\n    try:\n        write_excel(results, output_xlsx)\n        report[\"output_exists\"] = output_xlsx.exists() and output_xlsx.is_file()\n        if report[\"output_exists\"]:\n            report[\"output_size_bytes\"] = int(output_xlsx.stat().st_size)\n        report[\"excel_written\"] = bool(report[\"output_exists\"] and report[\"output_size_bytes\"] > 0)\n        emit_report(report, args.report_json)\n        return 0\n    except Exception as e:\n        report[\"status\"] = \"failed\"\n        report[\"error\"] = str(e)\n        report[\"output_exists\"] = output_xlsx.exists() and output_xlsx.is_file()\n        if report[\"output_exists\"]:\n            report[\"output_size_bytes\"] = int(output_xlsx.stat().st_size)\n        report[\"excel_written\"] = bool(report[\"output_exists\"] and report[\"output_size_bytes\"] > 0)\n        report[\"notes\"] = report.get(\"notes\", []) + [\"Excel write step failed after extraction.\"]\n        report[\"next_steps\"] = report.get(\"next_steps\", []) + [\"Check pandas/openpyxl availability and output path permissions.\"]\n        emit_report(report, args.report_json)\n        return 3\n\n\nif __name__ == \"__main__\":\n    raise SystemExit(main())\n",
+            "truncated": false
+          }
+        ],
+        "review_contract": {
+          "required_status": [
+            "success",
+            "partial",
+            "failed"
+          ],
+          "required_verdict_values": [
+            "fail",
+            "needs_revision",
+            "pass"
+          ],
+          "required_metadata_key": "verdict",
+          "must_write_review_artifact_to": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "artifact_policy": "Always include either `file_contents` for the review artifact path or `artifacts` referencing that exact path.",
+          "fallback_policy": "If evidence is insufficient, return `status=partial`, include explicit `errors`, still generate review artifact content, and set verdict=needs_revision."
+        },
+        "review_template": {
+          "title": "Review: <artifact name>",
+          "sections": [
+            "Scope",
+            "Findings",
+            "Verdict",
+            "Rationale"
+          ],
+          "verdict_required": true
+        }
+      }
+    },
+    "expected_outputs": [
+      {
+        "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+        "type": "review"
+      }
+    ],
+    "constraints": [
+      "Review must be grounded in produced automation artifact",
+      "When both wrapper and reviewed delegate snapshots are supplied, evaluate them as one end-to-end readonly pair instead of ignoring the delegate evidence.",
+      "Do not invent missing artifact content",
+      "Return a clear verdict: pass, fail, or needs_revision",
+      "Include metadata.verdict in output",
+      "Generate review artifact markdown for expected_outputs[0].path",
+      "Use artifact_snapshots when provided; avoid claiming access problems if snapshot content exists.",
+      "When both the generated wrapper and reviewed delegate snapshots are provided, review them together rather than silently narrowing scope to one file.",
+      "Return metadata.verdict with one of: pass, fail, needs_revision.",
+      "Always generate review artifact content for expected_outputs[0].path.",
+      "If evidence is insufficient, use partial + errors + verdict=needs_revision, but still output review artifact."
+    ],
+    "priority": "medium",
+    "source": {
+      "kind": "local_inbox",
+      "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+      "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl063-001.json",
+      "received_at": "2026-03-25T10:04:56.056950Z",
+      "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "provider": "trello",
+      "mode": "readonly",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "regeneration_token": "regen-20260325-bl063-001"
+    },
+    "acceptance_criteria": [
+      "Produce a review artifact with explicit verdict (pass/fail/needs_revision)"
+    ],
+    "metadata": {
+      "integration_phase": "8B",
+      "pipeline": "inbox->adapter->manager->automation->critic",
+      "request_type": "pdf_to_excel_ocr",
+      "payload_hash": "6b1d3f0946097f965d6d55116edb8bc665d0c5a5e9ff4524c569844262305772",
+      "regeneration_token": "regen-20260325-bl063-001",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "external_metadata": {
+        "source_system": "trello",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "card_short_id": 7,
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "date_last_activity": "2026-03-24T08:35:56.234Z",
+        "readonly_mapped_at": "2026-03-25T10:04:35.724632Z",
+        "contract_profile": "best_effort_evidence_backed",
+        "ocr_claim_policy": "do_not_claim_success_without_evidence",
+        "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+        "regeneration_token": "regen-20260325-bl063-001"
+      }
+    }
+  },
+  "result": {
+    "task_id": "CRITIC-20260325-288",
+    "worker": "critic",
+    "status": "success",
+    "summary": "Reviewed the inbox runner and paired delegate together as an end-to-end readonly smoke path. Generated the required markdown review artifact with an explicit verdict. Verdict: needs_revision.",
+    "artifacts": [
+      {
+        "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+        "type": "review"
+      }
+    ],
+    "timestamp": "2026-03-25T10:08:08.645116Z",
+    "duration_ms": 44181,
+    "notes": [
+      "Review is grounded in the provided artifact snapshots for both scripts.",
+      "Assessment covers wrapper/delegate interaction, readonly contract handling, evidence gating, and result semantics."
+    ],
+    "metadata": {
+      "verdict": "needs_revision",
+      "task_id": "CRITIC-20260325-288",
+      "worker": "critic",
+      "review_scope": [
+        "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "artifacts/scripts/pdf_to_excel_ocr.py"
+      ],
+      "primary_artifact": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+      "paired_artifact": "artifacts/scripts/pdf_to_excel_ocr.py"
+    }
+  }
+}

--- a/runtime_archives/bl063/runtime/automation-output.json
+++ b/runtime_archives/bl063/runtime/automation-output.json
@@ -1,0 +1,25 @@
+{
+  "task_id": "AUTO-20260325-872",
+  "worker": "automation",
+  "status": "success",
+  "summary": "Generated exactly one runnable wrapper script artifact that reuses the reviewed pdf_to_excel_ocr.py delegate, prefers sidecar JSON evidence via --report-json, preserves parameter-driven input/output behavior, enforces conservative success gates, keeps dry-run/zero-PDF/OCR-blocked outcomes reviewable as partial, and bounds delegate execution with an explicit timeout.",
+  "artifacts": [
+    {
+      "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+      "type": "script"
+    }
+  ],
+  "timestamp": "2026-03-25T10:07:24.051613Z",
+  "duration_ms": 79131,
+  "notes": [
+    "Only the expected script artifact was produced.",
+    "The script is deterministic and repository-relative for delegate resolution, avoiding Path.cwd()-dependent behavior.",
+    "The wrapper is designed to be parameter-driven and to preserve meaningful traceability from the request description.",
+    "Readonly semantics are explicit as no external/Trello writeback; local filesystem writes may still occur when dry_run=false."
+  ],
+  "metadata": {
+    "task_id": "AUTO-20260325-872",
+    "worker": "automation",
+    "created_artifact_count": 1
+  }
+}

--- a/runtime_archives/bl063/runtime/automation-produced-pdf_to_excel_ocr_inbox_runner.py
+++ b/runtime_archives/bl063/runtime/automation-produced-pdf_to_excel_ocr_inbox_runner.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+DEFAULT_TIMEOUT_SECONDS = 900
+REQUEST_PAYLOAD = {
+    "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+    "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+    "description": "Purpose: | Controlled Trello live preview smoke for openclaw-team. | Expected behavior: | - read-only Trello ingest | - preview creation smoke only | - no business execution claim | - no Trello writeback expected in this step | Traceability: | - backlog: BL-20260324-014 | - blocker context: BL-20260324-015 | - created_by: Oscarling | - created_at: 2026-03-24 Asia/Shanghai | Note: | This card is only for governed smoke verification and should remain open until the smoke is finished.",
+    "labels": ["best_effort", "evidence_backed", "readonly", "reviewable", "trello"],
+    "source": {
+        "kind": "local_inbox",
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl063-001.json",
+        "regeneration_token": "regen-20260325-bl063-001"
+    }
+}
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _expand_path(raw: str) -> Path:
+    return Path(os.path.expanduser(raw)).resolve()
+
+
+def _discover_pdfs(input_dir: Path) -> list[Path]:
+    if not input_dir.exists() or not input_dir.is_dir():
+        return []
+    return sorted(p for p in input_dir.rglob("*") if p.is_file() and p.suffix.lower() == ".pdf")
+
+
+def _parse_json_text(raw: str) -> dict[str, Any] | None:
+    raw = (raw or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _load_report(sidecar: Path, stdout_text: str) -> tuple[dict[str, Any] | None, str]:
+    if sidecar.exists():
+        try:
+            data = json.loads(sidecar.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                return data, "sidecar"
+        except Exception:
+            pass
+    parsed = _parse_json_text(stdout_text)
+    if parsed is not None:
+        return parsed, "stdout"
+    return None, "missing"
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
+def _status_counter(report: dict[str, Any] | None) -> dict[str, int]:
+    counter = report.get("status_counter") if isinstance(report, dict) else {}
+    if not isinstance(counter, dict):
+        counter = {}
+    return {
+        "success": _as_int(counter.get("success", 0)),
+        "partial": _as_int(counter.get("partial", 0)),
+        "failed": _as_int(counter.get("failed", 0)),
+    }
+
+
+def _build_summary(status: str, message: str, **extra: Any) -> dict[str, Any]:
+    summary = {
+        "status": status,
+        "message": message,
+        "origin_id": REQUEST_PAYLOAD["origin_id"],
+        "title": REQUEST_PAYLOAD["title"],
+        "description": REQUEST_PAYLOAD["description"],
+        "labels": REQUEST_PAYLOAD["labels"],
+        "readonly_scope": {
+            "external_writeback": False,
+            "trello_writeback": False,
+            "local_filesystem_writes_possible": True,
+        },
+    }
+    summary.update(extra)
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Readonly reviewable inbox runner for reviewed PDF-to-Excel delegate.")
+    parser.add_argument("--input-dir", default="~/Desktop/pdf样本", help="Directory containing input PDFs.")
+    parser.add_argument("--output-xlsx", default="artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx", help="Target XLSX output path.")
+    parser.add_argument("--ocr", default="auto", choices=["auto", "on", "off"], help="OCR mode passed through to delegate.")
+    parser.add_argument("--dry-run", action="store_true", help="Delegate dry-run mode; remains a reviewable partial outcome.")
+    parser.add_argument("--timeout-seconds", type=int, default=DEFAULT_TIMEOUT_SECONDS, help="Timeout for delegate subprocess execution.")
+    args = parser.parse_args()
+
+    repo_root = _repo_root()
+    script_path = Path(__file__).resolve()
+    delegate_path = (repo_root / "artifacts/scripts/pdf_to_excel_ocr.py").resolve()
+    input_dir = _expand_path(args.input_dir)
+    output_xlsx = _expand_path(args.output_xlsx) if os.path.isabs(os.path.expanduser(args.output_xlsx)) else (repo_root / args.output_xlsx).resolve()
+
+    if output_xlsx.suffix.lower() != ".xlsx":
+        print(json.dumps(_build_summary(
+            "failed",
+            "Refusing to run because output_xlsx must end with .xlsx for true workbook semantics.",
+            runtime_summary={
+                "script": str(script_path),
+                "delegate": str(delegate_path),
+                "input_dir": str(input_dir),
+                "output_xlsx": str(output_xlsx),
+                "ocr": args.ocr,
+                "dry_run": args.dry_run,
+                "timeout_seconds": args.timeout_seconds,
+            },
+        ), ensure_ascii=False, indent=2))
+        return 2
+
+    discovered_pdfs = _discover_pdfs(input_dir)
+    preflight = {
+        "input_dir": str(input_dir),
+        "output_xlsx": str(output_xlsx),
+        "ocr": args.ocr,
+        "dry_run": args.dry_run,
+        "timeout_seconds": args.timeout_seconds,
+        "delegate_path": str(delegate_path),
+        "discovered_pdf_count": len(discovered_pdfs),
+        "discovered_pdfs_sample": [str(p) for p in discovered_pdfs[:20]],
+        "readonly_semantics": "No external or Trello writeback. Local output files may be written when dry_run=false.",
+    }
+
+    if not delegate_path.exists():
+        print(json.dumps(_build_summary(
+            "failed",
+            "Reviewed delegate script was not found; refusing to broaden behavior with an arbitrary helper.",
+            runtime_summary=preflight,
+            limitations=["Missing reviewed delegate artifacts/scripts/pdf_to_excel_ocr.py"],
+            next_steps=["Restore the reviewed delegate script and rerun the wrapper."],
+        ), ensure_ascii=False, indent=2))
+        return 2
+
+    with tempfile.TemporaryDirectory(prefix="pdf_to_excel_runner_") as tmpdir:
+        report_path = Path(tmpdir) / "delegate_report.json"
+        cmd = [
+            sys.executable,
+            str(delegate_path),
+            "--input-dir", str(input_dir),
+            "--output-xlsx", str(output_xlsx),
+            "--ocr", args.ocr,
+            "--report-json", str(report_path),
+        ]
+        if args.dry_run:
+            cmd.append("--dry-run")
+
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=max(1, args.timeout_seconds),
+                cwd=str(repo_root),
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            print(json.dumps(_build_summary(
+                "failed",
+                "Delegate execution timed out.",
+                runtime_summary={
+                    **preflight,
+                    "delegate_command": cmd,
+                    "timeout_seconds": args.timeout_seconds,
+                    "stdout_excerpt": (exc.stdout or "")[:4000],
+                    "stderr_excerpt": (exc.stderr or "")[:4000],
+                },
+                limitations=["Delegate subprocess exceeded the configured timeout."],
+                next_steps=["Inspect the input PDFs and delegate runtime dependencies.", "Retry with a larger --timeout-seconds value if appropriate."],
+            ), ensure_ascii=False, indent=2))
+            return 2
+
+        report, report_source = _load_report(report_path, proc.stdout)
+        delegate_status = report.get("status") if isinstance(report, dict) else None
+        total_files = _as_int(report.get("total_files"), 0) if isinstance(report, dict) else 0
+        delegate_dry_run = bool(report.get("dry_run")) if isinstance(report, dict) else args.dry_run
+        counter = _status_counter(report)
+        excel_written = bool(report.get("excel_written")) if isinstance(report, dict) else False
+        output_exists = bool(report.get("output_exists")) if isinstance(report, dict) else output_xlsx.exists()
+        output_size_bytes = _as_int(report.get("output_size_bytes"), 0) if isinstance(report, dict) else (output_xlsx.stat().st_size if output_xlsx.exists() else 0)
+        ocr_runtime_status = report.get("ocr_runtime_status") if isinstance(report, dict) else None
+
+        runtime_summary = {
+            **preflight,
+            "delegate_command": cmd,
+            "delegate_exit_code": proc.returncode,
+            "delegate_report_source": report_source,
+            "delegate_status": delegate_status,
+            "delegate_total_files": total_files,
+            "delegate_dry_run": delegate_dry_run,
+            "delegate_status_counter": counter,
+            "excel_written": excel_written,
+            "output_exists": output_exists,
+            "output_size_bytes": output_size_bytes,
+            "ocr_runtime_status": ocr_runtime_status,
+            "stdout_excerpt": (proc.stdout or "")[:4000],
+            "stderr_excerpt": (proc.stderr or "")[:4000],
+        }
+
+        success_gates = all([
+            delegate_status == "success",
+            total_files >= 1,
+            delegate_dry_run is False,
+            counter.get("failed", 0) == 0,
+            counter.get("partial", 0) == 0,
+            excel_written is True,
+            output_exists is True,
+            output_size_bytes > 0,
+        ])
+
+        if args.ocr in {"auto", "on"} and ocr_runtime_status in {"blocked", "partial"}:
+            print(json.dumps(_build_summary(
+                "partial",
+                "Delegate reported limited OCR sufficiency; not claiming success.",
+                runtime_summary=runtime_summary,
+                limitations=["OCR runtime status was reported as blocked/partial."],
+                next_steps=["Review OCR/runtime dependencies and inspect the generated evidence before rerunning."],
+                delegate_report=report,
+            ), ensure_ascii=False, indent=2))
+            return 0
+
+        if success_gates:
+            print(json.dumps(_build_summary(
+                "success",
+                "Reviewed delegate reported a strong success outcome and attested a real XLSX output.",
+                runtime_summary=runtime_summary,
+                delegate_report=report,
+            ), ensure_ascii=False, indent=2))
+            return 0
+
+        if delegate_status == "partial":
+            limitations = []
+            if delegate_dry_run:
+                limitations.append("Dry-run was requested; no final XLSX success claim is appropriate.")
+            if total_files == 0:
+                limitations.append("No PDF inputs were discovered or processed.")
+            if counter.get("partial", 0) > 0 or counter.get("failed", 0) > 0:
+                limitations.append("Delegate reported partial/failed file-level outcomes.")
+            if args.ocr in {"auto", "on"} and ocr_runtime_status:
+                limitations.append(f"OCR runtime status: {ocr_runtime_status}.")
+            if not limitations:
+                limitations.append("Delegate provided a reviewable partial outcome.")
+            print(json.dumps(_build_summary(
+                "partial",
+                "Best-effort delegate outcome remained partial; preserving that status with explicit limitations.",
+                runtime_summary=runtime_summary,
+                limitations=limitations,
+                next_steps=[
+                    "Inspect the delegate report and stdout/stderr excerpts.",
+                    "Verify PDF inputs and OCR/runtime dependencies.",
+                    "Rerun without --dry-run once the environment is ready for a real workbook write."
+                ],
+                delegate_report=report,
+            ), ensure_ascii=False, indent=2))
+            return 0
+
+        if args.dry_run or len(discovered_pdfs) == 0:
+            limitations = []
+            if args.dry_run:
+                limitations.append("Dry-run requests are reviewable-only and do not justify success.")
+            if len(discovered_pdfs) == 0:
+                limitations.append("Zero PDFs discovered during wrapper preflight.")
+            if report is None:
+                limitations.append("Delegate did not provide canonical structured evidence.")
+            print(json.dumps(_build_summary(
+                "partial",
+                "Reviewable partial outcome due to dry-run and/or zero-PDF discovery.",
+                runtime_summary=runtime_summary,
+                limitations=limitations,
+                next_steps=[
+                    "Add or verify input PDFs under the provided input directory.",
+                    "Run again without --dry-run when ready to produce a workbook."
+                ],
+                delegate_report=report,
+            ), ensure_ascii=False, indent=2))
+            return 0
+
+        print(json.dumps(_build_summary(
+            "failed",
+            "Delegate did not provide strong enough evidence for success, and no contract-compliant partial outcome was established.",
+            runtime_summary=runtime_summary,
+            limitations=[
+                "Wrapper does not treat exit code plus output-file existence alone as sufficient success evidence.",
+                "Required delegate evidence gates were not all satisfied."
+            ],
+            next_steps=[
+                "Inspect the delegate JSON report for missing attestation fields.",
+                "Confirm the reviewed delegate supports --report-json and emits canonical status/total_files/status_counter/dry_run fields."
+            ],
+            delegate_report=report,
+        ), ensure_ascii=False, indent=2))
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/runtime_archives/bl063/runtime/automation-runtime.attempt-1.log
+++ b/runtime_archives/bl063/runtime/automation-runtime.attempt-1.log
@@ -1,0 +1,19 @@
+task_id: AUTO-20260325-872
+worker: automation
+attempt: 1
+container_name: argus-automation-auto-20260325-872
+worker_image: argus-worker:latest
+started_at: 2026-03-25T10:06:04.678243Z
+finished_at: 2026-03-25T10:07:24.214117Z
+exit_code: 0
+timed_out: False
+wait_error: 
+
+=== stdout ===
+[2026-03-25T10:06:04.920194Z] [automation] [INFO] Worker started using endpoint https://fast.vpsairobot.com/v1/chat/completions (timeout=120s, attempts=3, timeout_recovery_retries=1)
+[2026-03-25T10:07:24.051038Z] [automation] [INFO] Artifact written: artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
+[2026-03-25T10:07:24.052202Z] [automation] [INFO] Task completed AUTO-20260325-872 with status success
+[2026-03-25T10:07:24.052887Z] [automation] [INFO] Worker exiting from /app/workspaces/automation/AUTO-20260325-872
+
+=== stderr ===
+

--- a/runtime_archives/bl063/runtime/critic-output.json
+++ b/runtime_archives/bl063/runtime/critic-output.json
@@ -1,0 +1,29 @@
+{
+  "task_id": "CRITIC-20260325-288",
+  "worker": "critic",
+  "status": "success",
+  "summary": "Reviewed the inbox runner and paired delegate together as an end-to-end readonly smoke path. Generated the required markdown review artifact with an explicit verdict. Verdict: needs_revision.",
+  "artifacts": [
+    {
+      "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+      "type": "review"
+    }
+  ],
+  "timestamp": "2026-03-25T10:08:08.645116Z",
+  "duration_ms": 44181,
+  "notes": [
+    "Review is grounded in the provided artifact snapshots for both scripts.",
+    "Assessment covers wrapper/delegate interaction, readonly contract handling, evidence gating, and result semantics."
+  ],
+  "metadata": {
+    "verdict": "needs_revision",
+    "task_id": "CRITIC-20260325-288",
+    "worker": "critic",
+    "review_scope": [
+      "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+      "artifacts/scripts/pdf_to_excel_ocr.py"
+    ],
+    "primary_artifact": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+    "paired_artifact": "artifacts/scripts/pdf_to_excel_ocr.py"
+  }
+}

--- a/runtime_archives/bl063/runtime/critic-produced-pdf_to_excel_ocr_inbox_review.md
+++ b/runtime_archives/bl063/runtime/critic-produced-pdf_to_excel_ocr_inbox_review.md
@@ -1,0 +1,69 @@
+# Review: pdf_to_excel_ocr_inbox_runner.py
+
+## Scope
+
+Reviewed the generated inbox runner (`artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`) together with its paired reviewed delegate (`artifacts/scripts/pdf_to_excel_ocr.py`) as one end-to-end readonly local inbox smoke path.
+
+The review focused on:
+- readonly Trello/local inbox semantics
+- wrapper-to-delegate contract compatibility
+- evidence-backed success/partial/failure handling
+- OCR claim discipline
+- whether the pair supports a reviewable best-effort smoke without overstating success
+
+## Findings
+
+1. **Good: wrapper preserves readonly external semantics**
+   - The runner embeds request metadata and explicitly states no external/Trello writeback.
+   - It limits activity to local discovery and local file output, matching the stated smoke scope.
+   - It refuses to substitute a missing delegate with arbitrary behavior, which is appropriate for controlled reviewable execution.
+
+2. **Good: delegate is structured for best-effort evidence-backed execution**
+   - The delegate emits structured JSON with `status`, `total_files`, `status_counter`, `dry_run`, OCR runtime state, notes, and next steps.
+   - It avoids claiming OCR success when OCR dependencies are missing; instead it reports `ocr_runtime_status` and missing dependencies.
+   - Batch isolation is present: one file failure does not halt all processing.
+
+3. **Good: wrapper correctly avoids overstating success**
+   - The runner requires multiple gates before returning success, including delegate status, non-dry-run, nonzero files, zero partial/failed counts, and a real XLSX output.
+   - It downgrades OCR-limited situations to partial rather than success.
+   - This aligns well with the request’s instruction not to claim OCR/conversion success without evidence.
+
+4. **Issue: wrapper can misclassify some legitimate delegate outcomes as `failed`**
+   - The delegate sets aggregate status to `partial` whenever any file is `partial` or `failed`, even if an Excel file is still successfully written.
+   - The wrapper only has an explicit partial-preservation branch for `delegate_status == "partial"`, plus a separate dry-run/zero-PDF branch.
+   - But when the delegate returns `failed` specifically because the Excel write step failed after otherwise reviewable extraction, the wrapper falls through to wrapper-level `failed`.
+   - That is defensible for workbook production, but it compresses a potentially useful reviewable intermediate state into failure without distinguishing extraction evidence from export failure.
+
+5. **Issue: wrapper/output path policy is only partially readonly-safe**
+   - The wrapper states local filesystem writes are possible and defaults output under `artifacts/outputs/...`, which is fine for local smoke.
+   - However, `_expand_path` resolves the input path against the host environment and `--output-xlsx` may be absolute, so the pair permits arbitrary local write destinations if called with an absolute path.
+   - This does not violate the stated no-external-writeback contract, but it is broader than a tightly sandboxed “declared local artifacts only” interpretation.
+
+6. **Issue: delegate success semantics are extraction-centric, wrapper success semantics are workbook-centric**
+   - Delegate aggregate `success` means no per-file partial/failed results, not necessarily that Excel was written yet.
+   - The wrapper compensates by additionally checking `excel_written`, `output_exists`, and size > 0.
+   - This works, but the contract between the two scripts is implicit rather than unified. A future change in delegate report fields could break wrapper interpretation.
+
+7. **Issue: actual smoke evidence is not present in the reviewed material**
+   - The scripts are reviewable and plausibly implement the desired path, but no execution report, sample stdout, sidecar JSON, discovered PDF list from a run, or generated XLSX artifact was supplied.
+   - Therefore this review can validate implementation logic only, not an actual successful end-to-end smoke outcome.
+
+## Verdict
+
+**needs_revision**
+
+## Rationale
+
+The pair is generally well aligned with the best-effort, evidence-backed, readonly smoke contract. In particular, it shows disciplined handling of OCR uncertainty and avoids claiming success without structured evidence.
+
+However, this is not a clean pass because:
+- the wrapper/delegate contract is not fully normalized and relies on wrapper-side interpretation of delegate fields;
+- absolute output paths allow broader local writes than a stricter declared-artifacts-only policy would suggest;
+- some reviewable intermediate outcomes are collapsed into wrapper-level failure instead of being more explicitly preserved;
+- no actual run evidence was supplied, so end-to-end smoke behavior cannot be fully verified beyond static review.
+
+Recommended revisions:
+1. Tighten output path policy so writes are restricted to an approved artifact subtree unless explicitly overridden by a governed flag.
+2. Normalize the delegate report contract so workbook-write outcome is a first-class aggregate status dimension, not inferred by the wrapper.
+3. Preserve extraction-vs-export distinction more clearly in wrapper summaries when Excel writing fails after partial extraction evidence exists.
+4. Add an example execution artifact (JSON report and/or sample XLSX metadata) to support a stronger end-to-end review in future runs.

--- a/runtime_archives/bl063/runtime/critic-runtime.attempt-1.log
+++ b/runtime_archives/bl063/runtime/critic-runtime.attempt-1.log
@@ -1,0 +1,19 @@
+task_id: CRITIC-20260325-288
+worker: critic
+attempt: 1
+container_name: argus-critic-critic-20260325-288
+worker_image: argus-worker:latest
+started_at: 2026-03-25T10:07:24.255269Z
+finished_at: 2026-03-25T10:08:08.776609Z
+exit_code: 0
+timed_out: False
+wait_error: 
+
+=== stdout ===
+[2026-03-25T10:07:24.465185Z] [critic] [INFO] Worker started using endpoint https://fast.vpsairobot.com/v1/chat/completions (timeout=120s, attempts=3, timeout_recovery_retries=1)
+[2026-03-25T10:08:08.644711Z] [critic] [INFO] Artifact written: artifacts/reviews/pdf_to_excel_ocr_inbox_review.md
+[2026-03-25T10:08:08.645495Z] [critic] [INFO] Task completed CRITIC-20260325-288 with status success
+[2026-03-25T10:08:08.646413Z] [critic] [INFO] Worker exiting from /app/workspaces/critic/CRITIC-20260325-288
+
+=== stderr ===
+

--- a/runtime_archives/bl063/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609.json
+++ b/runtime_archives/bl063/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609.json
@@ -1,0 +1,404 @@
+{
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609",
+  "created_at": "2026-03-25T10:04:56.058095Z",
+  "approved": true,
+  "source": {
+    "kind": "local_inbox",
+    "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+    "received_at": "2026-03-25T10:04:56.056950Z",
+    "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl063-001.json",
+    "regeneration_token": "regen-20260325-bl063-001"
+  },
+  "external_input": {
+    "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+    "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+    "labels": [
+      "best_effort",
+      "evidence_backed",
+      "readonly",
+      "reviewable",
+      "trello"
+    ],
+    "metadata": {
+      "source_system": "trello",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "card_short_id": 7,
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "date_last_activity": "2026-03-24T08:35:56.234Z",
+      "readonly_mapped_at": "2026-03-25T10:04:35.724632Z",
+      "contract_profile": "best_effort_evidence_backed",
+      "ocr_claim_policy": "do_not_claim_success_without_evidence",
+      "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+      "regeneration_token": "regen-20260325-bl063-001"
+    },
+    "request_type": "pdf_to_excel_ocr",
+    "input": {
+      "input_dir": "~/Desktop/pdf样本",
+      "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+      "ocr": "auto",
+      "dry_run": false
+    }
+  },
+  "task_summary": {
+    "automation": {
+      "task_id": "AUTO-20260325-872",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+      "expected_outputs": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ]
+    },
+    "critic": {
+      "task_id": "CRITIC-20260325-288",
+      "worker": "critic",
+      "task_type": "review_artifact",
+      "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+      "expected_outputs": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ]
+    }
+  },
+  "internal_tasks": {
+    "automation": {
+      "task_id": "AUTO-20260325-872",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+      "inputs": {
+        "params": {
+          "input_dir": "~/Desktop/pdf样本",
+          "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+          "ocr": "auto",
+          "dry_run": false,
+          "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+          "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+          "description": "Purpose: | Controlled Trello live preview smoke for openclaw-team. | Expected behavior: | - read-only Trello ingest | - preview creation smoke only | - no business execution claim | - no Trello writeback expected in this step | Traceability: | - backlog: BL-20260324-014 | - blocker context: BL-20260324-015 | - created_by: Oscarling | - created_at: 2026-03-24 Asia/Shanghai | Note: | This card is only for governed smoke verification and should remain open until the smoke is finished.",
+          "labels": [
+            "best_effort",
+            "evidence_backed",
+            "readonly",
+            "reviewable",
+            "trello"
+          ],
+          "preferred_wrapper_script": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "preferred_base_script": "artifacts/scripts/pdf_to_excel_ocr.py",
+          "reference_docs": [
+            "artifacts/docs/pdf_to_excel_ocr_usage.md",
+            "artifacts/reviews/pdf_to_excel_ocr_review.md"
+          ],
+          "contract_hints": {
+            "output_format_fidelity": "If output_xlsx ends with .xlsx, produce a real XLSX workbook container or fail honestly before writing mismatched text/XML/CSV content to a .xlsx path.",
+            "path_portability": "Use the provided input_dir parameter as runtime input. Do not hardcode a user-home or absolute input path when params already declare the path.",
+            "traceability": "Preserve meaningful description context from the external input; do not collapse it to a heading fragment such as Purpose:.",
+            "reuse_preference": "Prefer reusing artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py as the wrapper baseline and artifacts/scripts/pdf_to_excel_ocr.py as the reviewed delegate when compatible, so workbook semantics and contract behavior stay aligned with repository evidence.",
+            "outcome_status_model": "Use the reviewable status model success/partial/failed. Dry-run requests or zero-PDF discovery should resolve to partial rather than claiming success without an output artifact.",
+            "delegate_resolution": "If preferred_base_script is relative, resolve it from the repository or script location instead of Path.cwd() so behavior stays portable across shells and CI.",
+            "reviewed_delegate_contract": "For readonly reviewable preview flows, delegate only to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py or fail honestly instead of broadening behavior through an arbitrary helper.",
+            "delegate_success_evidence": "Do not treat zero exit code plus output-file existence as sufficient wrapper success evidence on their own. Prefer a structured delegate report that confirms a real success outcome before the wrapper claims success. Require delegate status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, and explicit output attestation fields excel_written=true, output_exists=true, and output_size_bytes>0. Apply these gates only when wrapper status is success.",
+            "delegate_partial_evidence": "For best-effort readonly flows, if delegate status is partial and structured evidence is present, keep wrapper status partial instead of escalating to failed solely because success-only gates are unmet. Surface explicit limitations and next-step guidance in wrapper output.",
+            "delegate_timeout": "Bound delegate subprocess execution with an explicit timeout and report timeout as an honest failed/partial outcome instead of allowing smoke automation to hang indefinitely.",
+            "readonly_semantics": "Readonly semantics must be explicit: no external/Trello writeback is required, but local filesystem output writes may still occur when dry_run=false. Runtime summary fields must not overstate readonly scope.",
+            "ocr_sufficiency": "When OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial, do not claim wrapper success even if an output file exists; keep partial status with explicit OCR sufficiency notes.",
+            "runtime_summary": "The generated script should emit a structured summary of what it produced so later review can inspect behavior without guessing.",
+            "delegate_report_schema": "Treat delegate JSON report fields status/total_files/status_counter/dry_run as the canonical evidence contract. Do not require undeclared processed_files/succeeded_files/failed_files counters.",
+            "delegate_report_handoff": "When a sidecar report file is available, treat it as canonical evidence. Use stdout JSON parsing only as fallback when sidecar evidence is missing.",
+            "delegate_report_flag_contract": "If wrapper passes a sidecar report path to the reviewed delegate, use the reviewed delegate CLI flag --report-json (or another explicitly supported alias). Do not invent undeclared flags such as --report-file.",
+            "dry_run_semantics": "For readonly governed flows, do not short-circuit dry-run before delegate execution. Delegate under dry-run and pass through --dry-run explicitly so wrapper/delegate semantics remain aligned.",
+            "pdf_discovery_consistency": "Keep wrapper preflight PDF discovery semantics aligned with the reviewed delegate (for example recursive vs non-recursive), so wrapper evidence and delegated execution count the same candidate set."
+          }
+        }
+      },
+      "expected_outputs": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ],
+      "constraints": [
+        "Follow the local inbox normalized request",
+        "Do not claim unsupported runtime dependencies",
+        "Keep output deterministic and executable",
+        "Produce only the expected script artifact",
+        "Prefer honest, reviewable intermediate behavior over unsupported OCR claims",
+        "If the requested output path ends with .xlsx, do not write non-XLSX text/XML/CSV content to that path.",
+        "Do not hardcode an input directory when the task params already provide input_dir.",
+        "Preserve meaningful traceability from the incoming description instead of collapsing it to a heading fragment.",
+        "Prefer wrapping or adapting artifacts/scripts/pdf_to_excel_ocr.py when that existing repo script already matches the requested behavior.",
+        "When artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py already exists, prefer updating that reviewed wrapper baseline instead of rewriting a new control flow from scratch.",
+        "If dry_run is true or no PDFs are discovered, report a reviewable partial outcome instead of claiming success without an XLSX artifact.",
+        "Resolve relative delegate script paths from the repository or script location, not from Path.cwd().",
+        "For readonly reviewable preview flows, only delegate to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py unless failing honestly.",
+        "Do not claim wrapper success from exit code plus output existence alone when the reviewed delegate report does not provide strong enough success evidence.",
+        "When wrapper reports success, enforce delegate evidence gates: status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, excel_written=true, output_exists=true, and output_size_bytes>0.",
+        "If delegate reports partial with structured evidence in readonly best-effort mode, keep wrapper status partial (not failed) and include explicit limitations with next-step guidance.",
+        "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
+        "When a delegate sidecar report is present, treat sidecar JSON as canonical evidence and use stdout JSON only as fallback.",
+        "When wrapper passes a sidecar report path to the reviewed delegate, use --report-json exactly unless the reviewed delegate explicitly supports another alias.",
+        "For readonly governed flows, do not short-circuit dry-run before delegate execution; pass --dry-run through delegate and preserve partial status honestly.",
+        "Keep wrapper PDF discovery semantics aligned with reviewed delegate discovery semantics to avoid preflight/execution evidence drift.",
+        "Readonly semantics must be explicit as no external writeback; avoid claiming strict filesystem readonly when dry_run=false can write local outputs.",
+        "When OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial, keep wrapper status partial and surface OCR sufficiency limitations.",
+        "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely."
+      ],
+      "priority": "medium",
+      "source": {
+        "kind": "local_inbox",
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl063-001.json",
+        "received_at": "2026-03-25T10:04:56.056950Z",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "regeneration_token": "regen-20260325-bl063-001"
+      },
+      "acceptance_criteria": [
+        "Produce the expected script artifact at expected_outputs[0].path",
+        "Script behavior remains runnable, deterministic, and reviewable",
+        "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
+        "Artifact behavior remains parameter-driven for input_dir and output_xlsx rather than hardcoding unrelated local defaults.",
+        "Dry-run or zero-input behavior is represented as a reviewable partial outcome instead of artifact-production success.",
+        "Relative preferred_base_script resolution remains portable and does not depend on Path.cwd().",
+        "Wrapper success requires stronger delegate evidence than zero exit code plus a non-empty output file alone.",
+        "Wrapper success attestation requires delegate fields excel_written=true, output_exists=true, output_size_bytes>0, and status_counter.partial/status_counter.failed equal to 0.",
+        "Contract-compliant delegate partial outcomes remain partial with explicit limitations and next-step guidance, rather than being escalated to failed by success-only gates.",
+        "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
+        "Delegate report handoff prefers sidecar JSON as canonical evidence and only falls back to stdout JSON when sidecar evidence is unavailable.",
+        "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",
+        "Dry-run semantics remain explicit and delegated for readonly governed flows: pass --dry-run through delegate and preserve partial outcome honestly.",
+        "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
+        "Readonly semantics are explicit as no external writeback, and runtime summary wording does not overclaim strict filesystem readonly when dry_run=false.",
+        "Wrapper success is conservative when OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial.",
+        "Delegate execution is bounded by an explicit timeout and reports timeout honestly."
+      ],
+      "metadata": {
+        "integration_phase": "8B",
+        "pipeline": "inbox->adapter->manager->automation->critic",
+        "request_type": "pdf_to_excel_ocr",
+        "payload_hash": "6b1d3f0946097f965d6d55116edb8bc665d0c5a5e9ff4524c569844262305772",
+        "regeneration_token": "regen-20260325-bl063-001",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "external_metadata": {
+          "source_system": "trello",
+          "card_id": "69c24cd3c1a2359ddd7a1bf8",
+          "card_short_id": 7,
+          "board_id": "69be462743bfa0038ca10f7a",
+          "list_id": "69be462743bfa0038ca10f8f",
+          "date_last_activity": "2026-03-24T08:35:56.234Z",
+          "readonly_mapped_at": "2026-03-25T10:04:35.724632Z",
+          "contract_profile": "best_effort_evidence_backed",
+          "ocr_claim_policy": "do_not_claim_success_without_evidence",
+          "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+          "regeneration_token": "regen-20260325-bl063-001"
+        },
+        "automation_contract_profile": "narrow_script_artifact_with_repo_reuse_and_reviewable_runner_contract"
+      }
+    },
+    "critic": {
+      "task_id": "CRITIC-20260325-288",
+      "worker": "critic",
+      "task_type": "review_artifact",
+      "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+      "inputs": {
+        "artifacts": [
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "type": "script"
+          },
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+            "type": "script"
+          }
+        ],
+        "params": {
+          "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+          "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+          "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+          "labels": [
+            "best_effort",
+            "evidence_backed",
+            "readonly",
+            "reviewable",
+            "trello"
+          ],
+          "review_scope": {
+            "primary_artifact": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "paired_artifacts": [
+              "artifacts/scripts/pdf_to_excel_ocr.py"
+            ],
+            "goal": "Audit the wrapper and the reviewed delegate together so the review evidence can speak to the end-to-end readonly smoke path."
+          }
+        }
+      },
+      "expected_outputs": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ],
+      "constraints": [
+        "Review must be grounded in produced automation artifact",
+        "When both wrapper and reviewed delegate snapshots are supplied, evaluate them as one end-to-end readonly pair instead of ignoring the delegate evidence.",
+        "Do not invent missing artifact content",
+        "Return a clear verdict: pass, fail, or needs_revision",
+        "Include metadata.verdict in output",
+        "Generate review artifact markdown for expected_outputs[0].path"
+      ],
+      "priority": "medium",
+      "source": {
+        "kind": "local_inbox",
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl063-001.json",
+        "received_at": "2026-03-25T10:04:56.056950Z",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "regeneration_token": "regen-20260325-bl063-001"
+      },
+      "acceptance_criteria": [
+        "Produce a review artifact with explicit verdict (pass/fail/needs_revision)"
+      ],
+      "metadata": {
+        "integration_phase": "8B",
+        "pipeline": "inbox->adapter->manager->automation->critic",
+        "request_type": "pdf_to_excel_ocr",
+        "payload_hash": "6b1d3f0946097f965d6d55116edb8bc665d0c5a5e9ff4524c569844262305772",
+        "regeneration_token": "regen-20260325-bl063-001",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "external_metadata": {
+          "source_system": "trello",
+          "card_id": "69c24cd3c1a2359ddd7a1bf8",
+          "card_short_id": 7,
+          "board_id": "69be462743bfa0038ca10f7a",
+          "list_id": "69be462743bfa0038ca10f8f",
+          "date_last_activity": "2026-03-24T08:35:56.234Z",
+          "readonly_mapped_at": "2026-03-25T10:04:35.724632Z",
+          "contract_profile": "best_effort_evidence_backed",
+          "ocr_claim_policy": "do_not_claim_success_without_evidence",
+          "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+          "regeneration_token": "regen-20260325-bl063-001"
+        }
+      }
+    }
+  },
+  "expected_artifacts": [
+    "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+    "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py"
+  ],
+  "dedupe_keys": [
+    "origin_regeneration:trello:69c24cd3c1a2359ddd7a1bf8:regen-20260325-bl063-001",
+    "hash:6b1d3f0946097f965d6d55116edb8bc665d0c5a5e9ff4524c569844262305772"
+  ],
+  "risk_warnings": [],
+  "execution": {
+    "status": "rejected",
+    "executed": true,
+    "attempts": 3,
+    "executed_at": "2026-03-25T10:08:08.812245Z",
+    "decision_reason": "critic_verdict=needs_revision"
+  },
+  "approval": {
+    "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609.json",
+    "approved_by": "Oscarling",
+    "approved_at": "2026-03-25T10:05:23Z",
+    "note": "BL-20260325-063 governed validation execute only; no Git finalization; no Trello Done."
+  },
+  "last_execution": {
+    "decision": "rejected",
+    "decision_reason": "critic_verdict=needs_revision",
+    "automation_result": {
+      "task_id": "AUTO-20260325-872",
+      "worker": "automation",
+      "status": "success",
+      "summary": "Generated exactly one runnable wrapper script artifact that reuses the reviewed pdf_to_excel_ocr.py delegate, prefers sidecar JSON evidence via --report-json, preserves parameter-driven input/output behavior, enforces conservative success gates, keeps dry-run/zero-PDF/OCR-blocked outcomes reviewable as partial, and bounds delegate execution with an explicit timeout.",
+      "artifacts": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ],
+      "timestamp": "2026-03-25T10:07:24.051613Z",
+      "duration_ms": 79131,
+      "notes": [
+        "Only the expected script artifact was produced.",
+        "The script is deterministic and repository-relative for delegate resolution, avoiding Path.cwd()-dependent behavior.",
+        "The wrapper is designed to be parameter-driven and to preserve meaningful traceability from the request description.",
+        "Readonly semantics are explicit as no external/Trello writeback; local filesystem writes may still occur when dry_run=false."
+      ],
+      "metadata": {
+        "task_id": "AUTO-20260325-872",
+        "worker": "automation",
+        "created_artifact_count": 1
+      }
+    },
+    "critic_result": {
+      "task_id": "CRITIC-20260325-288",
+      "worker": "critic",
+      "status": "success",
+      "summary": "Reviewed the inbox runner and paired delegate together as an end-to-end readonly smoke path. Generated the required markdown review artifact with an explicit verdict. Verdict: needs_revision.",
+      "artifacts": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ],
+      "timestamp": "2026-03-25T10:08:08.645116Z",
+      "duration_ms": 44181,
+      "notes": [
+        "Review is grounded in the provided artifact snapshots for both scripts.",
+        "Assessment covers wrapper/delegate interaction, readonly contract handling, evidence gating, and result semantics."
+      ],
+      "metadata": {
+        "verdict": "needs_revision",
+        "task_id": "CRITIC-20260325-288",
+        "worker": "critic",
+        "review_scope": [
+          "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "artifacts/scripts/pdf_to_excel_ocr.py"
+        ],
+        "primary_artifact": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "paired_artifact": "artifacts/scripts/pdf_to_excel_ocr.py"
+      }
+    },
+    "critic_verdict": "needs_revision"
+  }
+}

--- a/runtime_archives/bl063/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609.result.json
+++ b/runtime_archives/bl063/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609.result.json
@@ -1,0 +1,9 @@
+{
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609",
+  "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609.json",
+  "executed_at": "2026-03-25T10:08:08.813143Z",
+  "status": "rejected",
+  "decision_reason": "critic_verdict=needs_revision",
+  "critic_verdict": "needs_revision",
+  "test_mode": "off"
+}

--- a/runtime_archives/bl063/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl063-001.json
+++ b/runtime_archives/bl063/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl063-001.json
@@ -1,0 +1,41 @@
+{
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "metadata": {
+    "source_system": "trello",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "card_short_id": 7,
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "date_last_activity": "2026-03-24T08:35:56.234Z",
+    "readonly_mapped_at": "2026-03-25T10:04:35.724632Z",
+    "contract_profile": "best_effort_evidence_backed",
+    "ocr_claim_policy": "do_not_claim_success_without_evidence",
+    "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+    "regeneration_token": "regen-20260325-bl063-001"
+  },
+  "source": {
+    "provider": "trello",
+    "mode": "readonly",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "regeneration_token": "regen-20260325-bl063-001"
+  },
+  "request_type": "pdf_to_excel_ocr",
+  "input": {
+    "input_dir": "~/Desktop/pdf样本",
+    "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+    "ocr": "auto",
+    "dry_run": false
+  },
+  "regeneration_token": "regen-20260325-bl063-001"
+}

--- a/runtime_archives/bl063/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl063-001.json.result.json
+++ b/runtime_archives/bl063/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl063-001.json.result.json
@@ -1,0 +1,23 @@
+{
+  "ingested_at": "2026-03-25T10:04:56.058539Z",
+  "status": "processed",
+  "decision": "preview_created_pending_approval",
+  "decision_reason": "preview_created; waiting_for_explicit_approval",
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "payload_hash": "6b1d3f0946097f965d6d55116edb8bc665d0c5a5e9ff4524c569844262305772",
+  "dedupe_keys": [
+    "origin_regeneration:trello:69c24cd3c1a2359ddd7a1bf8:regen-20260325-bl063-001",
+    "hash:6b1d3f0946097f965d6d55116edb8bc665d0c5a5e9ff4524c569844262305772"
+  ],
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609",
+  "preview_file": "/Users/lingguozhong/openclaw-team/preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609.json",
+  "regeneration_token": "regen-20260325-bl063-001"
+}

--- a/runtime_archives/bl063/tmp/bl063_execute_once_elevated.json
+++ b/runtime_archives/bl063/tmp/bl063_execute_once_elevated.json
@@ -1,0 +1,20 @@
+/Users/lingguozhong/Library/Python/3.9/lib/python/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
+  warnings.warn(
+{
+  "status": "done",
+  "processed": 0,
+  "rejected": 1,
+  "skipped": 0,
+  "test_mode": "off",
+  "allow_replay": true,
+  "results": [
+    {
+      "status": "rejected",
+      "decision_reason": "critic_verdict=needs_revision",
+      "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609",
+      "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609.json",
+      "result_sidecar": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609.result.json",
+      "critic_verdict": "needs_revision"
+    }
+  ]
+}

--- a/runtime_archives/bl063/tmp/bl063_execute_once_sandbox.json
+++ b/runtime_archives/bl063/tmp/bl063_execute_once_sandbox.json
@@ -1,0 +1,20 @@
+/Users/lingguozhong/Library/Python/3.9/lib/python/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
+  warnings.warn(
+{
+  "status": "done",
+  "processed": 0,
+  "rejected": 1,
+  "skipped": 0,
+  "test_mode": "off",
+  "allow_replay": false,
+  "results": [
+    {
+      "status": "rejected",
+      "decision_reason": "Failed to initialize docker client from environment. Ensure Docker access is available or pass docker_client explicitly.",
+      "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609",
+      "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609.json",
+      "result_sidecar": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609.result.json",
+      "critic_verdict": "needs_revision"
+    }
+  ]
+}

--- a/runtime_archives/bl063/tmp/bl063_ingest_once.json
+++ b/runtime_archives/bl063/tmp/bl063_ingest_once.json
@@ -1,0 +1,23 @@
+/Users/lingguozhong/Library/Python/3.9/lib/python/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
+  warnings.warn(
+{
+  "status": "done",
+  "processed": 1,
+  "rejected": 0,
+  "duplicate_skipped": 0,
+  "preview_created": 1,
+  "inbox_claimed": 1,
+  "processing_recovered": 0,
+  "test_mode": "success",
+  "results": [
+    {
+      "status": "processed",
+      "decision": "preview_created_pending_approval",
+      "decision_reason": "preview_created; waiting_for_explicit_approval",
+      "file": "/Users/lingguozhong/openclaw-team/processed/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl063-001.json",
+      "result_sidecar": "/Users/lingguozhong/openclaw-team/processed/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl063-001.json.result.json",
+      "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609",
+      "preview_file": "/Users/lingguozhong/openclaw-team/preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609.json"
+    }
+  ]
+}

--- a/runtime_archives/bl063/tmp/bl063_live_mapped_preview.json
+++ b/runtime_archives/bl063/tmp/bl063_live_mapped_preview.json
@@ -1,0 +1,38 @@
+{
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "metadata": {
+    "source_system": "trello",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "card_short_id": 7,
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "date_last_activity": "2026-03-24T08:35:56.234Z",
+    "readonly_mapped_at": "2026-03-25T10:04:35.724632Z",
+    "contract_profile": "best_effort_evidence_backed",
+    "ocr_claim_policy": "do_not_claim_success_without_evidence",
+    "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable"
+  },
+  "source": {
+    "provider": "trello",
+    "mode": "readonly",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f"
+  },
+  "request_type": "pdf_to_excel_ocr",
+  "input": {
+    "input_dir": "~/Desktop/pdf样本",
+    "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+    "ocr": "auto",
+    "dry_run": false
+  }
+}

--- a/runtime_archives/bl063/tmp/bl063_preview_state_pre_execute.json
+++ b/runtime_archives/bl063/tmp/bl063_preview_state_pre_execute.json
@@ -1,0 +1,337 @@
+{
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-6b1d3f094609",
+  "created_at": "2026-03-25T10:04:56.058095Z",
+  "approved": false,
+  "source": {
+    "kind": "local_inbox",
+    "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+    "received_at": "2026-03-25T10:04:56.056950Z",
+    "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl063-001.json",
+    "regeneration_token": "regen-20260325-bl063-001"
+  },
+  "external_input": {
+    "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+    "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+    "labels": [
+      "best_effort",
+      "evidence_backed",
+      "readonly",
+      "reviewable",
+      "trello"
+    ],
+    "metadata": {
+      "source_system": "trello",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "card_short_id": 7,
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "date_last_activity": "2026-03-24T08:35:56.234Z",
+      "readonly_mapped_at": "2026-03-25T10:04:35.724632Z",
+      "contract_profile": "best_effort_evidence_backed",
+      "ocr_claim_policy": "do_not_claim_success_without_evidence",
+      "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+      "regeneration_token": "regen-20260325-bl063-001"
+    },
+    "request_type": "pdf_to_excel_ocr",
+    "input": {
+      "input_dir": "~/Desktop/pdf样本",
+      "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+      "ocr": "auto",
+      "dry_run": false
+    }
+  },
+  "task_summary": {
+    "automation": {
+      "task_id": "AUTO-20260325-872",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+      "expected_outputs": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ]
+    },
+    "critic": {
+      "task_id": "CRITIC-20260325-288",
+      "worker": "critic",
+      "task_type": "review_artifact",
+      "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+      "expected_outputs": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ]
+    }
+  },
+  "internal_tasks": {
+    "automation": {
+      "task_id": "AUTO-20260325-872",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+      "inputs": {
+        "params": {
+          "input_dir": "~/Desktop/pdf样本",
+          "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+          "ocr": "auto",
+          "dry_run": false,
+          "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+          "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+          "description": "Purpose: | Controlled Trello live preview smoke for openclaw-team. | Expected behavior: | - read-only Trello ingest | - preview creation smoke only | - no business execution claim | - no Trello writeback expected in this step | Traceability: | - backlog: BL-20260324-014 | - blocker context: BL-20260324-015 | - created_by: Oscarling | - created_at: 2026-03-24 Asia/Shanghai | Note: | This card is only for governed smoke verification and should remain open until the smoke is finished.",
+          "labels": [
+            "best_effort",
+            "evidence_backed",
+            "readonly",
+            "reviewable",
+            "trello"
+          ],
+          "preferred_wrapper_script": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "preferred_base_script": "artifacts/scripts/pdf_to_excel_ocr.py",
+          "reference_docs": [
+            "artifacts/docs/pdf_to_excel_ocr_usage.md",
+            "artifacts/reviews/pdf_to_excel_ocr_review.md"
+          ],
+          "contract_hints": {
+            "output_format_fidelity": "If output_xlsx ends with .xlsx, produce a real XLSX workbook container or fail honestly before writing mismatched text/XML/CSV content to a .xlsx path.",
+            "path_portability": "Use the provided input_dir parameter as runtime input. Do not hardcode a user-home or absolute input path when params already declare the path.",
+            "traceability": "Preserve meaningful description context from the external input; do not collapse it to a heading fragment such as Purpose:.",
+            "reuse_preference": "Prefer reusing artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py as the wrapper baseline and artifacts/scripts/pdf_to_excel_ocr.py as the reviewed delegate when compatible, so workbook semantics and contract behavior stay aligned with repository evidence.",
+            "outcome_status_model": "Use the reviewable status model success/partial/failed. Dry-run requests or zero-PDF discovery should resolve to partial rather than claiming success without an output artifact.",
+            "delegate_resolution": "If preferred_base_script is relative, resolve it from the repository or script location instead of Path.cwd() so behavior stays portable across shells and CI.",
+            "reviewed_delegate_contract": "For readonly reviewable preview flows, delegate only to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py or fail honestly instead of broadening behavior through an arbitrary helper.",
+            "delegate_success_evidence": "Do not treat zero exit code plus output-file existence as sufficient wrapper success evidence on their own. Prefer a structured delegate report that confirms a real success outcome before the wrapper claims success. Require delegate status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, and explicit output attestation fields excel_written=true, output_exists=true, and output_size_bytes>0. Apply these gates only when wrapper status is success.",
+            "delegate_partial_evidence": "For best-effort readonly flows, if delegate status is partial and structured evidence is present, keep wrapper status partial instead of escalating to failed solely because success-only gates are unmet. Surface explicit limitations and next-step guidance in wrapper output.",
+            "delegate_timeout": "Bound delegate subprocess execution with an explicit timeout and report timeout as an honest failed/partial outcome instead of allowing smoke automation to hang indefinitely.",
+            "readonly_semantics": "Readonly semantics must be explicit: no external/Trello writeback is required, but local filesystem output writes may still occur when dry_run=false. Runtime summary fields must not overstate readonly scope.",
+            "ocr_sufficiency": "When OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial, do not claim wrapper success even if an output file exists; keep partial status with explicit OCR sufficiency notes.",
+            "runtime_summary": "The generated script should emit a structured summary of what it produced so later review can inspect behavior without guessing.",
+            "delegate_report_schema": "Treat delegate JSON report fields status/total_files/status_counter/dry_run as the canonical evidence contract. Do not require undeclared processed_files/succeeded_files/failed_files counters.",
+            "delegate_report_handoff": "When a sidecar report file is available, treat it as canonical evidence. Use stdout JSON parsing only as fallback when sidecar evidence is missing.",
+            "delegate_report_flag_contract": "If wrapper passes a sidecar report path to the reviewed delegate, use the reviewed delegate CLI flag --report-json (or another explicitly supported alias). Do not invent undeclared flags such as --report-file.",
+            "dry_run_semantics": "For readonly governed flows, do not short-circuit dry-run before delegate execution. Delegate under dry-run and pass through --dry-run explicitly so wrapper/delegate semantics remain aligned.",
+            "pdf_discovery_consistency": "Keep wrapper preflight PDF discovery semantics aligned with the reviewed delegate (for example recursive vs non-recursive), so wrapper evidence and delegated execution count the same candidate set."
+          }
+        }
+      },
+      "expected_outputs": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ],
+      "constraints": [
+        "Follow the local inbox normalized request",
+        "Do not claim unsupported runtime dependencies",
+        "Keep output deterministic and executable",
+        "Produce only the expected script artifact",
+        "Prefer honest, reviewable intermediate behavior over unsupported OCR claims",
+        "If the requested output path ends with .xlsx, do not write non-XLSX text/XML/CSV content to that path.",
+        "Do not hardcode an input directory when the task params already provide input_dir.",
+        "Preserve meaningful traceability from the incoming description instead of collapsing it to a heading fragment.",
+        "Prefer wrapping or adapting artifacts/scripts/pdf_to_excel_ocr.py when that existing repo script already matches the requested behavior.",
+        "When artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py already exists, prefer updating that reviewed wrapper baseline instead of rewriting a new control flow from scratch.",
+        "If dry_run is true or no PDFs are discovered, report a reviewable partial outcome instead of claiming success without an XLSX artifact.",
+        "Resolve relative delegate script paths from the repository or script location, not from Path.cwd().",
+        "For readonly reviewable preview flows, only delegate to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py unless failing honestly.",
+        "Do not claim wrapper success from exit code plus output existence alone when the reviewed delegate report does not provide strong enough success evidence.",
+        "When wrapper reports success, enforce delegate evidence gates: status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, excel_written=true, output_exists=true, and output_size_bytes>0.",
+        "If delegate reports partial with structured evidence in readonly best-effort mode, keep wrapper status partial (not failed) and include explicit limitations with next-step guidance.",
+        "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
+        "When a delegate sidecar report is present, treat sidecar JSON as canonical evidence and use stdout JSON only as fallback.",
+        "When wrapper passes a sidecar report path to the reviewed delegate, use --report-json exactly unless the reviewed delegate explicitly supports another alias.",
+        "For readonly governed flows, do not short-circuit dry-run before delegate execution; pass --dry-run through delegate and preserve partial status honestly.",
+        "Keep wrapper PDF discovery semantics aligned with reviewed delegate discovery semantics to avoid preflight/execution evidence drift.",
+        "Readonly semantics must be explicit as no external writeback; avoid claiming strict filesystem readonly when dry_run=false can write local outputs.",
+        "When OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial, keep wrapper status partial and surface OCR sufficiency limitations.",
+        "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely."
+      ],
+      "priority": "medium",
+      "source": {
+        "kind": "local_inbox",
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl063-001.json",
+        "received_at": "2026-03-25T10:04:56.056950Z",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "regeneration_token": "regen-20260325-bl063-001"
+      },
+      "acceptance_criteria": [
+        "Produce the expected script artifact at expected_outputs[0].path",
+        "Script behavior remains runnable, deterministic, and reviewable",
+        "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
+        "Artifact behavior remains parameter-driven for input_dir and output_xlsx rather than hardcoding unrelated local defaults.",
+        "Dry-run or zero-input behavior is represented as a reviewable partial outcome instead of artifact-production success.",
+        "Relative preferred_base_script resolution remains portable and does not depend on Path.cwd().",
+        "Wrapper success requires stronger delegate evidence than zero exit code plus a non-empty output file alone.",
+        "Wrapper success attestation requires delegate fields excel_written=true, output_exists=true, output_size_bytes>0, and status_counter.partial/status_counter.failed equal to 0.",
+        "Contract-compliant delegate partial outcomes remain partial with explicit limitations and next-step guidance, rather than being escalated to failed by success-only gates.",
+        "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
+        "Delegate report handoff prefers sidecar JSON as canonical evidence and only falls back to stdout JSON when sidecar evidence is unavailable.",
+        "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",
+        "Dry-run semantics remain explicit and delegated for readonly governed flows: pass --dry-run through delegate and preserve partial outcome honestly.",
+        "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
+        "Readonly semantics are explicit as no external writeback, and runtime summary wording does not overclaim strict filesystem readonly when dry_run=false.",
+        "Wrapper success is conservative when OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial.",
+        "Delegate execution is bounded by an explicit timeout and reports timeout honestly."
+      ],
+      "metadata": {
+        "integration_phase": "8B",
+        "pipeline": "inbox->adapter->manager->automation->critic",
+        "request_type": "pdf_to_excel_ocr",
+        "payload_hash": "6b1d3f0946097f965d6d55116edb8bc665d0c5a5e9ff4524c569844262305772",
+        "regeneration_token": "regen-20260325-bl063-001",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "external_metadata": {
+          "source_system": "trello",
+          "card_id": "69c24cd3c1a2359ddd7a1bf8",
+          "card_short_id": 7,
+          "board_id": "69be462743bfa0038ca10f7a",
+          "list_id": "69be462743bfa0038ca10f8f",
+          "date_last_activity": "2026-03-24T08:35:56.234Z",
+          "readonly_mapped_at": "2026-03-25T10:04:35.724632Z",
+          "contract_profile": "best_effort_evidence_backed",
+          "ocr_claim_policy": "do_not_claim_success_without_evidence",
+          "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+          "regeneration_token": "regen-20260325-bl063-001"
+        },
+        "automation_contract_profile": "narrow_script_artifact_with_repo_reuse_and_reviewable_runner_contract"
+      }
+    },
+    "critic": {
+      "task_id": "CRITIC-20260325-288",
+      "worker": "critic",
+      "task_type": "review_artifact",
+      "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+      "inputs": {
+        "artifacts": [
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "type": "script"
+          },
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+            "type": "script"
+          }
+        ],
+        "params": {
+          "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+          "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+          "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+          "labels": [
+            "best_effort",
+            "evidence_backed",
+            "readonly",
+            "reviewable",
+            "trello"
+          ],
+          "review_scope": {
+            "primary_artifact": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "paired_artifacts": [
+              "artifacts/scripts/pdf_to_excel_ocr.py"
+            ],
+            "goal": "Audit the wrapper and the reviewed delegate together so the review evidence can speak to the end-to-end readonly smoke path."
+          }
+        }
+      },
+      "expected_outputs": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ],
+      "constraints": [
+        "Review must be grounded in produced automation artifact",
+        "When both wrapper and reviewed delegate snapshots are supplied, evaluate them as one end-to-end readonly pair instead of ignoring the delegate evidence.",
+        "Do not invent missing artifact content",
+        "Return a clear verdict: pass, fail, or needs_revision",
+        "Include metadata.verdict in output",
+        "Generate review artifact markdown for expected_outputs[0].path"
+      ],
+      "priority": "medium",
+      "source": {
+        "kind": "local_inbox",
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl063-001.json",
+        "received_at": "2026-03-25T10:04:56.056950Z",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "regeneration_token": "regen-20260325-bl063-001"
+      },
+      "acceptance_criteria": [
+        "Produce a review artifact with explicit verdict (pass/fail/needs_revision)"
+      ],
+      "metadata": {
+        "integration_phase": "8B",
+        "pipeline": "inbox->adapter->manager->automation->critic",
+        "request_type": "pdf_to_excel_ocr",
+        "payload_hash": "6b1d3f0946097f965d6d55116edb8bc665d0c5a5e9ff4524c569844262305772",
+        "regeneration_token": "regen-20260325-bl063-001",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "external_metadata": {
+          "source_system": "trello",
+          "card_id": "69c24cd3c1a2359ddd7a1bf8",
+          "card_short_id": 7,
+          "board_id": "69be462743bfa0038ca10f7a",
+          "list_id": "69be462743bfa0038ca10f8f",
+          "date_last_activity": "2026-03-24T08:35:56.234Z",
+          "readonly_mapped_at": "2026-03-25T10:04:35.724632Z",
+          "contract_profile": "best_effort_evidence_backed",
+          "ocr_claim_policy": "do_not_claim_success_without_evidence",
+          "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+          "regeneration_token": "regen-20260325-bl063-001"
+        }
+      }
+    }
+  },
+  "expected_artifacts": [
+    "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+    "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py"
+  ],
+  "dedupe_keys": [
+    "origin_regeneration:trello:69c24cd3c1a2359ddd7a1bf8:regen-20260325-bl063-001",
+    "hash:6b1d3f0946097f965d6d55116edb8bc665d0c5a5e9ff4524c569844262305772"
+  ],
+  "risk_warnings": [],
+  "execution": {
+    "status": "pending_approval",
+    "executed": false,
+    "attempts": 0
+  }
+}

--- a/runtime_archives/bl063/tmp/bl063_smoke_elevated.json
+++ b/runtime_archives/bl063/tmp/bl063_smoke_elevated.json
@@ -1,0 +1,92 @@
+/Users/lingguozhong/Library/Python/3.9/lib/python/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
+  warnings.warn(
+{
+  "status": "done",
+  "fixture": "/Users/lingguozhong/openclaw-team/adapters/samples/trello_card_fixture.json",
+  "mapped_output": "/Users/lingguozhong/openclaw-team/artifacts/trello_readonly_prep/trello_readonly_mapped_sample.json",
+  "required_env": {
+    "credentials": [
+      "TRELLO_API_KEY",
+      "TRELLO_API_TOKEN"
+    ],
+    "credentials_aliases": [
+      "TRELLO_KEY",
+      "TRELLO_TOKEN"
+    ],
+    "credentials_priority": [
+      "TRELLO_API_KEY/TRELLO_API_TOKEN",
+      "TRELLO_KEY/TRELLO_TOKEN"
+    ],
+    "scope": [
+      "TRELLO_BOARD_ID",
+      "TRELLO_LIST_ID"
+    ],
+    "scope_rule": [
+      "TRELLO_BOARD_ID or TRELLO_LIST_ID (either one)"
+    ]
+  },
+  "smoke_read": {
+    "status": "pass",
+    "read_count": 1,
+    "scope": {
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": null
+    },
+    "scope_kind": "board",
+    "mapped_preview": {
+      "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+      "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+      "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "metadata": {
+        "source_system": "trello",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "card_short_id": 7,
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "date_last_activity": "2026-03-24T08:35:56.234Z",
+        "readonly_mapped_at": "2026-03-25T10:04:35.724632Z",
+        "contract_profile": "best_effort_evidence_backed",
+        "ocr_claim_policy": "do_not_claim_success_without_evidence",
+        "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable"
+      },
+      "source": {
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f"
+      },
+      "request_type": "pdf_to_excel_ocr",
+      "input": {
+        "input_dir": "~/Desktop/pdf样本",
+        "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+        "ocr": "auto",
+        "dry_run": false
+      }
+    },
+    "auth_env": {
+      "selected_names": {
+        "key": "TRELLO_API_KEY",
+        "token": "TRELLO_API_TOKEN"
+      },
+      "priority": "TRELLO_API_* first, fallback to TRELLO_*",
+      "presence": {
+        "TRELLO_API_KEY": "set",
+        "TRELLO_KEY": "set",
+        "TRELLO_API_TOKEN": "set",
+        "TRELLO_TOKEN": "set",
+        "TRELLO_BOARD_ID": "set",
+        "TRELLO_LIST_ID": "missing"
+      }
+    },
+    "note": "Read-only GET only. No write operations performed."
+  },
+  "mode": "trello_readonly_prep"
+}

--- a/runtime_archives/bl063/tmp/bl063_smoke_sandbox.json
+++ b/runtime_archives/bl063/tmp/bl063_smoke_sandbox.json
@@ -1,0 +1,50 @@
+/Users/lingguozhong/Library/Python/3.9/lib/python/site-packages/urllib3/__init__.py:35: NotOpenSSLWarning: urllib3 v2 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with 'LibreSSL 2.8.3'. See: https://github.com/urllib3/urllib3/issues/3020
+  warnings.warn(
+{
+  "status": "done",
+  "fixture": "/Users/lingguozhong/openclaw-team/adapters/samples/trello_card_fixture.json",
+  "mapped_output": "/Users/lingguozhong/openclaw-team/artifacts/trello_readonly_prep/trello_readonly_mapped_sample.json",
+  "required_env": {
+    "credentials": [
+      "TRELLO_API_KEY",
+      "TRELLO_API_TOKEN"
+    ],
+    "credentials_aliases": [
+      "TRELLO_KEY",
+      "TRELLO_TOKEN"
+    ],
+    "credentials_priority": [
+      "TRELLO_API_KEY/TRELLO_API_TOKEN",
+      "TRELLO_KEY/TRELLO_TOKEN"
+    ],
+    "scope": [
+      "TRELLO_BOARD_ID",
+      "TRELLO_LIST_ID"
+    ],
+    "scope_rule": [
+      "TRELLO_BOARD_ID or TRELLO_LIST_ID (either one)"
+    ]
+  },
+  "smoke_read": {
+    "status": "blocked",
+    "reason": "Read-only Trello request failed before HTTP response: ConnectionError",
+    "error_type": "ConnectionError",
+    "response_preview": "HTTPSConnectionPool(host='api.trello.com', port=443): Max retries exceeded with url: /1/boards/69be462743bfa0038ca10f7a/cards?key=***redacted_key***&token=***redacted_token***&fields=id%2CidShort%2Cname%2Cdesc%2CidList%2CidBoard%2CdateLastActivity%2Clabels&limit=1 (Caused by NameResolutionError(\"HTT",
+    "auth_env": {
+      "selected_names": {
+        "key": "TRELLO_API_KEY",
+        "token": "TRELLO_API_TOKEN"
+      },
+      "priority": "TRELLO_API_* first, fallback to TRELLO_*",
+      "presence": {
+        "TRELLO_API_KEY": "set",
+        "TRELLO_KEY": "set",
+        "TRELLO_API_TOKEN": "set",
+        "TRELLO_TOKEN": "set",
+        "TRELLO_BOARD_ID": "set",
+        "TRELLO_LIST_ID": "missing"
+      }
+    }
+  },
+  "mode": "trello_readonly_prep"
+}


### PR DESCRIPTION
## Summary
- validate BL-062 hardening on one fresh same-origin governed candidate (regen-20260325-bl063-001)
- capture sandbox/elevated smoke evidence, preview creation, approval, and real execute replay evidence
- archive AUTO-20260325-872 / CRITIC-20260325-288 runtime artifacts under runtime_archives/bl063
- publish BL-063 validation report and update backlog/work log
- mark BL-063 done and queue BL-064 as next blocker

## Verification
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh

Closes #119