### PR TITLE
BL-067: validate execution-outcome/diagnostic contract hardening

### DIFF
--- a/POST_WRAPPER_DELEGATE_EXECUTION_OUTCOME_DIAGNOSTIC_CONTRACT_VALIDATION_REPORT.md
+++ b/POST_WRAPPER_DELEGATE_EXECUTION_OUTCOME_DIAGNOSTIC_CONTRACT_VALIDATION_REPORT.md
@@ -1,0 +1,169 @@
+# Post-Execution-Outcome + Diagnostics Contract Validation Report
+
+## Objective
+
+Validate `BL-20260325-066` on one fresh same-origin governed candidate by
+running:
+
+- one live Trello read-only smoke
+- one explicit same-origin regeneration
+- one preview creation
+- one explicit approval
+- one real execute (`test_mode=off`)
+
+This phase objective is validation truth, not forcing a `pass` verdict.
+
+## Scope
+
+In scope:
+
+- one governed run against origin `trello:69c24cd3c1a2359ddd7a1bf8`
+- one regeneration token and one fresh preview candidate
+- runtime evidence capture for automation/critic progression
+- explicit recording of whether critic findings moved away from BL-066 target
+  gaps (wrapper/delegate execution outcome semantics and diagnostics
+  completeness)
+
+Out of scope:
+
+- source-code hardening in this validation phase
+- git finalization and Trello Done writeback
+- additional live reruns beyond this governed candidate
+
+## Pre-Run Checks
+
+- branch: `phase9r/validate-bl067-execution-outcome-diagnostic-contract`
+- Trello env loaded from `/tmp/trello_env.sh`
+- runtime LLM env configured in `/tmp/trello_env.sh`:
+  - `OPENAI_API_BASE=https://aixj.vip/v1`
+  - `OPENAI_MODEL_NAME=gpt-5-codex` (and one replay with
+    `OPENAI_MODEL_NAME=gpt-5.3-codex`)
+
+## Run Summary
+
+Target origin:
+
+- `trello:69c24cd3c1a2359ddd7a1bf8`
+
+Regeneration token:
+
+- `regen-20260325-bl067-001`
+
+### 1) Live Trello read-only smoke
+
+First sandboxed read:
+
+- blocked by DNS / sandbox network policy
+- error: `ConnectionError` / `NameResolutionError`
+- archive snapshot:
+  - `runtime_archives/bl067/tmp/bl067_smoke_sandbox.json`
+
+Elevated rerun:
+
+- `status = pass`
+- `read_count = 1`
+- archive snapshots:
+  - `runtime_archives/bl067/tmp/bl067_smoke_elevated.json`
+  - `runtime_archives/bl067/tmp/bl067_live_mapped_preview.json`
+
+### 2) Regenerated payload and preview ingest
+
+- generated inbox payload from elevated `smoke_read.mapped_preview` with token
+  `regen-20260325-bl067-001`
+- ingest decision:
+  - `status = processed`
+  - `decision = preview_created_pending_approval`
+  - `preview_id = preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153`
+- archive snapshot:
+  - `runtime_archives/bl067/tmp/bl067_ingest_once.json`
+
+### 3) Preview candidate and approval
+
+Generated preview:
+
+- `preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153`
+
+Pre-execute state:
+
+- `approved = false`
+- `execution.status = pending_approval`
+- `execution.executed = false`
+- `execution.attempts = 0`
+- `source.regeneration_token = regen-20260325-bl067-001`
+
+Approval file:
+
+- `approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153.json`
+
+### 4) Real execute (`test_mode=off`)
+
+First sandboxed execute:
+
+- rejected before worker dispatch
+- reason:
+  `Failed to initialize docker client from environment. Ensure Docker access is available or pass docker_client explicitly.`
+- archive snapshot:
+  - `runtime_archives/bl067/tmp/bl067_execute_once_sandbox.json`
+
+Elevated replay execute (`--preview-id ... --allow-replay`):
+
+- automation task created:
+  - `AUTO-20260325-874`
+- no critic task dispatched (automation failed before critic handoff)
+- final execute decision:
+  - `status = rejected`
+  - `decision_reason` includes automation failure
+- replay evidence snapshots:
+  - `runtime_archives/bl067/tmp/bl067_execute_once_elevated.json`
+    - first elevated replay failed due missing API key in runtime env
+  - `runtime_archives/bl067/tmp/bl067_execute_once_elevated_keyed.json`
+    - replay with key failed `http_400` at `https://aixj.vip/v1/chat/completions`
+  - `runtime_archives/bl067/tmp/bl067_execute_once_elevated_keyed_model53.json`
+    - replay with `OPENAI_MODEL_NAME=gpt-5.3-codex` still failed `http_400`
+- runtime snapshots:
+  - `runtime_archives/bl067/runtime/AUTO-20260325-874.json`
+  - `runtime_archives/bl067/runtime/automation-output.json`
+  - `runtime_archives/bl067/runtime/automation-runtime.attempt-1.log`
+
+Final preview execution state:
+
+- `approved = true`
+- `execution.status = rejected`
+- `execution.executed = true`
+- `execution.attempts = 4`
+
+## Critical Findings
+
+This validation did not reach critic review, so BL-066 target concerns cannot be
+runtime-verified in this run.
+
+Observed blocker class in this run:
+
+- runtime endpoint/protocol compatibility failure at automation stage:
+  - `LLM call exhausted (attempts=1/3, class=http_400, endpoint=https://aixj.vip/v1/chat/completions, retryable=False)`
+- because automation failed before script artifact generation:
+  - critic was not dispatched
+  - no new critic verdict exists for BL-066 target findings
+
+Inference from this run:
+
+- BL-066 source hardening remains unchallenged by critic in this governed run
+- next blocker class is runtime endpoint/protocol/model compatibility
+  alignment for automation worker execution
+
+## Validation Conclusion
+
+`BL-20260325-067` is complete as a governed validation phase.
+
+It answers the intended question with runtime evidence: this run is blocked
+before critic handoff by automation endpoint compatibility (`http_400`), so the
+BL-066 target finding shift remains unverified in runtime and requires an
+infrastructure/configuration blocker to be closed first.
+
+## Archive Preservation
+
+This phase archived outputs under:
+
+- `runtime_archives/bl067/runtime/`
+- `runtime_archives/bl067/state/`
+- `runtime_archives/bl067/tmp/`

--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -1183,8 +1183,8 @@ Allowed enum values:
 ### BL-20260325-067
 - title: Validate BL-20260325-066 execution outcome-contract and diagnostics hardening on a fresh same-origin governed candidate
 - type: mainline
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-066
@@ -1192,6 +1192,23 @@ Allowed enum values:
 - done_when: One governed validation run (smoke -> regeneration -> preview -> approval -> real execute) records whether critic findings no longer cite wrapper non-zero/partial semantics mismatches and diagnostics completeness gaps
 - source: `WRAPPER_DELEGATE_EXECUTION_OUTCOME_DIAGNOSTIC_CONTRACT_HARDENING_REPORT.md` on 2026-03-25 concludes the next required step is fresh governed runtime validation
 - link: /Users/lingguozhong/openclaw-team/POST_WRAPPER_DELEGATE_EXECUTION_OUTCOME_DIAGNOSTIC_CONTRACT_VALIDATION_REPORT.md
+- issue: https://github.com/Oscarling/openclaw-team/issues/127
+- evidence: `POST_WRAPPER_DELEGATE_EXECUTION_OUTCOME_DIAGNOSTIC_CONTRACT_VALIDATION_REPORT.md` records one fresh same-origin governed run (`regen-20260325-bl067-001`) to preview `preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153`; execution remained `rejected` because automation (`AUTO-20260325-874`) failed before critic dispatch with endpoint compatibility `http_400` at `https://aixj.vip/v1/chat/completions`, so BL-066 target finding shift stayed runtime-unverified
+- last_reviewed_at: 2026-03-25
+- opened_at: 2026-03-25
+
+### BL-20260325-068
+- title: Harden automation runtime endpoint/protocol compatibility for provider-backed LLM execution after BL-067 failures
+- type: blocker
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260325-067
+- start_when: `BL-20260325-067` confirms governed execution is blocked before critic handoff by provider endpoint compatibility failures (`http_400`) in automation runtime
+- done_when: Runtime/config hardening ensures automation worker can complete one real LLM call against declared provider settings (base URL + protocol + model mapping) without `http_400` contract mismatch, with focused tests and one blocker report
+- source: `POST_WRAPPER_DELEGATE_EXECUTION_OUTCOME_DIAGNOSTIC_CONTRACT_VALIDATION_REPORT.md` on 2026-03-25 records endpoint/protocol/model compatibility as the next blocker class
+- link: /Users/lingguozhong/openclaw-team/AUTOMATION_RUNTIME_ENDPOINT_PROTOCOL_COMPATIBILITY_HARDENING_REPORT.md
 - issue: -
 - evidence: -
 - last_reviewed_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -3849,3 +3849,66 @@ Verification snapshot on 2026-03-25:
   passed (`18/18`)
 - `python3 scripts/backlog_lint.py` passed
 - `python3 scripts/backlog_sync.py` passed
+
+### 76. Fresh Governed Validation After BL-066 Execution-Outcome + Diagnostics Hardening
+
+User objective:
+
+- continue strict backlog mainline without drift
+- validate BL-066 hardening on one fresh same-origin governed candidate
+
+Main work areas:
+
+- activated `BL-20260325-067` and mirrored it to issue `#127`
+- executed governed validation pipeline with token
+  `regen-20260325-bl067-001`:
+  - sandbox Trello smoke (captured network-policy block evidence)
+  - elevated Trello smoke (live pass + mapped preview)
+  - generated regeneration payload and ingest once -> fresh preview
+    `preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153`
+  - explicit approval write
+  - sandbox execute (captured Docker init block evidence)
+  - elevated replay execution attempts to unblock runtime:
+    - initial replay failed due missing runtime API key wiring
+    - replay with provider env (`OPENAI_API_BASE=https://aixj.vip/v1`)
+      reached automation but failed `http_400`
+    - replay with `OPENAI_MODEL_NAME=gpt-5.3-codex` still failed `http_400`
+- captured and archived runtime evidence:
+  - automation task failed (`AUTO-20260325-874`)
+  - critic was not dispatched (automation failed before handoff)
+  - final execute remained `rejected`
+- produced validation report and queued next blocker phase
+  (`BL-20260325-068`)
+
+Primary output:
+
+- [POST_WRAPPER_DELEGATE_EXECUTION_OUTCOME_DIAGNOSTIC_CONTRACT_VALIDATION_REPORT.md](/Users/lingguozhong/openclaw-team/POST_WRAPPER_DELEGATE_EXECUTION_OUTCOME_DIAGNOSTIC_CONTRACT_VALIDATION_REPORT.md)
+
+Key result:
+
+- `BL-20260325-067` is complete as a governed validation phase
+- this run did not reach critic, so BL-066 target finding shift remains
+  runtime-unverified
+- dominant blocker shifted to runtime endpoint/protocol/model compatibility for
+  automation worker execution (`BL-20260325-068`)
+
+Verification snapshot on 2026-03-25:
+
+- `python3 scripts/backlog_lint.py` passed after BL-067 activation
+- `python3 scripts/backlog_sync.py` passed with BL-067 issue mirror to `#127`
+- sandbox smoke evidence captured as blocked (`ConnectionError` /
+  `NameResolutionError`)
+- elevated smoke passed with `read_count = 1`
+- `python3 skills/ingest_tasks.py --once --test-mode success` returned:
+  - `processed = 1`
+  - `duplicate_skipped = 0`
+  - `preview_created = 1`
+- elevated execute replay returned:
+  - `status = rejected`
+  - automation error class: `http_400`
+  - endpoint: `https://aixj.vip/v1/chat/completions`
+- final preview state:
+  - `approved = true`
+  - `execution.status = rejected`
+  - `execution.executed = true`
+  - `execution.attempts = 4`

