### PR TITLE
fix: harden output boundary and outcome-contract semantics (BL-064)

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -1132,8 +1132,8 @@ Allowed enum values:
 ### BL-20260325-064
 - title: Harden wrapper/delegate output-boundary policy and aggregate outcome-contract clarity after BL-20260325-063 critic findings
 - type: blocker
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-063
@@ -1141,6 +1141,23 @@ Allowed enum values:
 - done_when: Source-side hardening constrains wrapper output destination policy for governed readonly runs, clarifies extraction-vs-export outcome semantics across wrapper/delegate reports, and records one blocker report with focused tests
 - source: `POST_WRAPPER_DELEGATE_REPORT_SCHEMA_DIAGNOSTIC_ROBUSTNESS_VALIDATION_REPORT.md` on 2026-03-25 records the next blocker class as output-boundary and aggregate outcome-contract clarity
 - link: /Users/lingguozhong/openclaw-team/WRAPPER_DELEGATE_OUTPUT_BOUNDARY_OUTCOME_CONTRACT_HARDENING_REPORT.md
+- issue: https://github.com/Oscarling/openclaw-team/issues/121
+- evidence: `WRAPPER_DELEGATE_OUTPUT_BOUNDARY_OUTCOME_CONTRACT_HARDENING_REPORT.md` records wrapper output-boundary enforcement in `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py` (approved root: `artifacts/outputs`) and extraction/export phase-semantic hardening in `artifacts/scripts/pdf_to_excel_ocr.py`, with focused regressions in `tests/test_pdf_to_excel_ocr_inbox_runner.py` and `tests/test_pdf_to_excel_ocr_script.py`
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-065
+- title: Validate BL-20260325-064 output-boundary and outcome-contract hardening on a fresh same-origin governed candidate
+- type: mainline
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-064
+- start_when: `BL-20260325-064` is merged so one fresh governed candidate can verify critic findings move away from output-boundary and aggregate outcome-contract clarity concerns
+- done_when: One governed validation run (smoke -> regeneration -> preview -> approval -> real execute) records whether critic findings no longer cite wrapper output-boundary policy and extraction-vs-export outcome-contract clarity gaps
+- source: `WRAPPER_DELEGATE_OUTPUT_BOUNDARY_OUTCOME_CONTRACT_HARDENING_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation
+- link: /Users/lingguozhong/openclaw-team/POST_WRAPPER_DELEGATE_OUTPUT_BOUNDARY_OUTCOME_CONTRACT_VALIDATION_REPORT.md
 - issue: -
 - evidence: -
 - last_reviewed_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -3678,3 +3678,56 @@ Verification snapshot on 2026-03-25:
   - `execution.status = rejected`
   - `execution.executed = true`
   - `execution.attempts = 3`
+
+### 73. Wrapper/Delegate Output-Boundary + Outcome-Contract Hardening After BL-063 Findings
+
+User objective:
+
+- continue strict backlog mainline without drift
+- close blocker on wrapper output-boundary policy and extraction-vs-export
+  outcome-contract clarity
+
+Main work areas:
+
+- activated `BL-20260325-064` and mirrored it to issue `#121`
+- implemented output-boundary hardening in
+  `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`:
+  - added approved output root policy (`artifacts/outputs`)
+  - added output-path resolution provenance
+  - rejects governed readonly runs when `output_xlsx` is outside approved root
+- implemented phase-semantic hardening in
+  `artifacts/scripts/pdf_to_excel_ocr.py`:
+  - normalized report fields now include `extraction_status` and
+    `export_status`
+  - added explicit dry-run/no-input/export-failed phase outcomes
+  - made export failure notes preserve extraction evidence context
+- implemented wrapper phase diagnostics in
+  `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`:
+  - surfaces `delegate_extraction_status` and `delegate_export_status`
+  - emits explicit notes when export fails after extraction evidence
+- expanded focused regressions:
+  - `tests/test_pdf_to_excel_ocr_inbox_runner.py`
+    - `test_rejects_output_path_outside_approved_root`
+    - `test_surfaces_delegate_extraction_export_phase_distinction`
+  - `tests/test_pdf_to_excel_ocr_script.py`
+    - `test_main_excel_write_failure_exposes_extraction_export_distinction`
+- produced blocker hardening report and advanced backlog tracking:
+  - `BL-20260325-064` moved to `done`
+  - added next validation item `BL-20260325-065` (`planned` / `next`)
+
+Primary output:
+
+- [WRAPPER_DELEGATE_OUTPUT_BOUNDARY_OUTCOME_CONTRACT_HARDENING_REPORT.md](/Users/lingguozhong/openclaw-team/WRAPPER_DELEGATE_OUTPUT_BOUNDARY_OUTCOME_CONTRACT_HARDENING_REPORT.md)
+
+Key result:
+
+- `BL-20260325-064` is complete as a source-side blocker-hardening phase
+- wrapper output destination is now constrained for governed readonly flow
+- delegate/wrapper reports now expose extraction/export phase semantics as
+  first-class diagnostics
+- governance docs and next-step backlog item are synchronized
+
+Verification snapshot on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_script.py tests/test_pdf_to_excel_ocr_inbox_runner.py`
+  passed (`20/20`)

--- a/WRAPPER_DELEGATE_OUTPUT_BOUNDARY_OUTCOME_CONTRACT_HARDENING_REPORT.md
+++ b/WRAPPER_DELEGATE_OUTPUT_BOUNDARY_OUTCOME_CONTRACT_HARDENING_REPORT.md
@@ -1,0 +1,111 @@
+# Wrapper/Delegate Output-Boundary + Outcome-Contract Hardening Report
+
+## Objective
+
+Close `BL-20260325-064` by hardening wrapper/delegate behavior after
+`BL-20260325-063` critic findings:
+
+- constrain wrapper output destination policy for governed readonly runs
+- clarify extraction-vs-export semantics so failure diagnostics are explicit
+  and not collapsed into ambiguous aggregate signals
+
+## Scope
+
+In scope:
+
+- `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py` output-boundary and
+  diagnostic hardening
+- `artifacts/scripts/pdf_to_excel_ocr.py` extraction/export phase semantics
+  hardening
+- focused regressions for boundary enforcement and phase-distinction signals
+
+Out of scope:
+
+- governed live rerun in this blocker phase
+- Trello workflow redesign
+- unrelated OCR extraction algorithm changes
+
+## Changes
+
+### 1) Wrapper output destination is now constrained to approved root
+
+Updated `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`:
+
+- added approved boundary root:
+  - `APPROVED_OUTPUT_ROOT = <repo>/artifacts/outputs`
+- added `resolve_output_path(...)` and recorded output resolution provenance in
+  summary payload
+- enforced boundary before delegate execution:
+  - when `output_xlsx` is outside approved root, wrapper fails fast and refuses
+    broader local write destination in governed readonly flow
+- exposed contract fields:
+  - `contract.approved_output_root`
+  - `contract.output_boundary_enforced`
+
+Effect:
+
+- wrapper no longer permits arbitrary host-path write destinations by default in
+  governed readonly runs.
+
+### 2) Delegate report now distinguishes extraction and export phases
+
+Updated `artifacts/scripts/pdf_to_excel_ocr.py`:
+
+- normalized report schema now includes:
+  - `extraction_status`
+  - `export_status`
+- discovery/no-input exits now set explicit phase statuses (`none`,
+  `not_started`/`skipped_no_input`)
+- dry-run path sets `export_status=skipped_dry_run`
+- write phase now tracks:
+  - `export_status=running|succeeded|failed`
+- Excel write failure now emits explicit distinction notes:
+  - extraction phase outcome remains visible
+  - export failure is explicit with actionable next steps
+
+Effect:
+
+- consumers can differentiate extraction evidence from workbook export outcome
+  without guessing from coarse aggregate status.
+
+### 3) Wrapper summary now surfaces delegate phase outcomes explicitly
+
+Updated `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`:
+
+- added `extract_delegate_phase_statuses(...)`
+- records delegate phase outcomes under:
+  - `execution.delegate_extraction_status`
+  - `execution.delegate_export_status`
+- emits explicit notes when:
+  - delegate phase outcomes are known
+  - export failed after extraction evidence exists
+
+Effect:
+
+- runtime summaries now preserve extraction-vs-export diagnostic clarity even
+  when final wrapper status is failed.
+
+## Tests
+
+Updated tests:
+
+- `tests/test_pdf_to_excel_ocr_inbox_runner.py`
+  - `test_rejects_output_path_outside_approved_root`
+  - `test_surfaces_delegate_extraction_export_phase_distinction`
+- `tests/test_pdf_to_excel_ocr_script.py`
+  - `test_main_excel_write_failure_exposes_extraction_export_distinction`
+
+Validation run:
+
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_script.py tests/test_pdf_to_excel_ocr_inbox_runner.py`
+  - passed (`20/20`)
+
+## Outcome
+
+`BL-20260325-064` source-side hardening is complete:
+
+- wrapper output writes are bounded to approved artifact root for governed
+  readonly execution
+- delegate/wrapper reports now expose extraction and export phase semantics as
+  first-class diagnostic evidence
+- focused regressions cover both boundary and phase-distinction hardening

