### PR TITLE
BL-066: harden wrapper/delegate execution outcome semantics

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -1166,8 +1166,8 @@ Allowed enum values:
 ### BL-20260325-066
 - title: Harden wrapper/delegate execution outcome-contract strictness and diagnostics completeness after BL-065 critic findings
 - type: blocker
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-065
@@ -1175,6 +1175,23 @@ Allowed enum values:
 - done_when: Source-side hardening makes wrapper subprocess exit-code handling deterministic (including non-zero with JSON evidence), canonicalizes no-input/partial/failed semantics across wrapper/delegate, preserves relevant stderr/stdout diagnostics in structured evidence, and records one blocker report with focused tests
 - source: `POST_WRAPPER_DELEGATE_OUTPUT_BOUNDARY_OUTCOME_CONTRACT_VALIDATION_REPORT.md` on 2026-03-25 records the next blocker class as execution outcome-contract strictness and diagnostics completeness
 - link: /Users/lingguozhong/openclaw-team/WRAPPER_DELEGATE_EXECUTION_OUTCOME_DIAGNOSTIC_CONTRACT_HARDENING_REPORT.md
+- issue: https://github.com/Oscarling/openclaw-team/issues/125
+- evidence: `WRAPPER_DELEGATE_EXECUTION_OUTCOME_DIAGNOSTIC_CONTRACT_HARDENING_REPORT.md` records wrapper hardening in `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py` for strict non-zero delegate exit handling, canonicalized partial/no-output semantics, and structured stdout/stderr diagnostics preservation, with focused regressions in `tests/test_pdf_to_excel_ocr_inbox_runner.py`
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-067
+- title: Validate BL-20260325-066 execution outcome-contract and diagnostics hardening on a fresh same-origin governed candidate
+- type: mainline
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-066
+- start_when: `BL-20260325-066` is merged so one fresh governed candidate can verify critic findings move away from wrapper/delegate execution outcome semantics and diagnostics completeness concerns
+- done_when: One governed validation run (smoke -> regeneration -> preview -> approval -> real execute) records whether critic findings no longer cite wrapper non-zero/partial semantics mismatches and diagnostics completeness gaps
+- source: `WRAPPER_DELEGATE_EXECUTION_OUTCOME_DIAGNOSTIC_CONTRACT_HARDENING_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation
+- link: /Users/lingguozhong/openclaw-team/POST_WRAPPER_DELEGATE_EXECUTION_OUTCOME_DIAGNOSTIC_CONTRACT_VALIDATION_REPORT.md
 - issue: -
 - evidence: -
 - last_reviewed_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -3790,3 +3790,62 @@ Verification snapshot on 2026-03-25:
   - `execution.status = rejected`
   - `execution.executed = true`
   - `execution.attempts = 2`
+
+### 75. Wrapper/Delegate Execution Outcome-Contract + Diagnostics Hardening After BL-065 Findings
+
+User objective:
+
+- continue strict backlog mainline without drift
+- close blocker on wrapper/delegate execution outcome semantics and
+  diagnostics completeness
+
+Main work areas:
+
+- activated `BL-20260325-066` and mirrored it to issue `#125`
+- implemented execution outcome-contract hardening in
+  `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`:
+  - made non-zero delegate return code a strict hard-failure signal even when
+    structured JSON exists
+  - added explicit note when delegate status evidence is overridden by non-zero
+    subprocess exit code
+  - preserved deterministic wrapper process contract (`success`/`partial` => 0,
+    `failed` => 1)
+- implemented canonical no-output partial semantics in
+  `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`:
+  - preserves `partial` when delegate exits 0 and reports `status=partial`
+    without XLSX artifact
+  - keeps `failed` for explicit delegate `failed` and contradictory
+    `success`-without-artifact paths
+- implemented diagnostics completeness fields in
+  `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`:
+  - added `stdout_present`/`stderr_present`
+  - added line counts and excerpts for stdout/stderr
+  - added explicit audit note when stderr is captured
+- expanded focused regressions in
+  `tests/test_pdf_to_excel_ocr_inbox_runner.py`:
+  - `test_preserves_delegate_partial_without_output_when_exit_zero`
+  - `test_nonzero_delegate_exit_hard_fails_even_with_structured_json`
+  - `test_preserves_stdout_stderr_diagnostics_in_summary`
+- produced blocker hardening report and advanced backlog tracking:
+  - `BL-20260325-066` moved to `done`
+  - added next validation item `BL-20260325-067` (`planned` / `next`)
+
+Primary output:
+
+- [WRAPPER_DELEGATE_EXECUTION_OUTCOME_DIAGNOSTIC_CONTRACT_HARDENING_REPORT.md](/Users/lingguozhong/openclaw-team/WRAPPER_DELEGATE_EXECUTION_OUTCOME_DIAGNOSTIC_CONTRACT_HARDENING_REPORT.md)
+
+Key result:
+
+- `BL-20260325-066` is complete as a source-side blocker-hardening phase
+- wrapper/delegate non-zero and partial/no-output semantics are now stricter
+  and more canonical
+- wrapper summary now preserves structured diagnostics completeness for
+  stdout/stderr evidence
+- governance docs and next-step backlog item are synchronized
+
+Verification snapshot on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py`
+  passed (`18/18`)
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed

--- a/WRAPPER_DELEGATE_EXECUTION_OUTCOME_DIAGNOSTIC_CONTRACT_HARDENING_REPORT.md
+++ b/WRAPPER_DELEGATE_EXECUTION_OUTCOME_DIAGNOSTIC_CONTRACT_HARDENING_REPORT.md
@@ -1,0 +1,102 @@
+# Wrapper/Delegate Execution Outcome-Contract + Diagnostics Completeness Hardening Report
+
+## Objective
+
+Close `BL-20260325-066` by hardening wrapper/delegate behavior after
+`BL-20260325-065` critic findings:
+
+- make wrapper subprocess exit-code handling deterministic and strict
+- canonicalize no-input/partial/failed semantics between wrapper and delegate
+- preserve relevant stdout/stderr diagnostics in structured wrapper evidence
+
+## Scope
+
+In scope:
+
+- `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py` outcome-contract and
+  diagnostics hardening
+- focused regressions in `tests/test_pdf_to_excel_ocr_inbox_runner.py`
+- backlog/worklog synchronization for blocker completion
+
+Out of scope:
+
+- governed live rerun in this blocker phase
+- Trello workflow redesign
+- OCR extraction algorithm changes in delegate internals
+
+## Changes
+
+### 1) Non-zero delegate exit code is now a hard wrapper failure signal
+
+Updated `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`:
+
+- made non-dry-run non-zero delegate return code a hard-failure branch
+- added explicit override note when delegate JSON reports `success`/`partial`
+  but subprocess exit code is non-zero
+- kept final wrapper exit contract deterministic:
+  - `success`/`partial` -> process exit `0`
+  - `failed` -> process exit `1`
+
+Effect:
+
+- wrapper outcome no longer risks softening delegate process-level failure
+  semantics.
+
+### 2) Canonical partial semantics are preserved without XLSX output
+
+Updated `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`:
+
+- when delegate exits `0` and reports `status=partial`, wrapper now preserves
+  `partial` even when workbook output does not exist
+- retained stricter `failed` handling for explicit `status=failed`
+- retained conservative `failed` handling for contradictory `status=success`
+  without workbook artifact
+
+Effect:
+
+- no-input / best-effort partial outcomes remain canonical across
+  wrapper/delegate and are not collapsed into wrapper `failed` by missing XLSX
+  alone.
+
+### 3) Structured diagnostics now preserve stdout/stderr evidence fields
+
+Updated `artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py`:
+
+- added execution diagnostics fields:
+  - `stdout_present`, `stderr_present`
+  - `stdout_line_count`, `stderr_line_count`
+  - `stdout_excerpt`, `stderr_excerpt`
+- added deterministic excerpt truncation for large logs
+- added explicit note when stderr was captured and preserved
+
+Effect:
+
+- reviewer can audit delegate diagnostics directly from wrapper summary payload
+  without relying only on ad-hoc log interpretation.
+
+## Tests
+
+Updated tests in `tests/test_pdf_to_excel_ocr_inbox_runner.py`:
+
+- `test_preserves_delegate_partial_without_output_when_exit_zero`
+- `test_nonzero_delegate_exit_hard_fails_even_with_structured_json`
+- `test_preserves_stdout_stderr_diagnostics_in_summary`
+
+Validation runs:
+
+- `python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py`
+  - passed (`18/18`)
+- `python3 scripts/backlog_lint.py`
+  - passed
+- `python3 scripts/backlog_sync.py`
+  - passed
+
+## Outcome
+
+`BL-20260325-066` source-side hardening is complete:
+
+- wrapper/delegate execution outcome contract is stricter on non-zero exits
+- wrapper/delegate partial semantics are more canonical in no-output
+  best-effort paths
+- wrapper summary now preserves diagnostics completeness via explicit
+  stdout/stderr evidence fields

--- a/artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
+++ b/artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py
@@ -43,6 +43,7 @@ ALLOWED_EXPORT_STATUSES = {
     "skipped_no_input",
     "unknown",
 }
+DIAGNOSTIC_EXCERPT_LIMIT = 1200
 
 
 def utc_now() -> str:
@@ -178,6 +179,21 @@ def load_delegate_report_file(path: Path) -> dict[str, Any] | None:
     if isinstance(payload, dict):
         return payload
     return None
+
+
+def build_diagnostic_excerpt(text: str, *, limit: int = DIAGNOSTIC_EXCERPT_LIMIT) -> str:
+    cleaned = text.strip()
+    if not cleaned:
+        return ""
+    if len(cleaned) <= limit:
+        return cleaned
+    return cleaned[:limit] + "...[truncated]"
+
+
+def line_count(text: str) -> int:
+    if not text:
+        return 0
+    return len(text.splitlines())
 
 
 def has_strong_delegate_success_evidence(
@@ -386,6 +402,12 @@ def main() -> int:
             "timeout_seconds": max(int(args.delegate_timeout_seconds), 1),
             "stdout": "",
             "stderr": "",
+            "stdout_present": False,
+            "stderr_present": False,
+            "stdout_line_count": 0,
+            "stderr_line_count": 0,
+            "stdout_excerpt": "",
+            "stderr_excerpt": "",
             "delegate_report": None,
             "delegate_report_source": "none",
             "delegate_report_sidecar_path": "",
@@ -502,6 +524,20 @@ def main() -> int:
     summary["execution"]["returncode"] = completed.returncode
     summary["execution"]["stdout"] = completed.stdout
     summary["execution"]["stderr"] = completed.stderr
+    summary["execution"]["stdout_present"] = bool(completed.stdout.strip())
+    summary["execution"]["stderr_present"] = bool(completed.stderr.strip())
+    summary["execution"]["stdout_line_count"] = line_count(completed.stdout)
+    summary["execution"]["stderr_line_count"] = line_count(completed.stderr)
+    summary["execution"]["stdout_excerpt"] = build_diagnostic_excerpt(completed.stdout)
+    summary["execution"]["stderr_excerpt"] = build_diagnostic_excerpt(completed.stderr)
+    if summary["execution"]["stderr_present"]:
+        summary["notes"].append(
+            "Delegate stderr was captured and preserved in execution diagnostics."
+        )
+    if summary["execution"]["stdout_present"] and not parse_delegate_report(completed.stdout):
+        summary["notes"].append(
+            "Delegate stdout was captured but did not contain a structured JSON report."
+        )
 
     sidecar_report = load_delegate_report_file(delegate_report_sidecar)
     stdout_report = parse_delegate_report(completed.stdout)
@@ -558,40 +594,62 @@ def main() -> int:
             else:
                 summary["notes"].append("Delegate did not emit a structured dry-run report; preserving partial status conservatively.")
         else:
-            summary["notes"].append("Delegate script returned a non-zero exit code during dry-run mode.")
-    elif completed.returncode == 0 and output_exists:
-        success_evidence_ok, success_evidence_note = has_strong_delegate_success_evidence(
-            delegate_report,
-            ocr_mode=args.ocr,
-        )
-        if delegate_status == "partial":
-            summary["status"] = "partial"
-            summary["notes"].append("Delegate reported a reviewable partial outcome; preserving partial status.")
-        elif delegate_status == "failed":
             summary["notes"].append(
-                "Delegate reported failed status despite producing an XLSX artifact; review extraction/export phase details."
+                "Delegate script returned a non-zero exit code during dry-run mode; hard-failing wrapper outcome."
             )
-        elif success_evidence_ok:
-            summary["status"] = "success"
-        elif delegate_status == "success":
-            summary["status"] = "partial"
+    elif completed.returncode != 0:
+        if delegate_status:
             summary["notes"].append(
-                success_evidence_note
-                or "Delegate success evidence was too weak for the wrapper to claim success."
+                (
+                    f"Delegate reported status={delegate_status}, but returncode={completed.returncode}; "
+                    "wrapper treats non-zero delegate exits as hard failure."
+                )
             )
         else:
-            summary["status"] = "partial"
-            summary["notes"].append("Delegate produced XLSX output but did not provide a recognized summary status.")
+            summary["notes"].append("Delegate script returned a non-zero exit code.")
     else:
-        if completed.returncode == 0 and not output_exists:
-            if delegate_status == "failed" and delegate_export_status == "failed":
+        if delegate_status == "failed":
+            if output_exists:
                 summary["notes"].append(
-                    "Delegate exited with failed export semantics and no XLSX artifact; preserving failed wrapper status."
+                    "Delegate reported failed status despite producing an XLSX artifact; review extraction/export phase details."
+                )
+            else:
+                summary["notes"].append(
+                    "Delegate exited with failed semantics and no XLSX artifact; preserving failed wrapper status."
+                )
+        elif delegate_status == "partial":
+            summary["status"] = "partial"
+            if output_exists:
+                summary["notes"].append(
+                    "Delegate reported a reviewable partial outcome with XLSX artifact; preserving partial status."
+                )
+            else:
+                summary["notes"].append(
+                    "Delegate reported a reviewable partial outcome without XLSX artifact; preserving partial status."
+                )
+        elif output_exists:
+            success_evidence_ok, success_evidence_note = has_strong_delegate_success_evidence(
+                delegate_report,
+                ocr_mode=args.ocr,
+            )
+            if success_evidence_ok:
+                summary["status"] = "success"
+            elif delegate_status == "success":
+                summary["status"] = "partial"
+                summary["notes"].append(
+                    success_evidence_note
+                    or "Delegate success evidence was too weak for the wrapper to claim success."
+                )
+            else:
+                summary["status"] = "partial"
+                summary["notes"].append("Delegate produced XLSX output but did not provide a recognized summary status.")
+        else:
+            if delegate_status == "success":
+                summary["notes"].append(
+                    "Delegate reported success but expected XLSX output was not found; preserving failed wrapper status."
                 )
             else:
                 summary["notes"].append("Delegate exited successfully but expected XLSX output was not found.")
-        elif completed.returncode != 0:
-            summary["notes"].append("Delegate script returned a non-zero exit code.")
 
     emit_summary(summary, args.summary_json)
     delegate_report_sidecar.unlink(missing_ok=True)

--- a/tests/test_pdf_to_excel_ocr_inbox_runner.py
+++ b/tests/test_pdf_to_excel_ocr_inbox_runner.py
@@ -240,6 +240,155 @@ class PdfToExcelOcrInboxRunnerTests(unittest.TestCase):
         self.assertTrue(summary["output"]["exists"])
         self.assertEqual(summary["execution"]["delegate_report_source"], "sidecar")
 
+    def test_preserves_delegate_partial_without_output_when_exit_zero(self) -> None:
+        input_dir = self._make_input_dir(with_pdf=True)
+        fake_base = self.tmpdir / "fake_pdf_to_excel_ocr_partial_without_output.py"
+        fake_base.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env python3
+                import argparse
+                import json
+                from pathlib import Path
+
+                parser = argparse.ArgumentParser()
+                parser.add_argument("--input-dir", required=True)
+                parser.add_argument("--output-xlsx", required=True)
+                parser.add_argument("--ocr", default="auto")
+                parser.add_argument("--report-json", default="")
+                args = parser.parse_args()
+
+                payload = {
+                    "status": "partial",
+                    "total_files": 0,
+                    "status_counter": {},
+                    "dry_run": False,
+                    "extraction_status": "none",
+                    "export_status": "skipped_no_input",
+                    "excel_written": False,
+                    "output_exists": False,
+                    "output_size_bytes": 0,
+                    "notes": ["No PDFs were available to process."],
+                }
+                if args.report_json:
+                    Path(args.report_json).write_text(json.dumps(payload), encoding="utf-8")
+                print(json.dumps(payload))
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        exit_code, summary, _ = self._invoke_main(
+            input_dir=input_dir,
+            extra_args=["--preferred-base-script", str(fake_base)],
+            reviewed_base_script=fake_base,
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(summary["status"], "partial")
+        self.assertFalse(summary["output"]["exists"])
+        self.assertEqual(summary["execution"]["returncode"], 0)
+        self.assertTrue(any("without XLSX artifact" in note for note in summary["notes"]))
+
+    def test_nonzero_delegate_exit_hard_fails_even_with_structured_json(self) -> None:
+        input_dir = self._make_input_dir(with_pdf=True)
+        fake_base = self.tmpdir / "fake_pdf_to_excel_ocr_nonzero_with_json.py"
+        fake_base.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env python3
+                import argparse
+                import json
+                import sys
+                from pathlib import Path
+
+                parser = argparse.ArgumentParser()
+                parser.add_argument("--input-dir", required=True)
+                parser.add_argument("--output-xlsx", required=True)
+                parser.add_argument("--ocr", default="auto")
+                parser.add_argument("--report-json", default="")
+                args = parser.parse_args()
+
+                payload = {
+                    "status": "partial",
+                    "total_files": 1,
+                    "dry_run": False,
+                    "excel_written": False,
+                    "output_exists": False,
+                    "output_size_bytes": 0,
+                }
+                if args.report_json:
+                    Path(args.report_json).write_text(json.dumps(payload), encoding="utf-8")
+                print(json.dumps(payload))
+                sys.exit(7)
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        exit_code, summary, _ = self._invoke_main(
+            input_dir=input_dir,
+            extra_args=["--preferred-base-script", str(fake_base)],
+            reviewed_base_script=fake_base,
+        )
+
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(summary["status"], "failed")
+        self.assertEqual(summary["execution"]["returncode"], 7)
+        self.assertTrue(any("hard failure" in note for note in summary["notes"]))
+
+    def test_preserves_stdout_stderr_diagnostics_in_summary(self) -> None:
+        input_dir = self._make_input_dir(with_pdf=True)
+        fake_base = self.tmpdir / "fake_pdf_to_excel_ocr_diagnostics.py"
+        fake_base.write_text(
+            textwrap.dedent(
+                """\
+                #!/usr/bin/env python3
+                import argparse
+                import json
+                import sys
+                from pathlib import Path
+
+                parser = argparse.ArgumentParser()
+                parser.add_argument("--input-dir", required=True)
+                parser.add_argument("--output-xlsx", required=True)
+                parser.add_argument("--ocr", default="auto")
+                parser.add_argument("--report-json", default="")
+                args = parser.parse_args()
+
+                payload = {
+                    "status": "partial",
+                    "total_files": 1,
+                    "dry_run": False,
+                    "excel_written": False,
+                    "output_exists": False,
+                    "output_size_bytes": 0,
+                }
+                if args.report_json:
+                    Path(args.report_json).write_text(json.dumps(payload), encoding="utf-8")
+                print("diagnostic: delegate stdout line")
+                print(json.dumps(payload))
+                print("diagnostic: delegate stderr line", file=sys.stderr)
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        exit_code, summary, _ = self._invoke_main(
+            input_dir=input_dir,
+            extra_args=["--preferred-base-script", str(fake_base)],
+            reviewed_base_script=fake_base,
+        )
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(summary["status"], "partial")
+        self.assertTrue(summary["execution"]["stdout_present"])
+        self.assertTrue(summary["execution"]["stderr_present"])
+        self.assertGreaterEqual(summary["execution"]["stdout_line_count"], 2)
+        self.assertGreaterEqual(summary["execution"]["stderr_line_count"], 1)
+        self.assertIn("delegate stderr line", summary["execution"]["stderr_excerpt"])
+        self.assertTrue(any("captured and preserved in execution diagnostics" in note for note in summary["notes"]))
+
     def test_sidecar_report_is_canonical_when_stdout_diverges(self) -> None:
         input_dir = self._make_input_dir(with_pdf=True)
         fake_base = self.tmpdir / "fake_pdf_to_excel_ocr_sidecar_priority.py"


### PR DESCRIPTION
## Summary
- harden wrapper/delegate non-zero exit handling as strict hard-failure semantics
- preserve delegate `partial` semantics even when no XLSX artifact is produced on zero exit
- add structured stdout/stderr diagnostics completeness fields in wrapper summary
- add focused regressions in `tests/test_pdf_to_excel_ocr_inbox_runner.py`
- mark `BL-20260325-066` done and queue `BL-20260325-067` as planned/next

## Validation
- python3 -m unittest -v tests/test_pdf_to_excel_ocr_inbox_runner.py
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh

Closes #125