--- a/runtime_archives/bl067/runtime/AUTO-20260325-874.json
+++ b/runtime_archives/bl067/runtime/AUTO-20260325-874.json
@@ -1,0 +1,189 @@
+{
+  "task_id": "AUTO-20260325-874",
+  "worker": "automation",
+  "status": "failed",
+  "created_at": "2026-03-25T12:10:53.687369Z",
+  "updated_at": "2026-03-25T12:10:54.629309Z",
+  "retries": 0,
+  "max_retries": 0,
+  "attempts": [
+    {
+      "attempt": 1,
+      "status": "failed",
+      "retryable": false,
+      "error": "LLM call exhausted (attempts=1/3, class=http_400, endpoint=https://aixj.vip/v1/chat/completions, retryable=False): HTTP Error 400: Bad Request",
+      "runtime_log": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-874/runtime.attempt-1.log",
+      "exit_code": 0,
+      "timed_out": false,
+      "wait_error": null,
+      "output_path": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-874/output.json",
+      "started_at": "2026-03-25T12:10:53.688378Z",
+      "finished_at": "2026-03-25T12:10:54.603729Z"
+    }
+  ],
+  "task_dir": "/Users/lingguozhong/openclaw-team/workspaces/automation/AUTO-20260325-874",
+  "payload": {
+    "task_id": "AUTO-20260325-874",
+    "worker": "automation",
+    "task_type": "generate_script",
+    "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+    "inputs": {
+      "params": {
+        "input_dir": "~/Desktop/pdf样本",
+        "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+        "ocr": "auto",
+        "dry_run": false,
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "description": "Purpose: | Controlled Trello live preview smoke for openclaw-team. | Expected behavior: | - read-only Trello ingest | - preview creation smoke only | - no business execution claim | - no Trello writeback expected in this step | Traceability: | - backlog: BL-20260324-014 | - blocker context: BL-20260324-015 | - created_by: Oscarling | - created_at: 2026-03-24 Asia/Shanghai | Note: | This card is only for governed smoke verification and should remain open until the smoke is finished.",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "preferred_wrapper_script": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "preferred_base_script": "artifacts/scripts/pdf_to_excel_ocr.py",
+        "reference_docs": [
+          "artifacts/docs/pdf_to_excel_ocr_usage.md",
+          "artifacts/reviews/pdf_to_excel_ocr_review.md"
+        ],
+        "contract_hints": {
+          "output_format_fidelity": "If output_xlsx ends with .xlsx, produce a real XLSX workbook container or fail honestly before writing mismatched text/XML/CSV content to a .xlsx path.",
+          "path_portability": "Use the provided input_dir parameter as runtime input. Do not hardcode a user-home or absolute input path when params already declare the path.",
+          "traceability": "Preserve meaningful description context from the external input; do not collapse it to a heading fragment such as Purpose:.",
+          "reuse_preference": "Prefer reusing artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py as the wrapper baseline and artifacts/scripts/pdf_to_excel_ocr.py as the reviewed delegate when compatible, so workbook semantics and contract behavior stay aligned with repository evidence.",
+          "outcome_status_model": "Use the reviewable status model success/partial/failed. Dry-run requests or zero-PDF discovery should resolve to partial rather than claiming success without an output artifact.",
+          "delegate_resolution": "If preferred_base_script is relative, resolve it from the repository or script location instead of Path.cwd() so behavior stays portable across shells and CI.",
+          "reviewed_delegate_contract": "For readonly reviewable preview flows, delegate only to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py or fail honestly instead of broadening behavior through an arbitrary helper.",
+          "delegate_success_evidence": "Do not treat zero exit code plus output-file existence as sufficient wrapper success evidence on their own. Prefer a structured delegate report that confirms a real success outcome before the wrapper claims success. Require delegate status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, and explicit output attestation fields excel_written=true, output_exists=true, and output_size_bytes>0. Apply these gates only when wrapper status is success.",
+          "delegate_partial_evidence": "For best-effort readonly flows, if delegate status is partial and structured evidence is present, keep wrapper status partial instead of escalating to failed solely because success-only gates are unmet. Surface explicit limitations and next-step guidance in wrapper output.",
+          "delegate_timeout": "Bound delegate subprocess execution with an explicit timeout and report timeout as an honest failed/partial outcome instead of allowing smoke automation to hang indefinitely.",
+          "readonly_semantics": "Readonly semantics must be explicit: no external/Trello writeback is required, but local filesystem output writes may still occur when dry_run=false. Runtime summary fields must not overstate readonly scope.",
+          "ocr_sufficiency": "When OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial, do not claim wrapper success even if an output file exists; keep partial status with explicit OCR sufficiency notes.",
+          "runtime_summary": "The generated script should emit a structured summary of what it produced so later review can inspect behavior without guessing.",
+          "delegate_report_schema": "Treat delegate JSON report fields status/total_files/status_counter/dry_run as the canonical evidence contract. Do not require undeclared processed_files/succeeded_files/failed_files counters.",
+          "delegate_report_handoff": "When a sidecar report file is available, treat it as canonical evidence. Use stdout JSON parsing only as fallback when sidecar evidence is missing.",
+          "delegate_report_flag_contract": "If wrapper passes a sidecar report path to the reviewed delegate, use the reviewed delegate CLI flag --report-json (or another explicitly supported alias). Do not invent undeclared flags such as --report-file.",
+          "dry_run_semantics": "For readonly governed flows, do not short-circuit dry-run before delegate execution. Delegate under dry-run and pass through --dry-run explicitly so wrapper/delegate semantics remain aligned.",
+          "pdf_discovery_consistency": "Keep wrapper preflight PDF discovery semantics aligned with the reviewed delegate (for example recursive vs non-recursive), so wrapper evidence and delegated execution count the same candidate set."
+        }
+      }
+    },
+    "expected_outputs": [
+      {
+        "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+        "type": "script"
+      }
+    ],
+    "constraints": [
+      "Follow the local inbox normalized request",
+      "Do not claim unsupported runtime dependencies",
+      "Keep output deterministic and executable",
+      "Produce only the expected script artifact",
+      "Prefer honest, reviewable intermediate behavior over unsupported OCR claims",
+      "If the requested output path ends with .xlsx, do not write non-XLSX text/XML/CSV content to that path.",
+      "Do not hardcode an input directory when the task params already provide input_dir.",
+      "Preserve meaningful traceability from the incoming description instead of collapsing it to a heading fragment.",
+      "Prefer wrapping or adapting artifacts/scripts/pdf_to_excel_ocr.py when that existing repo script already matches the requested behavior.",
+      "When artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py already exists, prefer updating that reviewed wrapper baseline instead of rewriting a new control flow from scratch.",
+      "If dry_run is true or no PDFs are discovered, report a reviewable partial outcome instead of claiming success without an XLSX artifact.",
+      "Resolve relative delegate script paths from the repository or script location, not from Path.cwd().",
+      "For readonly reviewable preview flows, only delegate to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py unless failing honestly.",
+      "Do not claim wrapper success from exit code plus output existence alone when the reviewed delegate report does not provide strong enough success evidence.",
+      "When wrapper reports success, enforce delegate evidence gates: status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, excel_written=true, output_exists=true, and output_size_bytes>0.",
+      "If delegate reports partial with structured evidence in readonly best-effort mode, keep wrapper status partial (not failed) and include explicit limitations with next-step guidance.",
+      "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
+      "When a delegate sidecar report is present, treat sidecar JSON as canonical evidence and use stdout JSON only as fallback.",
+      "When wrapper passes a sidecar report path to the reviewed delegate, use --report-json exactly unless the reviewed delegate explicitly supports another alias.",
+      "For readonly governed flows, do not short-circuit dry-run before delegate execution; pass --dry-run through delegate and preserve partial status honestly.",
+      "Keep wrapper PDF discovery semantics aligned with reviewed delegate discovery semantics to avoid preflight/execution evidence drift.",
+      "Readonly semantics must be explicit as no external writeback; avoid claiming strict filesystem readonly when dry_run=false can write local outputs.",
+      "When OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial, keep wrapper status partial and surface OCR sufficiency limitations.",
+      "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely."
+    ],
+    "priority": "medium",
+    "source": {
+      "kind": "local_inbox",
+      "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+      "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl067-001.json",
+      "received_at": "2026-03-25T11:45:58.529105Z",
+      "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "provider": "trello",
+      "mode": "readonly",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "regeneration_token": "regen-20260325-bl067-001"
+    },
+    "acceptance_criteria": [
+      "Produce the expected script artifact at expected_outputs[0].path",
+      "Script behavior remains runnable, deterministic, and reviewable",
+      "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
+      "Artifact behavior remains parameter-driven for input_dir and output_xlsx rather than hardcoding unrelated local defaults.",
+      "Dry-run or zero-input behavior is represented as a reviewable partial outcome instead of artifact-production success.",
+      "Relative preferred_base_script resolution remains portable and does not depend on Path.cwd().",
+      "Wrapper success requires stronger delegate evidence than zero exit code plus a non-empty output file alone.",
+      "Wrapper success attestation requires delegate fields excel_written=true, output_exists=true, output_size_bytes>0, and status_counter.partial/status_counter.failed equal to 0.",
+      "Contract-compliant delegate partial outcomes remain partial with explicit limitations and next-step guidance, rather than being escalated to failed by success-only gates.",
+      "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
+      "Delegate report handoff prefers sidecar JSON as canonical evidence and only falls back to stdout JSON when sidecar evidence is unavailable.",
+      "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",
+      "Dry-run semantics remain explicit and delegated for readonly governed flows: pass --dry-run through delegate and preserve partial outcome honestly.",
+      "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
+      "Readonly semantics are explicit as no external writeback, and runtime summary wording does not overclaim strict filesystem readonly when dry_run=false.",
+      "Wrapper success is conservative when OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial.",
+      "Delegate execution is bounded by an explicit timeout and reports timeout honestly."
+    ],
+    "metadata": {
+      "integration_phase": "8B",
+      "pipeline": "inbox->adapter->manager->automation->critic",
+      "request_type": "pdf_to_excel_ocr",
+      "payload_hash": "687ebc83a15301413ccf4c39574ace2121af2e87e87563fbd3bb18ec8ef8d7ad",
+      "regeneration_token": "regen-20260325-bl067-001",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "external_metadata": {
+        "source_system": "trello",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "card_short_id": 7,
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "date_last_activity": "2026-03-24T08:35:56.234Z",
+        "readonly_mapped_at": "2026-03-25T11:45:32.575060Z",
+        "contract_profile": "best_effort_evidence_backed",
+        "ocr_claim_policy": "do_not_claim_success_without_evidence",
+        "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+        "regeneration_token": "regen-20260325-bl067-001"
+      },
+      "automation_contract_profile": "narrow_script_artifact_with_repo_reuse_and_reviewable_runner_contract"
+    }
+  },
+  "result": {
+    "task_id": "AUTO-20260325-874",
+    "worker": "automation",
+    "status": "failed",
+    "summary": "Worker execution failed",
+    "artifacts": [],
+    "errors": [
+      "LLM call exhausted (attempts=1/3, class=http_400, endpoint=https://aixj.vip/v1/chat/completions, retryable=False): HTTP Error 400: Bad Request"
+    ],
+    "metadata": {},
+    "duration_ms": 537,
+    "timestamp": "2026-03-25T12:10:54.491158Z"
+  },
+  "error": "LLM call exhausted (attempts=1/3, class=http_400, endpoint=https://aixj.vip/v1/chat/completions, retryable=False): HTTP Error 400: Bad Request"
+}