--- a/artifacts/scripts/pdf_to_excel_ocr.py
+++ b/artifacts/scripts/pdf_to_excel_ocr.py
@@ -276,6 +276,8 @@ def build_report_template(
         "files": [],
         "status_counter": {},
         "dry_run": bool(dry_run),
+        "extraction_status": "none",
+        "export_status": "not_started",
         "excel_written": False,
         "output_exists": False,
         "output_size_bytes": 0,
@@ -300,6 +302,8 @@ def main() -> int:
             dry_run=args.dry_run,
         )
         report["error"] = str(e)
+        report["extraction_status"] = "none"
+        report["export_status"] = "not_started"
         report["notes"].append("Input discovery failed before extraction could start.")
         report["next_steps"].append("Verify input directory exists and is readable, then rerun.")
         emit_report(report, args.report_json)
@@ -313,6 +317,8 @@ def main() -> int:
             dry_run=args.dry_run,
         )
         report["status"] = "partial"
+        report["extraction_status"] = "none"
+        report["export_status"] = "skipped_no_input"
         report["notes"] = [f"No PDF files found under {input_dir}"]
         report["next_steps"] = [
             "Add one or more .pdf files under the input directory and rerun.",
@@ -355,9 +361,9 @@ def main() -> int:
     failed_count = status_counter.get("failed", 0)
     partial_count = status_counter.get("partial", 0)
     if failed_count == 0 and partial_count == 0:
-        aggregate_status = "success"
+        extraction_status = "success"
     else:
-        aggregate_status = "partial"
+        extraction_status = "partial"
 
     notes: list[str] = []
     next_steps: list[str] = []
@@ -379,27 +385,40 @@ def main() -> int:
     )
     report.update(
         {
-            "status": aggregate_status,
+            "status": extraction_status,
             "ocr_runtime_status": ocr_runtime,
             "ocr_missing_dependencies": missing,
             "total_files": len(results),
             "files": files_payload,
             "status_counter": status_counter,
+            "extraction_status": extraction_status,
+            "export_status": "not_started",
             "notes": notes,
             "next_steps": next_steps,
         }
     )
 
     if args.dry_run:
+        report["export_status"] = "skipped_dry_run"
         emit_report(report, args.report_json)
         return 0
 
+    report["export_status"] = "running"
     try:
         write_excel(results, output_xlsx)
         report["output_exists"] = output_xlsx.exists() and output_xlsx.is_file()
         if report["output_exists"]:
             report["output_size_bytes"] = int(output_xlsx.stat().st_size)
         report["excel_written"] = bool(report["output_exists"] and report["output_size_bytes"] > 0)
+        report["export_status"] = "succeeded" if report["excel_written"] else "failed"
+        if report["export_status"] == "failed":
+            report["status"] = "failed"
+            report["notes"] = report.get("notes", []) + [
+                "Excel write step completed without a usable XLSX artifact; treating export as failed."
+            ]
+            report["next_steps"] = report.get("next_steps", []) + [
+                "Inspect output artifact path permissions and workbook writer dependencies.",
+            ]
         emit_report(report, args.report_json)
         return 0
     except Exception as e:
@@ -409,8 +428,18 @@ def main() -> int:
         if report["output_exists"]:
             report["output_size_bytes"] = int(output_xlsx.stat().st_size)
         report["excel_written"] = bool(report["output_exists"] and report["output_size_bytes"] > 0)
-        report["notes"] = report.get("notes", []) + ["Excel write step failed after extraction."]
-        report["next_steps"] = report.get("next_steps", []) + ["Check pandas/openpyxl availability and output path permissions."]
+        report["export_status"] = "failed"
+        report["notes"] = report.get("notes", []) + [
+            "Excel write step failed after extraction.",
+            (
+                f"Extraction phase completed with extraction_status={report.get('extraction_status', 'unknown')}; "
+                "export_status=failed."
+            ),
+        ]
+        report["next_steps"] = report.get("next_steps", []) + [
+            "Inspect extraction evidence in `files`/`status_counter` even when export fails.",
+            "Check pandas/openpyxl availability and output path permissions.",
+        ]
         emit_report(report, args.report_json)
         return 3
 