--- a/runtime_archives/bl067/runtime/automation-output.json
+++ b/runtime_archives/bl067/runtime/automation-output.json
@@ -1,0 +1,13 @@
+{
+  "task_id": "AUTO-20260325-874",
+  "worker": "automation",
+  "status": "failed",
+  "summary": "Worker execution failed",
+  "artifacts": [],
+  "errors": [
+    "LLM call exhausted (attempts=1/3, class=http_400, endpoint=https://aixj.vip/v1/chat/completions, retryable=False): HTTP Error 400: Bad Request"
+  ],
+  "metadata": {},
+  "duration_ms": 537,
+  "timestamp": "2026-03-25T12:10:54.491158Z"
+}

--- a/runtime_archives/bl067/runtime/automation-runtime.attempt-1.log
+++ b/runtime_archives/bl067/runtime/automation-runtime.attempt-1.log
@@ -1,0 +1,19 @@
+task_id: AUTO-20260325-874
+worker: automation
+attempt: 1
+container_name: argus-automation-auto-20260325-874
+worker_image: argus-worker:latest
+started_at: 2026-03-25T12:10:53.688378Z
+finished_at: 2026-03-25T12:10:54.603729Z
+exit_code: 0
+timed_out: False
+wait_error: 
+
+=== stdout ===
+[2026-03-25T12:10:53.953870Z] [automation] [INFO] Worker started using endpoint https://aixj.vip/v1/chat/completions (timeout=120s, attempts=3, timeout_recovery_retries=1)
+[2026-03-25T12:10:54.490152Z] [automation] [WARN] LLM call failed attempt 1/3 (endpoint=https://aixj.vip/v1/chat/completions, class=http_400, retryable=False): HTTP Error 400: Bad Request
+[2026-03-25T12:10:54.490305Z] [automation] [ERROR] Task failed AUTO-20260325-874: LLM call exhausted (attempts=1/3, class=http_400, endpoint=https://aixj.vip/v1/chat/completions, retryable=False): HTTP Error 400: Bad Request
+[2026-03-25T12:10:54.494993Z] [automation] [INFO] Worker exiting from /app/workspaces/automation/AUTO-20260325-874
+
+=== stderr ===
+

--- a/runtime_archives/bl067/runtime/automation-task.json
+++ b/runtime_archives/bl067/runtime/automation-task.json
@@ -1,0 +1,150 @@
+{
+  "task_id": "AUTO-20260325-874",
+  "worker": "automation",
+  "task_type": "generate_script",
+  "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+  "inputs": {
+    "params": {
+      "input_dir": "~/Desktop/pdf样本",
+      "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+      "ocr": "auto",
+      "dry_run": false,
+      "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+      "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+      "description": "Purpose: | Controlled Trello live preview smoke for openclaw-team. | Expected behavior: | - read-only Trello ingest | - preview creation smoke only | - no business execution claim | - no Trello writeback expected in this step | Traceability: | - backlog: BL-20260324-014 | - blocker context: BL-20260324-015 | - created_by: Oscarling | - created_at: 2026-03-24 Asia/Shanghai | Note: | This card is only for governed smoke verification and should remain open until the smoke is finished.",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "preferred_wrapper_script": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+      "preferred_base_script": "artifacts/scripts/pdf_to_excel_ocr.py",
+      "reference_docs": [
+        "artifacts/docs/pdf_to_excel_ocr_usage.md",
+        "artifacts/reviews/pdf_to_excel_ocr_review.md"
+      ],
+      "contract_hints": {
+        "output_format_fidelity": "If output_xlsx ends with .xlsx, produce a real XLSX workbook container or fail honestly before writing mismatched text/XML/CSV content to a .xlsx path.",
+        "path_portability": "Use the provided input_dir parameter as runtime input. Do not hardcode a user-home or absolute input path when params already declare the path.",
+        "traceability": "Preserve meaningful description context from the external input; do not collapse it to a heading fragment such as Purpose:.",
+        "reuse_preference": "Prefer reusing artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py as the wrapper baseline and artifacts/scripts/pdf_to_excel_ocr.py as the reviewed delegate when compatible, so workbook semantics and contract behavior stay aligned with repository evidence.",
+        "outcome_status_model": "Use the reviewable status model success/partial/failed. Dry-run requests or zero-PDF discovery should resolve to partial rather than claiming success without an output artifact.",
+        "delegate_resolution": "If preferred_base_script is relative, resolve it from the repository or script location instead of Path.cwd() so behavior stays portable across shells and CI.",
+        "reviewed_delegate_contract": "For readonly reviewable preview flows, delegate only to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py or fail honestly instead of broadening behavior through an arbitrary helper.",
+        "delegate_success_evidence": "Do not treat zero exit code plus output-file existence as sufficient wrapper success evidence on their own. Prefer a structured delegate report that confirms a real success outcome before the wrapper claims success. Require delegate status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, and explicit output attestation fields excel_written=true, output_exists=true, and output_size_bytes>0. Apply these gates only when wrapper status is success.",
+        "delegate_partial_evidence": "For best-effort readonly flows, if delegate status is partial and structured evidence is present, keep wrapper status partial instead of escalating to failed solely because success-only gates are unmet. Surface explicit limitations and next-step guidance in wrapper output.",
+        "delegate_timeout": "Bound delegate subprocess execution with an explicit timeout and report timeout as an honest failed/partial outcome instead of allowing smoke automation to hang indefinitely.",
+        "readonly_semantics": "Readonly semantics must be explicit: no external/Trello writeback is required, but local filesystem output writes may still occur when dry_run=false. Runtime summary fields must not overstate readonly scope.",
+        "ocr_sufficiency": "When OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial, do not claim wrapper success even if an output file exists; keep partial status with explicit OCR sufficiency notes.",
+        "runtime_summary": "The generated script should emit a structured summary of what it produced so later review can inspect behavior without guessing.",
+        "delegate_report_schema": "Treat delegate JSON report fields status/total_files/status_counter/dry_run as the canonical evidence contract. Do not require undeclared processed_files/succeeded_files/failed_files counters.",
+        "delegate_report_handoff": "When a sidecar report file is available, treat it as canonical evidence. Use stdout JSON parsing only as fallback when sidecar evidence is missing.",
+        "delegate_report_flag_contract": "If wrapper passes a sidecar report path to the reviewed delegate, use the reviewed delegate CLI flag --report-json (or another explicitly supported alias). Do not invent undeclared flags such as --report-file.",
+        "dry_run_semantics": "For readonly governed flows, do not short-circuit dry-run before delegate execution. Delegate under dry-run and pass through --dry-run explicitly so wrapper/delegate semantics remain aligned.",
+        "pdf_discovery_consistency": "Keep wrapper preflight PDF discovery semantics aligned with the reviewed delegate (for example recursive vs non-recursive), so wrapper evidence and delegated execution count the same candidate set."
+      }
+    }
+  },
+  "expected_outputs": [
+    {
+      "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+      "type": "script"
+    }
+  ],
+  "constraints": [
+    "Follow the local inbox normalized request",
+    "Do not claim unsupported runtime dependencies",
+    "Keep output deterministic and executable",
+    "Produce only the expected script artifact",
+    "Prefer honest, reviewable intermediate behavior over unsupported OCR claims",
+    "If the requested output path ends with .xlsx, do not write non-XLSX text/XML/CSV content to that path.",
+    "Do not hardcode an input directory when the task params already provide input_dir.",
+    "Preserve meaningful traceability from the incoming description instead of collapsing it to a heading fragment.",
+    "Prefer wrapping or adapting artifacts/scripts/pdf_to_excel_ocr.py when that existing repo script already matches the requested behavior.",
+    "When artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py already exists, prefer updating that reviewed wrapper baseline instead of rewriting a new control flow from scratch.",
+    "If dry_run is true or no PDFs are discovered, report a reviewable partial outcome instead of claiming success without an XLSX artifact.",
+    "Resolve relative delegate script paths from the repository or script location, not from Path.cwd().",
+    "For readonly reviewable preview flows, only delegate to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py unless failing honestly.",
+    "Do not claim wrapper success from exit code plus output existence alone when the reviewed delegate report does not provide strong enough success evidence.",
+    "When wrapper reports success, enforce delegate evidence gates: status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, excel_written=true, output_exists=true, and output_size_bytes>0.",
+    "If delegate reports partial with structured evidence in readonly best-effort mode, keep wrapper status partial (not failed) and include explicit limitations with next-step guidance.",
+    "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
+    "When a delegate sidecar report is present, treat sidecar JSON as canonical evidence and use stdout JSON only as fallback.",
+    "When wrapper passes a sidecar report path to the reviewed delegate, use --report-json exactly unless the reviewed delegate explicitly supports another alias.",
+    "For readonly governed flows, do not short-circuit dry-run before delegate execution; pass --dry-run through delegate and preserve partial status honestly.",
+    "Keep wrapper PDF discovery semantics aligned with reviewed delegate discovery semantics to avoid preflight/execution evidence drift.",
+    "Readonly semantics must be explicit as no external writeback; avoid claiming strict filesystem readonly when dry_run=false can write local outputs.",
+    "When OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial, keep wrapper status partial and surface OCR sufficiency limitations.",
+    "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely."
+  ],
+  "priority": "medium",
+  "source": {
+    "kind": "local_inbox",
+    "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+    "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl067-001.json",
+    "received_at": "2026-03-25T11:45:58.529105Z",
+    "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+    "labels": [
+      "best_effort",
+      "evidence_backed",
+      "readonly",
+      "reviewable",
+      "trello"
+    ],
+    "provider": "trello",
+    "mode": "readonly",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "regeneration_token": "regen-20260325-bl067-001"
+  },
+  "acceptance_criteria": [
+    "Produce the expected script artifact at expected_outputs[0].path",
+    "Script behavior remains runnable, deterministic, and reviewable",
+    "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
+    "Artifact behavior remains parameter-driven for input_dir and output_xlsx rather than hardcoding unrelated local defaults.",
+    "Dry-run or zero-input behavior is represented as a reviewable partial outcome instead of artifact-production success.",
+    "Relative preferred_base_script resolution remains portable and does not depend on Path.cwd().",
+    "Wrapper success requires stronger delegate evidence than zero exit code plus a non-empty output file alone.",
+    "Wrapper success attestation requires delegate fields excel_written=true, output_exists=true, output_size_bytes>0, and status_counter.partial/status_counter.failed equal to 0.",
+    "Contract-compliant delegate partial outcomes remain partial with explicit limitations and next-step guidance, rather than being escalated to failed by success-only gates.",
+    "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
+    "Delegate report handoff prefers sidecar JSON as canonical evidence and only falls back to stdout JSON when sidecar evidence is unavailable.",
+    "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",
+    "Dry-run semantics remain explicit and delegated for readonly governed flows: pass --dry-run through delegate and preserve partial outcome honestly.",
+    "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
+    "Readonly semantics are explicit as no external writeback, and runtime summary wording does not overclaim strict filesystem readonly when dry_run=false.",
+    "Wrapper success is conservative when OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial.",
+    "Delegate execution is bounded by an explicit timeout and reports timeout honestly."
+  ],
+  "metadata": {
+    "integration_phase": "8B",
+    "pipeline": "inbox->adapter->manager->automation->critic",
+    "request_type": "pdf_to_excel_ocr",
+    "payload_hash": "687ebc83a15301413ccf4c39574ace2121af2e87e87563fbd3bb18ec8ef8d7ad",
+    "regeneration_token": "regen-20260325-bl067-001",
+    "labels": [
+      "best_effort",
+      "evidence_backed",
+      "readonly",
+      "reviewable",
+      "trello"
+    ],
+    "external_metadata": {
+      "source_system": "trello",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "card_short_id": 7,
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "date_last_activity": "2026-03-24T08:35:56.234Z",
+      "readonly_mapped_at": "2026-03-25T11:45:32.575060Z",
+      "contract_profile": "best_effort_evidence_backed",
+      "ocr_claim_policy": "do_not_claim_success_without_evidence",
+      "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+      "regeneration_token": "regen-20260325-bl067-001"
+    },
+    "automation_contract_profile": "narrow_script_artifact_with_repo_reuse_and_reviewable_runner_contract"
+  }
+}

--- a/runtime_archives/bl067/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153.json
+++ b/runtime_archives/bl067/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153.json
@@ -1,0 +1,364 @@
+{
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153",
+  "created_at": "2026-03-25T11:45:58.530873Z",
+  "approved": true,
+  "source": {
+    "kind": "local_inbox",
+    "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+    "received_at": "2026-03-25T11:45:58.529105Z",
+    "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl067-001.json",
+    "regeneration_token": "regen-20260325-bl067-001"
+  },
+  "external_input": {
+    "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+    "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+    "labels": [
+      "best_effort",
+      "evidence_backed",
+      "readonly",
+      "reviewable",
+      "trello"
+    ],
+    "metadata": {
+      "source_system": "trello",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "card_short_id": 7,
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "date_last_activity": "2026-03-24T08:35:56.234Z",
+      "readonly_mapped_at": "2026-03-25T11:45:32.575060Z",
+      "contract_profile": "best_effort_evidence_backed",
+      "ocr_claim_policy": "do_not_claim_success_without_evidence",
+      "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+      "regeneration_token": "regen-20260325-bl067-001"
+    },
+    "request_type": "pdf_to_excel_ocr",
+    "input": {
+      "input_dir": "~/Desktop/pdf样本",
+      "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+      "ocr": "auto",
+      "dry_run": false
+    }
+  },
+  "task_summary": {
+    "automation": {
+      "task_id": "AUTO-20260325-874",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+      "expected_outputs": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ]
+    },
+    "critic": {
+      "task_id": "CRITIC-20260325-290",
+      "worker": "critic",
+      "task_type": "review_artifact",
+      "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+      "expected_outputs": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ]
+    }
+  },
+  "internal_tasks": {
+    "automation": {
+      "task_id": "AUTO-20260325-874",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+      "inputs": {
+        "params": {
+          "input_dir": "~/Desktop/pdf样本",
+          "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+          "ocr": "auto",
+          "dry_run": false,
+          "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+          "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+          "description": "Purpose: | Controlled Trello live preview smoke for openclaw-team. | Expected behavior: | - read-only Trello ingest | - preview creation smoke only | - no business execution claim | - no Trello writeback expected in this step | Traceability: | - backlog: BL-20260324-014 | - blocker context: BL-20260324-015 | - created_by: Oscarling | - created_at: 2026-03-24 Asia/Shanghai | Note: | This card is only for governed smoke verification and should remain open until the smoke is finished.",
+          "labels": [
+            "best_effort",
+            "evidence_backed",
+            "readonly",
+            "reviewable",
+            "trello"
+          ],
+          "preferred_wrapper_script": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "preferred_base_script": "artifacts/scripts/pdf_to_excel_ocr.py",
+          "reference_docs": [
+            "artifacts/docs/pdf_to_excel_ocr_usage.md",
+            "artifacts/reviews/pdf_to_excel_ocr_review.md"
+          ],
+          "contract_hints": {
+            "output_format_fidelity": "If output_xlsx ends with .xlsx, produce a real XLSX workbook container or fail honestly before writing mismatched text/XML/CSV content to a .xlsx path.",
+            "path_portability": "Use the provided input_dir parameter as runtime input. Do not hardcode a user-home or absolute input path when params already declare the path.",
+            "traceability": "Preserve meaningful description context from the external input; do not collapse it to a heading fragment such as Purpose:.",
+            "reuse_preference": "Prefer reusing artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py as the wrapper baseline and artifacts/scripts/pdf_to_excel_ocr.py as the reviewed delegate when compatible, so workbook semantics and contract behavior stay aligned with repository evidence.",
+            "outcome_status_model": "Use the reviewable status model success/partial/failed. Dry-run requests or zero-PDF discovery should resolve to partial rather than claiming success without an output artifact.",
+            "delegate_resolution": "If preferred_base_script is relative, resolve it from the repository or script location instead of Path.cwd() so behavior stays portable across shells and CI.",
+            "reviewed_delegate_contract": "For readonly reviewable preview flows, delegate only to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py or fail honestly instead of broadening behavior through an arbitrary helper.",
+            "delegate_success_evidence": "Do not treat zero exit code plus output-file existence as sufficient wrapper success evidence on their own. Prefer a structured delegate report that confirms a real success outcome before the wrapper claims success. Require delegate status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, and explicit output attestation fields excel_written=true, output_exists=true, and output_size_bytes>0. Apply these gates only when wrapper status is success.",
+            "delegate_partial_evidence": "For best-effort readonly flows, if delegate status is partial and structured evidence is present, keep wrapper status partial instead of escalating to failed solely because success-only gates are unmet. Surface explicit limitations and next-step guidance in wrapper output.",
+            "delegate_timeout": "Bound delegate subprocess execution with an explicit timeout and report timeout as an honest failed/partial outcome instead of allowing smoke automation to hang indefinitely.",
+            "readonly_semantics": "Readonly semantics must be explicit: no external/Trello writeback is required, but local filesystem output writes may still occur when dry_run=false. Runtime summary fields must not overstate readonly scope.",
+            "ocr_sufficiency": "When OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial, do not claim wrapper success even if an output file exists; keep partial status with explicit OCR sufficiency notes.",
+            "runtime_summary": "The generated script should emit a structured summary of what it produced so later review can inspect behavior without guessing.",
+            "delegate_report_schema": "Treat delegate JSON report fields status/total_files/status_counter/dry_run as the canonical evidence contract. Do not require undeclared processed_files/succeeded_files/failed_files counters.",
+            "delegate_report_handoff": "When a sidecar report file is available, treat it as canonical evidence. Use stdout JSON parsing only as fallback when sidecar evidence is missing.",
+            "delegate_report_flag_contract": "If wrapper passes a sidecar report path to the reviewed delegate, use the reviewed delegate CLI flag --report-json (or another explicitly supported alias). Do not invent undeclared flags such as --report-file.",
+            "dry_run_semantics": "For readonly governed flows, do not short-circuit dry-run before delegate execution. Delegate under dry-run and pass through --dry-run explicitly so wrapper/delegate semantics remain aligned.",
+            "pdf_discovery_consistency": "Keep wrapper preflight PDF discovery semantics aligned with the reviewed delegate (for example recursive vs non-recursive), so wrapper evidence and delegated execution count the same candidate set."
+          }
+        }
+      },
+      "expected_outputs": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ],
+      "constraints": [
+        "Follow the local inbox normalized request",
+        "Do not claim unsupported runtime dependencies",
+        "Keep output deterministic and executable",
+        "Produce only the expected script artifact",
+        "Prefer honest, reviewable intermediate behavior over unsupported OCR claims",
+        "If the requested output path ends with .xlsx, do not write non-XLSX text/XML/CSV content to that path.",
+        "Do not hardcode an input directory when the task params already provide input_dir.",
+        "Preserve meaningful traceability from the incoming description instead of collapsing it to a heading fragment.",
+        "Prefer wrapping or adapting artifacts/scripts/pdf_to_excel_ocr.py when that existing repo script already matches the requested behavior.",
+        "When artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py already exists, prefer updating that reviewed wrapper baseline instead of rewriting a new control flow from scratch.",
+        "If dry_run is true or no PDFs are discovered, report a reviewable partial outcome instead of claiming success without an XLSX artifact.",
+        "Resolve relative delegate script paths from the repository or script location, not from Path.cwd().",
+        "For readonly reviewable preview flows, only delegate to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py unless failing honestly.",
+        "Do not claim wrapper success from exit code plus output existence alone when the reviewed delegate report does not provide strong enough success evidence.",
+        "When wrapper reports success, enforce delegate evidence gates: status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, excel_written=true, output_exists=true, and output_size_bytes>0.",
+        "If delegate reports partial with structured evidence in readonly best-effort mode, keep wrapper status partial (not failed) and include explicit limitations with next-step guidance.",
+        "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
+        "When a delegate sidecar report is present, treat sidecar JSON as canonical evidence and use stdout JSON only as fallback.",
+        "When wrapper passes a sidecar report path to the reviewed delegate, use --report-json exactly unless the reviewed delegate explicitly supports another alias.",
+        "For readonly governed flows, do not short-circuit dry-run before delegate execution; pass --dry-run through delegate and preserve partial status honestly.",
+        "Keep wrapper PDF discovery semantics aligned with reviewed delegate discovery semantics to avoid preflight/execution evidence drift.",
+        "Readonly semantics must be explicit as no external writeback; avoid claiming strict filesystem readonly when dry_run=false can write local outputs.",
+        "When OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial, keep wrapper status partial and surface OCR sufficiency limitations.",
+        "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely."
+      ],
+      "priority": "medium",
+      "source": {
+        "kind": "local_inbox",
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl067-001.json",
+        "received_at": "2026-03-25T11:45:58.529105Z",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "regeneration_token": "regen-20260325-bl067-001"
+      },
+      "acceptance_criteria": [
+        "Produce the expected script artifact at expected_outputs[0].path",
+        "Script behavior remains runnable, deterministic, and reviewable",
+        "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
+        "Artifact behavior remains parameter-driven for input_dir and output_xlsx rather than hardcoding unrelated local defaults.",
+        "Dry-run or zero-input behavior is represented as a reviewable partial outcome instead of artifact-production success.",
+        "Relative preferred_base_script resolution remains portable and does not depend on Path.cwd().",
+        "Wrapper success requires stronger delegate evidence than zero exit code plus a non-empty output file alone.",
+        "Wrapper success attestation requires delegate fields excel_written=true, output_exists=true, output_size_bytes>0, and status_counter.partial/status_counter.failed equal to 0.",
+        "Contract-compliant delegate partial outcomes remain partial with explicit limitations and next-step guidance, rather than being escalated to failed by success-only gates.",
+        "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
+        "Delegate report handoff prefers sidecar JSON as canonical evidence and only falls back to stdout JSON when sidecar evidence is unavailable.",
+        "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",
+        "Dry-run semantics remain explicit and delegated for readonly governed flows: pass --dry-run through delegate and preserve partial outcome honestly.",
+        "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
+        "Readonly semantics are explicit as no external writeback, and runtime summary wording does not overclaim strict filesystem readonly when dry_run=false.",
+        "Wrapper success is conservative when OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial.",
+        "Delegate execution is bounded by an explicit timeout and reports timeout honestly."
+      ],
+      "metadata": {
+        "integration_phase": "8B",
+        "pipeline": "inbox->adapter->manager->automation->critic",
+        "request_type": "pdf_to_excel_ocr",
+        "payload_hash": "687ebc83a15301413ccf4c39574ace2121af2e87e87563fbd3bb18ec8ef8d7ad",
+        "regeneration_token": "regen-20260325-bl067-001",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "external_metadata": {
+          "source_system": "trello",
+          "card_id": "69c24cd3c1a2359ddd7a1bf8",
+          "card_short_id": 7,
+          "board_id": "69be462743bfa0038ca10f7a",
+          "list_id": "69be462743bfa0038ca10f8f",
+          "date_last_activity": "2026-03-24T08:35:56.234Z",
+          "readonly_mapped_at": "2026-03-25T11:45:32.575060Z",
+          "contract_profile": "best_effort_evidence_backed",
+          "ocr_claim_policy": "do_not_claim_success_without_evidence",
+          "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+          "regeneration_token": "regen-20260325-bl067-001"
+        },
+        "automation_contract_profile": "narrow_script_artifact_with_repo_reuse_and_reviewable_runner_contract"
+      }
+    },
+    "critic": {
+      "task_id": "CRITIC-20260325-290",
+      "worker": "critic",
+      "task_type": "review_artifact",
+      "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+      "inputs": {
+        "artifacts": [
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "type": "script"
+          },
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+            "type": "script"
+          }
+        ],
+        "params": {
+          "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+          "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+          "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+          "labels": [
+            "best_effort",
+            "evidence_backed",
+            "readonly",
+            "reviewable",
+            "trello"
+          ],
+          "review_scope": {
+            "primary_artifact": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "paired_artifacts": [
+              "artifacts/scripts/pdf_to_excel_ocr.py"
+            ],
+            "goal": "Audit the wrapper and the reviewed delegate together so the review evidence can speak to the end-to-end readonly smoke path."
+          }
+        }
+      },
+      "expected_outputs": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ],
+      "constraints": [
+        "Review must be grounded in produced automation artifact",
+        "When both wrapper and reviewed delegate snapshots are supplied, evaluate them as one end-to-end readonly pair instead of ignoring the delegate evidence.",
+        "Do not invent missing artifact content",
+        "Return a clear verdict: pass, fail, or needs_revision",
+        "Include metadata.verdict in output",
+        "Generate review artifact markdown for expected_outputs[0].path"
+      ],
+      "priority": "medium",
+      "source": {
+        "kind": "local_inbox",
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl067-001.json",
+        "received_at": "2026-03-25T11:45:58.529105Z",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "regeneration_token": "regen-20260325-bl067-001"
+      },
+      "acceptance_criteria": [
+        "Produce a review artifact with explicit verdict (pass/fail/needs_revision)"
+      ],
+      "metadata": {
+        "integration_phase": "8B",
+        "pipeline": "inbox->adapter->manager->automation->critic",
+        "request_type": "pdf_to_excel_ocr",
+        "payload_hash": "687ebc83a15301413ccf4c39574ace2121af2e87e87563fbd3bb18ec8ef8d7ad",
+        "regeneration_token": "regen-20260325-bl067-001",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "external_metadata": {
+          "source_system": "trello",
+          "card_id": "69c24cd3c1a2359ddd7a1bf8",
+          "card_short_id": 7,
+          "board_id": "69be462743bfa0038ca10f7a",
+          "list_id": "69be462743bfa0038ca10f8f",
+          "date_last_activity": "2026-03-24T08:35:56.234Z",
+          "readonly_mapped_at": "2026-03-25T11:45:32.575060Z",
+          "contract_profile": "best_effort_evidence_backed",
+          "ocr_claim_policy": "do_not_claim_success_without_evidence",
+          "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+          "regeneration_token": "regen-20260325-bl067-001"
+        }
+      }
+    }
+  },
+  "expected_artifacts": [
+    "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+    "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py"
+  ],
+  "dedupe_keys": [
+    "origin_regeneration:trello:69c24cd3c1a2359ddd7a1bf8:regen-20260325-bl067-001",
+    "hash:687ebc83a15301413ccf4c39574ace2121af2e87e87563fbd3bb18ec8ef8d7ad"
+  ],
+  "risk_warnings": [],
+  "execution": {
+    "status": "rejected",
+    "executed": true,
+    "attempts": 2,
+    "executed_at": "2026-03-25T11:46:59.799926Z",
+    "decision_reason": "Automation task failed: {\"task_id\": \"AUTO-20260325-874\", \"worker\": \"automation\", \"status\": \"failed\", \"summary\": \"Worker execution failed\", \"artifacts\": [], \"errors\": [\"Missing API key. Checked: openai_api_key, api_key, OPENAI_API_KEY, API_KEY\"], \"metadata\": {}, \"duration_ms\": 1, \"timestamp\": \"2026-03-25T11:46:59.711458Z\"}"
+  },
+  "approval": {
+    "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153.json",
+    "approved_by": "Oscarling",
+    "approved_at": "2026-03-25T11:46:31Z",
+    "note": "BL-20260325-067 governed validation execute only; no Git finalization; no Trello Done."
+  },
+  "last_execution": {
+    "decision": "rejected",
+    "decision_reason": "Automation task failed: {\"task_id\": \"AUTO-20260325-874\", \"worker\": \"automation\", \"status\": \"failed\", \"summary\": \"Worker execution failed\", \"artifacts\": [], \"errors\": [\"Missing API key. Checked: openai_api_key, api_key, OPENAI_API_KEY, API_KEY\"], \"metadata\": {}, \"duration_ms\": 1, \"timestamp\": \"2026-03-25T11:46:59.711458Z\"}",
+    "automation_result": {
+      "task_id": "AUTO-20260325-874",
+      "worker": "automation",
+      "status": "failed",
+      "summary": "Worker execution failed",
+      "artifacts": [],
+      "errors": [
+        "Missing API key. Checked: openai_api_key, api_key, OPENAI_API_KEY, API_KEY"
+      ],
+      "metadata": {},
+      "duration_ms": 1,
+      "timestamp": "2026-03-25T11:46:59.711458Z"
+    },
+    "critic_result": null,
+    "critic_verdict": "needs_revision"
+  }
+}