--- a/artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
+++ b/artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
@@ -30,8 +30,19 @@ DEFAULT_REFERENCE_DOCS = [
 ]
 RUNNER_PATH = Path(__file__).resolve()
 REPO_ROOT = RUNNER_PATH.parents[2]
+APPROVED_OUTPUT_ROOT = (REPO_ROOT / "artifacts" / "outputs").resolve()
 REVIEWED_BASE_SCRIPT = (REPO_ROOT / DEFAULT_PREFERRED_BASE_SCRIPT).resolve()
 ALLOWED_SUMMARY_STATUSES = {"success", "partial", "failed"}
+ALLOWED_EXTRACTION_STATUSES = {"none", "success", "partial", "failed"}
+ALLOWED_EXPORT_STATUSES = {
+    "not_started",
+    "running",
+    "succeeded",
+    "failed",
+    "skipped_dry_run",
+    "skipped_no_input",
+    "unknown",
+}
 
 
 def utc_now() -> str:
@@ -67,6 +78,37 @@ def resolve_delegate_script(path_str: str) -> tuple[Path, dict[str, Any]]:
         "resolved": str(resolved),
         "within_repo_root": relative_to_repo is not None,
         "repo_relative_path": relative_to_repo,
+    }
+    return resolved, resolution
+
+
+def resolve_output_path(path_str: str) -> tuple[Path, dict[str, Any]]:
+    requested = expand_path(path_str)
+    if requested.is_absolute():
+        resolved = requested.resolve()
+        strategy = "absolute"
+    else:
+        resolved = (REPO_ROOT / requested).resolve()
+        strategy = "repo_root_relative"
+
+    relative_to_repo = repo_relative_path(resolved)
+    try:
+        relative_to_output_root = str(resolved.relative_to(APPROVED_OUTPUT_ROOT))
+        within_output_root = True
+    except ValueError:
+        relative_to_output_root = None
+        within_output_root = False
+
+    resolution = {
+        "requested": path_str,
+        "expanded": str(requested),
+        "strategy": strategy,
+        "resolved": str(resolved),
+        "within_repo_root": relative_to_repo is not None,
+        "repo_relative_path": relative_to_repo,
+        "approved_output_root": str(APPROVED_OUTPUT_ROOT),
+        "within_approved_output_root": within_output_root,
+        "approved_output_relative_path": relative_to_output_root,
     }
     return resolved, resolution
 
@@ -203,6 +245,37 @@ def extract_delegate_error(delegate_report: dict[str, Any] | None) -> str | None
     return cleaned or None
 
 
+def extract_delegate_phase_statuses(delegate_report: dict[str, Any] | None) -> tuple[str, str]:
+    if not isinstance(delegate_report, dict):
+        return "", ""
+
+    extraction_status = str(delegate_report.get("extraction_status", "")).strip().lower()
+    if extraction_status not in ALLOWED_EXTRACTION_STATUSES:
+        extraction_status = ""
+    export_status = str(delegate_report.get("export_status", "")).strip().lower()
+    if export_status not in ALLOWED_EXPORT_STATUSES:
+        export_status = ""
+
+    if not extraction_status:
+        status = str(delegate_report.get("status", "")).strip().lower()
+        if status == "success":
+            extraction_status = "success"
+        elif status == "partial":
+            extraction_status = "partial"
+        elif status == "failed":
+            extraction_status = "failed"
+
+    if not export_status:
+        if bool(delegate_report.get("dry_run", False)):
+            export_status = "skipped_dry_run"
+        elif delegate_report.get("excel_written") is True:
+            export_status = "succeeded"
+        elif str(delegate_report.get("status", "")).strip().lower() == "failed":
+            export_status = "failed"
+
+    return extraction_status, export_status
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Best-effort inbox runner that reuses the repository PDF-to-Excel OCR script."
@@ -237,7 +310,7 @@ def main() -> int:
     requested_at = utc_now()
     run_id = "bl050-wrapper-" + requested_at.replace(":", "").replace("-", "").replace(".", "")
     input_dir = expand_path(args.input_dir)