--- a/runtime_archives/bl067/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153.result.json
+++ b/runtime_archives/bl067/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153.result.json
@@ -1,0 +1,9 @@
+{
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153",
+  "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153.json",
+  "executed_at": "2026-03-25T11:46:59.800782Z",
+  "status": "rejected",
+  "decision_reason": "Automation task failed: {\"task_id\": \"AUTO-20260325-874\", \"worker\": \"automation\", \"status\": \"failed\", \"summary\": \"Worker execution failed\", \"artifacts\": [], \"errors\": [\"Missing API key. Checked: openai_api_key, api_key, OPENAI_API_KEY, API_KEY\"], \"metadata\": {}, \"duration_ms\": 1, \"timestamp\": \"2026-03-25T11:46:59.711458Z\"}",
+  "critic_verdict": "needs_revision",
+  "test_mode": "off"
+}

--- a/runtime_archives/bl067/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl067-001.json
+++ b/runtime_archives/bl067/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl067-001.json
@@ -1,0 +1,41 @@
+{
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "metadata": {
+    "source_system": "trello",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "card_short_id": 7,
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "date_last_activity": "2026-03-24T08:35:56.234Z",
+    "readonly_mapped_at": "2026-03-25T11:45:32.575060Z",
+    "contract_profile": "best_effort_evidence_backed",
+    "ocr_claim_policy": "do_not_claim_success_without_evidence",
+    "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+    "regeneration_token": "regen-20260325-bl067-001"
+  },
+  "source": {
+    "provider": "trello",
+    "mode": "readonly",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "regeneration_token": "regen-20260325-bl067-001"
+  },
+  "request_type": "pdf_to_excel_ocr",
+  "input": {
+    "input_dir": "~/Desktop/pdf样本",
+    "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+    "ocr": "auto",
+    "dry_run": false
+  },
+  "regeneration_token": "regen-20260325-bl067-001"
+}

--- a/runtime_archives/bl067/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl067-001.json.result.json
+++ b/runtime_archives/bl067/state/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl067-001.json.result.json
@@ -1,0 +1,23 @@
+{
+  "ingested_at": "2026-03-25T11:45:58.531400Z",
+  "status": "processed",
+  "decision": "preview_created_pending_approval",
+  "decision_reason": "preview_created; waiting_for_explicit_approval",
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "payload_hash": "687ebc83a15301413ccf4c39574ace2121af2e87e87563fbd3bb18ec8ef8d7ad",
+  "dedupe_keys": [
+    "origin_regeneration:trello:69c24cd3c1a2359ddd7a1bf8:regen-20260325-bl067-001",
+    "hash:687ebc83a15301413ccf4c39574ace2121af2e87e87563fbd3bb18ec8ef8d7ad"
+  ],
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153",
+  "preview_file": "/Users/lingguozhong/openclaw-team/preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153.json",
+  "regeneration_token": "regen-20260325-bl067-001"
+}

--- a/runtime_archives/bl067/tmp/bl067_execute_once_elevated.json
+++ b/runtime_archives/bl067/tmp/bl067_execute_once_elevated.json
@@ -1,0 +1,18 @@
+{
+  "status": "done",
+  "processed": 0,
+  "rejected": 1,
+  "skipped": 0,
+  "test_mode": "off",
+  "allow_replay": true,
+  "results": [
+    {
+      "status": "rejected",
+      "decision_reason": "Automation task failed: {\"task_id\": \"AUTO-20260325-874\", \"worker\": \"automation\", \"status\": \"failed\", \"summary\": \"Worker execution failed\", \"artifacts\": [], \"errors\": [\"Missing API key. Checked: openai_api_key, api_key, OPENAI_API_KEY, API_KEY\"], \"metadata\": {}, \"duration_ms\": 1, \"timestamp\": \"2026-03-25T11:46:59.711458Z\"}",
+      "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153",
+      "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153.json",
+      "result_sidecar": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153.result.json",
+      "critic_verdict": "needs_revision"
+    }
+  ]
+}

--- a/runtime_archives/bl067/tmp/bl067_execute_once_elevated_keyed.json
+++ b/runtime_archives/bl067/tmp/bl067_execute_once_elevated_keyed.json
@@ -1,0 +1,18 @@
+{
+  "status": "done",
+  "processed": 0,
+  "rejected": 1,
+  "skipped": 0,
+  "test_mode": "off",
+  "allow_replay": true,
+  "results": [
+    {
+      "status": "rejected",
+      "decision_reason": "Automation task failed: {\"task_id\": \"AUTO-20260325-874\", \"worker\": \"automation\", \"status\": \"failed\", \"summary\": \"Worker execution failed\", \"artifacts\": [], \"errors\": [\"LLM call exhausted (attempts=1/3, class=http_400, endpoint=https://aixj.vip/v1/chat/completions, retryable=False): HTTP Error 400: Bad Request\"], \"metadata\": {}, \"duration_ms\": 486, \"timestamp\": \"2026-03-25T12:09:55.530120Z\"}",
+      "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153",
+      "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153.json",
+      "result_sidecar": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153.result.json",
+      "critic_verdict": "needs_revision"
+    }
+  ]
+}

--- a/runtime_archives/bl067/tmp/bl067_execute_once_elevated_keyed_model53.json
+++ b/runtime_archives/bl067/tmp/bl067_execute_once_elevated_keyed_model53.json
@@ -1,0 +1,18 @@
+{
+  "status": "done",
+  "processed": 0,
+  "rejected": 1,
+  "skipped": 0,
+  "test_mode": "off",
+  "allow_replay": true,
+  "results": [
+    {
+      "status": "rejected",
+      "decision_reason": "Automation task failed: {\"task_id\": \"AUTO-20260325-874\", \"worker\": \"automation\", \"status\": \"failed\", \"summary\": \"Worker execution failed\", \"artifacts\": [], \"errors\": [\"LLM call exhausted (attempts=1/3, class=http_400, endpoint=https://aixj.vip/v1/chat/completions, retryable=False): HTTP Error 400: Bad Request\"], \"metadata\": {}, \"duration_ms\": 537, \"timestamp\": \"2026-03-25T12:10:54.491158Z\"}",
+      "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153",
+      "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153.json",
+      "result_sidecar": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153.result.json",
+      "critic_verdict": "needs_revision"
+    }
+  ]
+}

--- a/runtime_archives/bl067/tmp/bl067_execute_once_sandbox.json
+++ b/runtime_archives/bl067/tmp/bl067_execute_once_sandbox.json
@@ -1,0 +1,18 @@
+{
+  "status": "done",
+  "processed": 0,
+  "rejected": 1,
+  "skipped": 0,
+  "test_mode": "off",
+  "allow_replay": false,
+  "results": [
+    {
+      "status": "rejected",
+      "decision_reason": "Failed to initialize docker client from environment. Ensure Docker access is available or pass docker_client explicitly.",
+      "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153",
+      "approval_file": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153.json",
+      "result_sidecar": "/Users/lingguozhong/openclaw-team/approvals/preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153.result.json",
+      "critic_verdict": "needs_revision"
+    }
+  ]
+}

--- a/runtime_archives/bl067/tmp/bl067_ingest_once.json
+++ b/runtime_archives/bl067/tmp/bl067_ingest_once.json
@@ -1,0 +1,21 @@
+{
+  "status": "done",
+  "processed": 1,
+  "rejected": 0,
+  "duplicate_skipped": 0,
+  "preview_created": 1,
+  "inbox_claimed": 1,
+  "processing_recovered": 0,
+  "test_mode": "success",
+  "results": [
+    {
+      "status": "processed",
+      "decision": "preview_created_pending_approval",
+      "decision_reason": "preview_created; waiting_for_explicit_approval",
+      "file": "/Users/lingguozhong/openclaw-team/processed/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl067-001.json",
+      "result_sidecar": "/Users/lingguozhong/openclaw-team/processed/trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl067-001.json.result.json",
+      "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153",
+      "preview_file": "/Users/lingguozhong/openclaw-team/preview/preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153.json"
+    }
+  ]
+}

--- a/runtime_archives/bl067/tmp/bl067_live_mapped_preview.json
+++ b/runtime_archives/bl067/tmp/bl067_live_mapped_preview.json
@@ -1,0 +1,38 @@
+{
+  "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+  "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+  "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+  "labels": [
+    "best_effort",
+    "evidence_backed",
+    "readonly",
+    "reviewable",
+    "trello"
+  ],
+  "metadata": {
+    "source_system": "trello",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "card_short_id": 7,
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f",
+    "date_last_activity": "2026-03-24T08:35:56.234Z",
+    "readonly_mapped_at": "2026-03-25T11:45:32.575060Z",
+    "contract_profile": "best_effort_evidence_backed",
+    "ocr_claim_policy": "do_not_claim_success_without_evidence",
+    "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable"
+  },
+  "source": {
+    "provider": "trello",
+    "mode": "readonly",
+    "card_id": "69c24cd3c1a2359ddd7a1bf8",
+    "board_id": "69be462743bfa0038ca10f7a",
+    "list_id": "69be462743bfa0038ca10f8f"
+  },
+  "request_type": "pdf_to_excel_ocr",
+  "input": {
+    "input_dir": "~/Desktop/pdf样本",
+    "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+    "ocr": "auto",
+    "dry_run": false
+  }
+}