-    output_xlsx = expand_path(args.output_xlsx)
+    output_xlsx, output_resolution = resolve_output_path(args.output_xlsx)
     base_script, delegate_resolution = resolve_delegate_script(args.preferred_base_script)
     pdfs = discover_pdfs(input_dir)
     readonly_labels_present = any(str(label).strip().lower() == "readonly" for label in args.labels)
@@ -268,6 +341,8 @@ def main() -> int:
             "reviewed_base_script": str(REVIEWED_BASE_SCRIPT),
             "readonly_labels_present": readonly_labels_present,
             "readonly_delegate_verified": delegate_contract_error is None,
+            "approved_output_root": str(APPROVED_OUTPUT_ROOT),
+            "output_boundary_enforced": True,
             "delegate_timeout_seconds": max(int(args.delegate_timeout_seconds), 1),
             "delegate_success_evidence_policy": (
                 "Require delegate report status=success, total_files>=1, no failed files, "
@@ -279,6 +354,7 @@ def main() -> int:
             "repo_root": str(REPO_ROOT),
             "origin_id": args.origin_id,
             "delegate_path_resolution": delegate_resolution,
+            "output_path_resolution": output_resolution,
             "input_dir_resolution": {
                 "requested": args.input_dir,
                 "resolved": str(input_dir.resolve()),
@@ -313,6 +389,8 @@ def main() -> int:
             "delegate_report": None,
             "delegate_report_source": "none",
             "delegate_report_sidecar_path": "",
+            "delegate_extraction_status": "",
+            "delegate_export_status": "",
         },
         "output": {
             "exists": False,
@@ -335,6 +413,17 @@ def main() -> int:
         summary["notes"].append("Requested output path does not end with .xlsx; refusing mismatched workbook contract.")
         emit_summary(summary, args.summary_json)
         return 2
+
+    if not bool(output_resolution.get("within_approved_output_root", False)):
+        summary["notes"].append(
+            (
+                "Requested output path is outside approved output root "
+                f"{APPROVED_OUTPUT_ROOT}; refusing broader local write destination "
+                "for governed readonly flow."
+            )
+        )
+        emit_summary(summary, args.summary_json)
+        return 6
 
     if delegate_contract_error:
         summary["notes"].append(delegate_contract_error)
@@ -418,9 +507,27 @@ def main() -> int:
     stdout_report = parse_delegate_report(completed.stdout)
     delegate_report = sidecar_report or stdout_report
     summary["execution"]["delegate_report"] = delegate_report
+    delegate_extraction_status, delegate_export_status = extract_delegate_phase_statuses(delegate_report)
+    summary["execution"]["delegate_extraction_status"] = delegate_extraction_status
+    summary["execution"]["delegate_export_status"] = delegate_export_status
     delegate_error = extract_delegate_error(delegate_report)
     if delegate_error:
         summary["notes"].append(f"Delegate reported error: {delegate_error}")
+    if delegate_extraction_status or delegate_export_status:
+        summary["notes"].append(
+            (
+                "Delegate phase outcomes: "
+                f"extraction_status={delegate_extraction_status or 'unknown'}, "
+                f"export_status={delegate_export_status or 'unknown'}."
+            )
+        )
+    if delegate_export_status == "failed" and delegate_extraction_status in {"success", "partial"}:
+        summary["notes"].append(
+            (
+                "Delegate reported export failure after extraction evidence was produced "
+                f"(extraction_status={delegate_extraction_status}, export_status=failed)."
+            )
+        )
     if isinstance(sidecar_report, dict):
         summary["execution"]["delegate_report_source"] = "sidecar"
         if isinstance(stdout_report, dict) and stdout_report != sidecar_report:
@@ -461,7 +568,9 @@ def main() -> int:
             summary["status"] = "partial"
             summary["notes"].append("Delegate reported a reviewable partial outcome; preserving partial status.")
         elif delegate_status == "failed":
-            summary["notes"].append("Delegate reported failed status despite producing an XLSX artifact.")
+            summary["notes"].append(
+                "Delegate reported failed status despite producing an XLSX artifact; review extraction/export phase details."
+            )
         elif success_evidence_ok:
             summary["status"] = "success"
         elif delegate_status == "success":
@@ -475,7 +584,12 @@ def main() -> int:
             summary["notes"].append("Delegate produced XLSX output but did not provide a recognized summary status.")
     else:
         if completed.returncode == 0 and not output_exists:
-            summary["notes"].append("Delegate exited successfully but expected XLSX output was not found.")
+            if delegate_status == "failed" and delegate_export_status == "failed":
+                summary["notes"].append(
+                    "Delegate exited with failed export semantics and no XLSX artifact; preserving failed wrapper status."
+                )
+            else:
+                summary["notes"].append("Delegate exited successfully but expected XLSX output was not found.")
         elif completed.returncode != 0:
             summary["notes"].append("Delegate script returned a non-zero exit code.")
 

--- a/tests/test_pdf_to_excel_ocr_inbox_runner.py
+++ b/tests/test_pdf_to_excel_ocr_inbox_runner.py
@@ -51,7 +51,7 @@ class PdfToExcelOcrInboxRunnerTests(unittest.TestCase):
         reviewed_base_script: Path | None = None,
     ) -> tuple[int, dict[str, Any], str]:
         summary_path = self.tmpdir / "summary.json"
-        output_path = self.tmpdir / "output.xlsx"
+        output_path = REPO_ROOT / "artifacts" / "outputs" / "unit_tests" / f"{self.tmpdir.name}-output.xlsx"
         argv = [
             "pdf_to_excel_ocr_inbox_runner.py",
             "--input-dir",
@@ -335,6 +335,74 @@ class PdfToExcelOcrInboxRunnerTests(unittest.TestCase):
         self.assertEqual(summary["status"], "partial")
         self.assertTrue(summary["output"]["exists"])
         self.assertTrue(any("at least one processed PDF file" in note for note in summary["notes"]))
+
+    def test_rejects_output_path_outside_approved_root(self) -> None:
+        input_dir = self._make_input_dir(with_pdf=True)
+
+        exit_code, summary, _ = self._invoke_main(
+            input_dir=input_dir,
+            extra_args=["--output-xlsx", str(self.tmpdir / "outside.xlsx")],
+        )
+
+        self.assertEqual(exit_code, 6)
+        self.assertEqual(summary["status"], "failed")
+        self.assertFalse(summary["execution"]["delegated"])
+        self.assertFalse(summary["provenance"]["output_path_resolution"]["within_approved_output_root"])
+        self.assertTrue(any("outside approved output root" in note for note in summary["notes"]))
+
+    def test_surfaces_delegate_extraction_export_phase_distinction(self) -> None:
+        input_dir = self._make_input_dir(with_pdf=True)
+        fake_base = self.tmpdir / "fake_pdf_to_excel_ocr_export_failed.py"
+        fake_base.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env python3
+                import argparse
+                import json
+                from pathlib import Path
+
+                parser = argparse.ArgumentParser()
+                parser.add_argument("--input-dir", required=True)
+                parser.add_argument("--output-xlsx", required=True)
+                parser.add_argument("--ocr", default="auto")
+                parser.add_argument("--report-json", default="")
+                args = parser.parse_args()
+
+                payload = {
+                    "status": "failed",
+                    "total_files": 1,
+                    "status_counter": {"partial": 1},
+                    "dry_run": False,
+                    "extraction_status": "partial",
+                    "export_status": "failed",
+                    "excel_written": False,
+                    "output_exists": False,
+                    "output_size_bytes": 0,
+                    "ocr_runtime_status": "available",
+                    "notes": ["Excel write step failed after extraction."],
+                    "next_steps": ["Inspect extraction evidence in files/status_counter."],
+                    "error": "openpyxl missing",
+                }
+                if args.report_json:
+                    Path(args.report_json).write_text(json.dumps(payload), encoding="utf-8")
+                print(json.dumps(payload))
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        exit_code, summary, _ = self._invoke_main(
+            input_dir=input_dir,
+            extra_args=["--preferred-base-script", str(fake_base)],
+            reviewed_base_script=fake_base,
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(summary["status"], "failed")
+        self.assertEqual(summary["execution"]["delegate_extraction_status"], "partial")
+        self.assertEqual(summary["execution"]["delegate_export_status"], "failed")
+        self.assertTrue(any("extraction_status=partial" in note for note in summary["notes"]))
+        self.assertTrue(any("export_status=failed" in note for note in summary["notes"]))
 
     def test_surfaces_delegate_error_context_in_wrapper_notes(self) -> None:
         input_dir = self._make_input_dir(with_pdf=True)

--- a/tests/test_pdf_to_excel_ocr_script.py
+++ b/tests/test_pdf_to_excel_ocr_script.py
@@ -137,9 +137,59 @@ class PdfToExcelOcrScriptTests(unittest.TestCase):
         self.assertFalse(report["output_exists"])
         self.assertEqual(report["output_size_bytes"], 0)
         self.assertEqual(report["ocr_runtime_status"], "unknown")
+        self.assertEqual(report["extraction_status"], "none")
+        self.assertEqual(report["export_status"], "not_started")
         self.assertIn("Input discovery failed", report["notes"][0])
         self.assertTrue(any("Verify input directory exists" in step for step in report["next_steps"]))
         self.assertIn("Input directory does not exist", report["error"])
+
+    def test_main_excel_write_failure_exposes_extraction_export_distinction(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="pdf-to-excel-ocr-script-export-failed-") as tmp:
+            tmpdir = Path(tmp)
+            input_dir = tmpdir / "input"
+            input_dir.mkdir(parents=True, exist_ok=True)
+            output_xlsx = tmpdir / "output.xlsx"
+            sample_pdf = input_dir / "sample.pdf"
+            sample_pdf.write_bytes(b"%PDF-1.4\n")
+
+            args = SimpleNamespace(
+                input_dir=str(input_dir),
+                output_xlsx=str(output_xlsx),
+                ocr="auto",
+                dry_run=False,
+                ocr_lang="chi_sim+eng",
+                auto_ocr_min_chars=50,
+                report_json="",
+            )
+            success_file = self.script.FileResult(
+                file_name="sample.pdf",
+                file_path=str(sample_pdf),
+                status="success",
+                extract_method="text",
+                page_count=1,
+                text_chars=24,
+                text_preview="preview",
+                warnings="",
+                error="",
+            )
+
+            stdout = io.StringIO()
+            with mock.patch.object(self.script, "parse_args", return_value=args):
+                with mock.patch.object(self.script, "discover_pdfs", return_value=[sample_pdf]):
+                    with mock.patch.object(self.script, "detect_ocr_runtime_status", return_value=("available", [])):
+                        with mock.patch.object(self.script, "process_one_pdf", return_value=success_file):
+                            with mock.patch.object(self.script, "write_excel", side_effect=RuntimeError("openpyxl missing")):
+                                with contextlib.redirect_stdout(stdout):
+                                    exit_code = self.script.main()
+
+        self.assertEqual(exit_code, 3)
+        report = json.loads(stdout.getvalue())
+        self.assertEqual(report["status"], "failed")
+        self.assertEqual(report["extraction_status"], "success")
+        self.assertEqual(report["export_status"], "failed")
+        self.assertIn("openpyxl missing", report["error"])
+        self.assertTrue(any("extraction_status=success" in note for note in report["notes"]))
+        self.assertTrue(any("Inspect extraction evidence" in step for step in report["next_steps"]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- enforce governed readonly output boundary under artifacts/outputs in wrapper runtime policy
- add output path provenance fields and explicit boundary-enforcement contract fields
- normalize delegate phase semantics with extraction_status/export_status across failure/no-input/dry-run/export-failure paths
- surface delegate extraction/export phase outcomes explicitly in wrapper notes and execution summary
- add focused regressions for output-boundary rejection and extraction-vs-export diagnostics
- complete BL-064 report/log updates and queue BL-065 as next validation item

## Verification
- python3 -m unittest -v tests/test_pdf_to_excel_ocr_script.py tests/test_pdf_to_excel_ocr_inbox_runner.py
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh

Closes #121