--- a/runtime_archives/bl067/tmp/bl067_preview_state_pre_execute.json
+++ b/runtime_archives/bl067/tmp/bl067_preview_state_pre_execute.json
@@ -1,0 +1,337 @@
+{
+  "preview_id": "preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153",
+  "created_at": "2026-03-25T11:45:58.530873Z",
+  "approved": false,
+  "source": {
+    "kind": "local_inbox",
+    "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+    "received_at": "2026-03-25T11:45:58.529105Z",
+    "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl067-001.json",
+    "regeneration_token": "regen-20260325-bl067-001"
+  },
+  "external_input": {
+    "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+    "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+    "labels": [
+      "best_effort",
+      "evidence_backed",
+      "readonly",
+      "reviewable",
+      "trello"
+    ],
+    "metadata": {
+      "source_system": "trello",
+      "card_id": "69c24cd3c1a2359ddd7a1bf8",
+      "card_short_id": 7,
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": "69be462743bfa0038ca10f8f",
+      "date_last_activity": "2026-03-24T08:35:56.234Z",
+      "readonly_mapped_at": "2026-03-25T11:45:32.575060Z",
+      "contract_profile": "best_effort_evidence_backed",
+      "ocr_claim_policy": "do_not_claim_success_without_evidence",
+      "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+      "regeneration_token": "regen-20260325-bl067-001"
+    },
+    "request_type": "pdf_to_excel_ocr",
+    "input": {
+      "input_dir": "~/Desktop/pdf样本",
+      "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+      "ocr": "auto",
+      "dry_run": false
+    }
+  },
+  "task_summary": {
+    "automation": {
+      "task_id": "AUTO-20260325-874",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+      "expected_outputs": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ]
+    },
+    "critic": {
+      "task_id": "CRITIC-20260325-290",
+      "worker": "critic",
+      "task_type": "review_artifact",
+      "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+      "expected_outputs": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ]
+    }
+  },
+  "internal_tasks": {
+    "automation": {
+      "task_id": "AUTO-20260325-874",
+      "worker": "automation",
+      "task_type": "generate_script",
+      "objective": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt). Generate exactly one runnable local helper script artifact for a best-effort PDF extraction/conversion attempt using the provided parameters. Prefer reusing the repository's existing inbox runner and reviewed PDF-to-Excel implementation when they already satisfy the request instead of re-implementing the pipeline from scratch.",
+      "inputs": {
+        "params": {
+          "input_dir": "~/Desktop/pdf样本",
+          "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+          "ocr": "auto",
+          "dry_run": false,
+          "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+          "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+          "description": "Purpose: | Controlled Trello live preview smoke for openclaw-team. | Expected behavior: | - read-only Trello ingest | - preview creation smoke only | - no business execution claim | - no Trello writeback expected in this step | Traceability: | - backlog: BL-20260324-014 | - blocker context: BL-20260324-015 | - created_by: Oscarling | - created_at: 2026-03-24 Asia/Shanghai | Note: | This card is only for governed smoke verification and should remain open until the smoke is finished.",
+          "labels": [
+            "best_effort",
+            "evidence_backed",
+            "readonly",
+            "reviewable",
+            "trello"
+          ],
+          "preferred_wrapper_script": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "preferred_base_script": "artifacts/scripts/pdf_to_excel_ocr.py",
+          "reference_docs": [
+            "artifacts/docs/pdf_to_excel_ocr_usage.md",
+            "artifacts/reviews/pdf_to_excel_ocr_review.md"
+          ],
+          "contract_hints": {
+            "output_format_fidelity": "If output_xlsx ends with .xlsx, produce a real XLSX workbook container or fail honestly before writing mismatched text/XML/CSV content to a .xlsx path.",
+            "path_portability": "Use the provided input_dir parameter as runtime input. Do not hardcode a user-home or absolute input path when params already declare the path.",
+            "traceability": "Preserve meaningful description context from the external input; do not collapse it to a heading fragment such as Purpose:.",
+            "reuse_preference": "Prefer reusing artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py as the wrapper baseline and artifacts/scripts/pdf_to_excel_ocr.py as the reviewed delegate when compatible, so workbook semantics and contract behavior stay aligned with repository evidence.",
+            "outcome_status_model": "Use the reviewable status model success/partial/failed. Dry-run requests or zero-PDF discovery should resolve to partial rather than claiming success without an output artifact.",
+            "delegate_resolution": "If preferred_base_script is relative, resolve it from the repository or script location instead of Path.cwd() so behavior stays portable across shells and CI.",
+            "reviewed_delegate_contract": "For readonly reviewable preview flows, delegate only to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py or fail honestly instead of broadening behavior through an arbitrary helper.",
+            "delegate_success_evidence": "Do not treat zero exit code plus output-file existence as sufficient wrapper success evidence on their own. Prefer a structured delegate report that confirms a real success outcome before the wrapper claims success. Require delegate status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, and explicit output attestation fields excel_written=true, output_exists=true, and output_size_bytes>0. Apply these gates only when wrapper status is success.",
+            "delegate_partial_evidence": "For best-effort readonly flows, if delegate status is partial and structured evidence is present, keep wrapper status partial instead of escalating to failed solely because success-only gates are unmet. Surface explicit limitations and next-step guidance in wrapper output.",
+            "delegate_timeout": "Bound delegate subprocess execution with an explicit timeout and report timeout as an honest failed/partial outcome instead of allowing smoke automation to hang indefinitely.",
+            "readonly_semantics": "Readonly semantics must be explicit: no external/Trello writeback is required, but local filesystem output writes may still occur when dry_run=false. Runtime summary fields must not overstate readonly scope.",
+            "ocr_sufficiency": "When OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial, do not claim wrapper success even if an output file exists; keep partial status with explicit OCR sufficiency notes.",
+            "runtime_summary": "The generated script should emit a structured summary of what it produced so later review can inspect behavior without guessing.",
+            "delegate_report_schema": "Treat delegate JSON report fields status/total_files/status_counter/dry_run as the canonical evidence contract. Do not require undeclared processed_files/succeeded_files/failed_files counters.",
+            "delegate_report_handoff": "When a sidecar report file is available, treat it as canonical evidence. Use stdout JSON parsing only as fallback when sidecar evidence is missing.",
+            "delegate_report_flag_contract": "If wrapper passes a sidecar report path to the reviewed delegate, use the reviewed delegate CLI flag --report-json (or another explicitly supported alias). Do not invent undeclared flags such as --report-file.",
+            "dry_run_semantics": "For readonly governed flows, do not short-circuit dry-run before delegate execution. Delegate under dry-run and pass through --dry-run explicitly so wrapper/delegate semantics remain aligned.",
+            "pdf_discovery_consistency": "Keep wrapper preflight PDF discovery semantics aligned with the reviewed delegate (for example recursive vs non-recursive), so wrapper evidence and delegated execution count the same candidate set."
+          }
+        }
+      },
+      "expected_outputs": [
+        {
+          "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+          "type": "script"
+        }
+      ],
+      "constraints": [
+        "Follow the local inbox normalized request",
+        "Do not claim unsupported runtime dependencies",
+        "Keep output deterministic and executable",
+        "Produce only the expected script artifact",
+        "Prefer honest, reviewable intermediate behavior over unsupported OCR claims",
+        "If the requested output path ends with .xlsx, do not write non-XLSX text/XML/CSV content to that path.",
+        "Do not hardcode an input directory when the task params already provide input_dir.",
+        "Preserve meaningful traceability from the incoming description instead of collapsing it to a heading fragment.",
+        "Prefer wrapping or adapting artifacts/scripts/pdf_to_excel_ocr.py when that existing repo script already matches the requested behavior.",
+        "When artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py already exists, prefer updating that reviewed wrapper baseline instead of rewriting a new control flow from scratch.",
+        "If dry_run is true or no PDFs are discovered, report a reviewable partial outcome instead of claiming success without an XLSX artifact.",
+        "Resolve relative delegate script paths from the repository or script location, not from Path.cwd().",
+        "For readonly reviewable preview flows, only delegate to the reviewed repository script artifacts/scripts/pdf_to_excel_ocr.py unless failing honestly.",
+        "Do not claim wrapper success from exit code plus output existence alone when the reviewed delegate report does not provide strong enough success evidence.",
+        "When wrapper reports success, enforce delegate evidence gates: status=success, total_files>=1, dry_run=false, status_counter.failed=0, status_counter.partial=0, excel_written=true, output_exists=true, and output_size_bytes>0.",
+        "If delegate reports partial with structured evidence in readonly best-effort mode, keep wrapper status partial (not failed) and include explicit limitations with next-step guidance.",
+        "Use delegate report fields status/total_files/status_counter/dry_run as canonical evidence; do not require undeclared per-counter keys.",
+        "When a delegate sidecar report is present, treat sidecar JSON as canonical evidence and use stdout JSON only as fallback.",
+        "When wrapper passes a sidecar report path to the reviewed delegate, use --report-json exactly unless the reviewed delegate explicitly supports another alias.",
+        "For readonly governed flows, do not short-circuit dry-run before delegate execution; pass --dry-run through delegate and preserve partial status honestly.",
+        "Keep wrapper PDF discovery semantics aligned with reviewed delegate discovery semantics to avoid preflight/execution evidence drift.",
+        "Readonly semantics must be explicit as no external writeback; avoid claiming strict filesystem readonly when dry_run=false can write local outputs.",
+        "When OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial, keep wrapper status partial and surface OCR sufficiency limitations.",
+        "Use an explicit timeout on delegate subprocess execution so the smoke wrapper cannot hang indefinitely."
+      ],
+      "priority": "medium",
+      "source": {
+        "kind": "local_inbox",
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl067-001.json",
+        "received_at": "2026-03-25T11:45:58.529105Z",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "regeneration_token": "regen-20260325-bl067-001"
+      },
+      "acceptance_criteria": [
+        "Produce the expected script artifact at expected_outputs[0].path",
+        "Script behavior remains runnable, deterministic, and reviewable",
+        "If output_xlsx ends with .xlsx, the artifact must preserve true XLSX output semantics or fail honestly before writing a mismatched format.",
+        "Artifact behavior remains parameter-driven for input_dir and output_xlsx rather than hardcoding unrelated local defaults.",
+        "Dry-run or zero-input behavior is represented as a reviewable partial outcome instead of artifact-production success.",
+        "Relative preferred_base_script resolution remains portable and does not depend on Path.cwd().",
+        "Wrapper success requires stronger delegate evidence than zero exit code plus a non-empty output file alone.",
+        "Wrapper success attestation requires delegate fields excel_written=true, output_exists=true, output_size_bytes>0, and status_counter.partial/status_counter.failed equal to 0.",
+        "Contract-compliant delegate partial outcomes remain partial with explicit limitations and next-step guidance, rather than being escalated to failed by success-only gates.",
+        "Wrapper evidence logic remains compatible with delegate JSON fields status/total_files/status_counter/dry_run.",
+        "Delegate report handoff prefers sidecar JSON as canonical evidence and only falls back to stdout JSON when sidecar evidence is unavailable.",
+        "Wrapper/delegate sidecar report handoff remains CLI-compatible by using --report-json (or another explicitly supported delegate alias).",
+        "Dry-run semantics remain explicit and delegated for readonly governed flows: pass --dry-run through delegate and preserve partial outcome honestly.",
+        "Wrapper preflight PDF discovery semantics remain aligned with delegate discovery semantics to keep evidence counts consistent.",
+        "Readonly semantics are explicit as no external writeback, and runtime summary wording does not overclaim strict filesystem readonly when dry_run=false.",
+        "Wrapper success is conservative when OCR mode is auto/on and delegate reports ocr_runtime_status as blocked/partial.",
+        "Delegate execution is bounded by an explicit timeout and reports timeout honestly."
+      ],
+      "metadata": {
+        "integration_phase": "8B",
+        "pipeline": "inbox->adapter->manager->automation->critic",
+        "request_type": "pdf_to_excel_ocr",
+        "payload_hash": "687ebc83a15301413ccf4c39574ace2121af2e87e87563fbd3bb18ec8ef8d7ad",
+        "regeneration_token": "regen-20260325-bl067-001",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "external_metadata": {
+          "source_system": "trello",
+          "card_id": "69c24cd3c1a2359ddd7a1bf8",
+          "card_short_id": 7,
+          "board_id": "69be462743bfa0038ca10f7a",
+          "list_id": "69be462743bfa0038ca10f8f",
+          "date_last_activity": "2026-03-24T08:35:56.234Z",
+          "readonly_mapped_at": "2026-03-25T11:45:32.575060Z",
+          "contract_profile": "best_effort_evidence_backed",
+          "ocr_claim_policy": "do_not_claim_success_without_evidence",
+          "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+          "regeneration_token": "regen-20260325-bl067-001"
+        },
+        "automation_contract_profile": "narrow_script_artifact_with_repo_reuse_and_reviewable_runner_contract"
+      }
+    },
+    "critic": {
+      "task_id": "CRITIC-20260325-290",
+      "worker": "critic",
+      "task_type": "review_artifact",
+      "objective": "Review the generated inbox runner together with its reviewed delegate script from the local inbox pipeline and provide a structured verdict using one of: pass, fail, needs_revision. Always output a review markdown artifact and include verdict in metadata.",
+      "inputs": {
+        "artifacts": [
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "type": "script"
+          },
+          {
+            "path": "artifacts/scripts/pdf_to_excel_ocr.py",
+            "type": "script"
+          }
+        ],
+        "params": {
+          "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+          "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+          "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+          "labels": [
+            "best_effort",
+            "evidence_backed",
+            "readonly",
+            "reviewable",
+            "trello"
+          ],
+          "review_scope": {
+            "primary_artifact": "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py",
+            "paired_artifacts": [
+              "artifacts/scripts/pdf_to_excel_ocr.py"
+            ],
+            "goal": "Audit the wrapper and the reviewed delegate together so the review evidence can speak to the end-to-end readonly smoke path."
+          }
+        }
+      },
+      "expected_outputs": [
+        {
+          "path": "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+          "type": "review"
+        }
+      ],
+      "constraints": [
+        "Review must be grounded in produced automation artifact",
+        "When both wrapper and reviewed delegate snapshots are supplied, evaluate them as one end-to-end readonly pair instead of ignoring the delegate evidence.",
+        "Do not invent missing artifact content",
+        "Return a clear verdict: pass, fail, or needs_revision",
+        "Include metadata.verdict in output",
+        "Generate review artifact markdown for expected_outputs[0].path"
+      ],
+      "priority": "medium",
+      "source": {
+        "kind": "local_inbox",
+        "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+        "inbox_file": "trello-69c24cd3c1a2359ddd7a1bf8-regen-20260325-bl067-001.json",
+        "received_at": "2026-03-25T11:45:58.529105Z",
+        "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "regeneration_token": "regen-20260325-bl067-001"
+      },
+      "acceptance_criteria": [
+        "Produce a review artifact with explicit verdict (pass/fail/needs_revision)"
+      ],
+      "metadata": {
+        "integration_phase": "8B",
+        "pipeline": "inbox->adapter->manager->automation->critic",
+        "request_type": "pdf_to_excel_ocr",
+        "payload_hash": "687ebc83a15301413ccf4c39574ace2121af2e87e87563fbd3bb18ec8ef8d7ad",
+        "regeneration_token": "regen-20260325-bl067-001",
+        "labels": [
+          "best_effort",
+          "evidence_backed",
+          "readonly",
+          "reviewable",
+          "trello"
+        ],
+        "external_metadata": {
+          "source_system": "trello",
+          "card_id": "69c24cd3c1a2359ddd7a1bf8",
+          "card_short_id": 7,
+          "board_id": "69be462743bfa0038ca10f7a",
+          "list_id": "69be462743bfa0038ca10f8f",
+          "date_last_activity": "2026-03-24T08:35:56.234Z",
+          "readonly_mapped_at": "2026-03-25T11:45:32.575060Z",
+          "contract_profile": "best_effort_evidence_backed",
+          "ocr_claim_policy": "do_not_claim_success_without_evidence",
+          "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable",
+          "regeneration_token": "regen-20260325-bl067-001"
+        }
+      }
+    }
+  },
+  "expected_artifacts": [
+    "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md",
+    "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py"
+  ],
+  "dedupe_keys": [
+    "origin_regeneration:trello:69c24cd3c1a2359ddd7a1bf8:regen-20260325-bl067-001",
+    "hash:687ebc83a15301413ccf4c39574ace2121af2e87e87563fbd3bb18ec8ef8d7ad"
+  ],
+  "risk_warnings": [],
+  "execution": {
+    "status": "pending_approval",
+    "executed": false,
+    "attempts": 0
+  }
+}

--- a/runtime_archives/bl067/tmp/bl067_smoke_elevated.json
+++ b/runtime_archives/bl067/tmp/bl067_smoke_elevated.json
@@ -1,0 +1,90 @@
+{
+  "status": "done",
+  "fixture": "/Users/lingguozhong/openclaw-team/adapters/samples/trello_card_fixture.json",
+  "mapped_output": "/Users/lingguozhong/openclaw-team/artifacts/trello_readonly_prep/trello_readonly_mapped_sample.json",
+  "required_env": {
+    "credentials": [
+      "TRELLO_API_KEY",
+      "TRELLO_API_TOKEN"
+    ],
+    "credentials_aliases": [
+      "TRELLO_KEY",
+      "TRELLO_TOKEN"
+    ],
+    "credentials_priority": [
+      "TRELLO_API_KEY/TRELLO_API_TOKEN",
+      "TRELLO_KEY/TRELLO_TOKEN"
+    ],
+    "scope": [
+      "TRELLO_BOARD_ID",
+      "TRELLO_LIST_ID"
+    ],
+    "scope_rule": [
+      "TRELLO_BOARD_ID or TRELLO_LIST_ID (either one)"
+    ]
+  },
+  "smoke_read": {
+    "status": "pass",
+    "read_count": 1,
+    "scope": {
+      "board_id": "69be462743bfa0038ca10f7a",
+      "list_id": null
+    },
+    "scope_kind": "board",
+    "mapped_preview": {
+      "origin_id": "trello:69c24cd3c1a2359ddd7a1bf8",
+      "title": "BL-20260324-014 live preview smoke sample 2026-03-24 (best-effort reviewable attempt)",
+      "description": "Purpose:\n\n  Controlled Trello live preview smoke for openclaw-team.\n\n‌\n\n  Expected behavior:\n\n- read-only Trello ingest\n\n- preview creation smoke only\n\n- no business execution claim\n\n- no Trello writeback expected in this step\n\n‌\n\n  Traceability:\n\n- backlog: BL-20260324-014\n\n- blocker context: BL-20260324-015\n\n- created_by: Oscarling\n\n- created_at: 2026-03-24 Asia/Shanghai\n\n‌\n\n  Note:\n\n  This card is only for governed smoke verification and should remain open until the smoke is finished.\n\nExecution contract: treat this as a best-effort, evidence-backed PDF extraction/conversion attempt. Do not claim OCR success without evidence. If full OCR/Excel conversion is not honestly achievable, return reviewable intermediate artifacts, explicit limitations, and next-step guidance. Keep behavior deterministic and limited to declared local artifacts.",
+      "labels": [
+        "best_effort",
+        "evidence_backed",
+        "readonly",
+        "reviewable",
+        "trello"
+      ],
+      "metadata": {
+        "source_system": "trello",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "card_short_id": 7,
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f",
+        "date_last_activity": "2026-03-24T08:35:56.234Z",
+        "readonly_mapped_at": "2026-03-25T11:45:32.575060Z",
+        "contract_profile": "best_effort_evidence_backed",
+        "ocr_claim_policy": "do_not_claim_success_without_evidence",
+        "fallback_policy": "return_reviewable_artifacts_limitations_and_next_steps_when_full_conversion_is_not_honestly_achievable"
+      },
+      "source": {
+        "provider": "trello",
+        "mode": "readonly",
+        "card_id": "69c24cd3c1a2359ddd7a1bf8",
+        "board_id": "69be462743bfa0038ca10f7a",
+        "list_id": "69be462743bfa0038ca10f8f"
+      },
+      "request_type": "pdf_to_excel_ocr",
+      "input": {
+        "input_dir": "~/Desktop/pdf样本",
+        "output_xlsx": "artifacts/outputs/trello_readonly/pdf_to_excel_from_trello.xlsx",
+        "ocr": "auto",
+        "dry_run": false
+      }
+    },
+    "auth_env": {
+      "selected_names": {
+        "key": "TRELLO_API_KEY",
+        "token": "TRELLO_API_TOKEN"
+      },
+      "priority": "TRELLO_API_* first, fallback to TRELLO_*",
+      "presence": {
+        "TRELLO_API_KEY": "set",
+        "TRELLO_KEY": "set",
+        "TRELLO_API_TOKEN": "set",
+        "TRELLO_TOKEN": "set",
+        "TRELLO_BOARD_ID": "set",
+        "TRELLO_LIST_ID": "missing"
+      }
+    },
+    "note": "Read-only GET only. No write operations performed."
+  },
+  "mode": "trello_readonly_prep"
+}

--- a/runtime_archives/bl067/tmp/bl067_smoke_sandbox.json
+++ b/runtime_archives/bl067/tmp/bl067_smoke_sandbox.json
@@ -1,0 +1,48 @@
+{
+  "status": "done",
+  "fixture": "/Users/lingguozhong/openclaw-team/adapters/samples/trello_card_fixture.json",
+  "mapped_output": "/Users/lingguozhong/openclaw-team/artifacts/trello_readonly_prep/trello_readonly_mapped_sample.json",
+  "required_env": {
+    "credentials": [
+      "TRELLO_API_KEY",
+      "TRELLO_API_TOKEN"
+    ],
+    "credentials_aliases": [
+      "TRELLO_KEY",
+      "TRELLO_TOKEN"
+    ],
+    "credentials_priority": [
+      "TRELLO_API_KEY/TRELLO_API_TOKEN",
+      "TRELLO_KEY/TRELLO_TOKEN"
+    ],
+    "scope": [
+      "TRELLO_BOARD_ID",
+      "TRELLO_LIST_ID"
+    ],
+    "scope_rule": [
+      "TRELLO_BOARD_ID or TRELLO_LIST_ID (either one)"
+    ]
+  },
+  "smoke_read": {
+    "status": "blocked",
+    "reason": "Read-only Trello request failed before HTTP response: ConnectionError",
+    "error_type": "ConnectionError",
+    "response_preview": "HTTPSConnectionPool(host='api.trello.com', port=443): Max retries exceeded with url: /1/boards/69be462743bfa0038ca10f7a/cards?key=***redacted_key***&token=***redacted_token***&fields=id%2CidShort%2Cname%2Cdesc%2CidList%2CidBoard%2CdateLastActivity%2Clabels&limit=1 (Caused by NameResolutionError(\"HTT",
+    "auth_env": {
+      "selected_names": {
+        "key": "TRELLO_API_KEY",
+        "token": "TRELLO_API_TOKEN"
+      },
+      "priority": "TRELLO_API_* first, fallback to TRELLO_*",
+      "presence": {
+        "TRELLO_API_KEY": "set",
+        "TRELLO_KEY": "set",
+        "TRELLO_API_TOKEN": "set",
+        "TRELLO_TOKEN": "set",
+        "TRELLO_BOARD_ID": "set",
+        "TRELLO_LIST_ID": "missing"
+      }
+    }
+  },
+  "mode": "trello_readonly_prep"
+}


### PR DESCRIPTION
## Summary
- add `POST_WRAPPER_DELEGATE_EXECUTION_OUTCOME_DIAGNOSTIC_CONTRACT_VALIDATION_REPORT.md`
- archive BL-067 governed runtime/state/tmp evidence under `runtime_archives/bl067/`
- mark `BL-20260325-067` done and queue `BL-20260325-068` as planned/next in `PROJECT_BACKLOG.md`
- append work log section 76 with run evidence, blocker shift, and conclusion

## Validation
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh

Closes #127
