### PR TITLE
BL-071: Stabilize governed execute provider profile selection

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -1251,16 +1251,16 @@ Allowed enum values:
 ### BL-20260325-071
 - title: Stabilize governed execute provider profile selection to avoid manual desktop-secret dependency in BL-070 flow
 - type: blocker
-- status: planned
-- phase: next
+- status: done
+- phase: now
 - priority: p1
 - owner: Oscarling
 - depends_on: BL-20260325-070
 - start_when: `BL-20260325-070` confirms fresh governed validation passes only after explicitly switching runtime env to a healthy backup provider profile
 - done_when: Governed execute path can select an approved healthy provider profile from repository/runtime configuration without manual extraction of base URL/key from ad-hoc desktop files
 - source: `POST_PROVIDER_AVAILABILITY_FAILOVER_GOVERNED_VALIDATION_REPORT.md` on 2026-03-25 shows BL-070 pass required manual backup profile injection from `~/Desktop/备用key.rtf`
-- link: -
-- issue: -
-- evidence: -
+- link: /Users/lingguozhong/openclaw-team/PROVIDER_PROFILE_SELECTION_STABILIZATION_REPORT.md
+- issue: https://github.com/Oscarling/openclaw-team/issues/135
+- evidence: `skills/delegate_task.py` now supports profile-selected provider env assembly via `ARGUS_PROVIDER_PROFILE` and `ARGUS_PROVIDER_PROFILES_FILE` (with fail-closed key reference checks), `contracts/provider_profiles.example.json` defines non-secret profile structure, `tests/test_argus_hardening.py` adds three profile-selection regressions, and `bash scripts/premerge_check.sh` passed on 2026-03-25 with no failures
 - last_reviewed_at: 2026-03-25
 - opened_at: 2026-03-25

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -4125,3 +4125,55 @@ Verification snapshot on 2026-03-25:
   - `processed = 1`
   - `rejected = 0`
   - `critic_verdict = pass`
+
+### 81. BL-071 Governed Execute Provider Profile Selection Stabilization
+
+User objective:
+
+- continue strict backlog mainline without drift
+- remove BL-070 manual desktop-secret dependency and keep governed execute
+  provider selection inside repo/runtime configuration
+
+Main work areas:
+
+- activated `BL-20260325-071` and mirrored it to issue `#135`
+- hardened `skills/delegate_task.py` provider env assembly:
+  - added profile selectors:
+    - `ARGUS_PROVIDER_PROFILE`
+    - `ARGUS_PROVIDER_PROFILES_FILE`
+  - added profile parsing for both payload shapes:
+    - top-level profile map
+    - `{ "profiles": { ... } }`
+  - added profile key resolution policy:
+    - `api_key`
+    - `api_key_env`
+    - `api_key_secret`
+  - enforced fail-closed behavior when selected profile or key reference is invalid
+  - preserved backward-compatible env behavior when no profile is selected
+- added profile configuration template:
+  - `contracts/provider_profiles.example.json`
+- extended runtime contract docs:
+  - `RUNTIME_CONTRACT.md` section `13. Provider Profile 选择契约（BL-071）`
+- added focused regressions in `tests/test_argus_hardening.py`:
+  - `test_build_worker_env_uses_selected_provider_profile`
+  - `test_build_worker_env_profile_key_env_missing_raises`
+  - `test_build_worker_env_without_profile_keeps_legacy_env_resolution`
+- produced completion report and marked `BL-20260325-071` done in backlog
+
+Primary output:
+
+- [PROVIDER_PROFILE_SELECTION_STABILIZATION_REPORT.md](/Users/lingguozhong/openclaw-team/PROVIDER_PROFILE_SELECTION_STABILIZATION_REPORT.md)
+
+Key result:
+
+- governed execute path can now pick provider runtime settings from profile config
+  instead of ad-hoc desktop-secret extraction
+- profile/key misconfiguration now fails closed with explicit runtime errors
+- legacy non-profile flow remains intact
+
+Verification snapshot on 2026-03-25:
+
+- `python3 -m unittest -v tests/test_argus_hardening.py` passed (`21/21`)
+- `python3 scripts/backlog_lint.py` passed
+- `python3 scripts/backlog_sync.py` passed with BL-071 mirror to `#135`
+- `bash scripts/premerge_check.sh` passed (`Failures: 0`)

--- a/PROVIDER_PROFILE_SELECTION_STABILIZATION_REPORT.md
+++ b/PROVIDER_PROFILE_SELECTION_STABILIZATION_REPORT.md
@@ -1,0 +1,92 @@
+# Provider Profile Selection Stabilization Report (BL-20260325-071)
+
+## Objective
+
+Close `BL-20260325-071` by eliminating the BL-070 manual desktop-secret dependency.
+The governed execute path must select an approved provider profile from repo/runtime
+configuration, without ad-hoc key/base extraction during each run.
+
+## Scope
+
+In scope:
+
+- profile-based provider selection in delegate runtime env assembly
+- fail-closed handling for invalid profile or missing key references
+- backward compatibility when no profile is selected
+- focused regression coverage
+- configuration template for profile definitions
+
+Out of scope:
+
+- rotating or issuing provider keys
+- changing worker runtime HTTP/retry semantics
+- re-running a full governed execute flow in this backlog item
+
+## Changes
+
+### 1) Added provider profile selection to `build_worker_env(...)`
+
+Updated `skills/delegate_task.py`:
+
+- added profile resolution path:
+  - `ARGUS_PROVIDER_PROFILE`
+  - `ARGUS_PROVIDER_PROFILES_FILE` (default: `contracts/provider_profiles.json`)
+- added profile loader and normalizers:
+  - object or `{ "profiles": { ... } }` payload support
+  - string/list fallback fields normalized to runtime env CSV format
+- added API key resolution policy per profile:
+  - `api_key` / `openai_api_key`
+  - `api_key_env`
+  - `api_key_secret`
+- profile-selected values now override ambient defaults when explicitly enabled
+
+### 2) Added fail-closed guarantees for profile/key misconfiguration
+
+`build_worker_env(...)` now raises runtime errors when:
+
+- selected profile file is missing or invalid JSON
+- selected profile name does not exist
+- profile references an unset `api_key_env`
+- profile references an unavailable `api_key_secret`
+
+This prevents silent fallback to unintended provider credentials.
+
+### 3) Added profile configuration template and contract docs
+
+- added `contracts/provider_profiles.example.json` for non-secret profile structure
+- extended `RUNTIME_CONTRACT.md` with BL-071 provider profile contract section
+
+## Regression Tests
+
+Updated `tests/test_argus_hardening.py` with:
+
+- `test_build_worker_env_uses_selected_provider_profile`
+- `test_build_worker_env_profile_key_env_missing_raises`
+- `test_build_worker_env_without_profile_keeps_legacy_env_resolution`
+
+Validation:
+
+- `python3 -m unittest -v tests/test_argus_hardening.py` passed (`21/21`)
+
+## Usage Notes
+
+Example runtime selection:
+
+```bash
+export ARGUS_PROVIDER_PROFILE=aixj_vip_backup
+export ARGUS_PROVIDER_PROFILES_FILE=contracts/provider_profiles.json
+export OPENAI_API_KEY_AIXJ_VIP='***'
+python3 skills/execute_approved_previews.py --once --test-mode off
+```
+
+Without `ARGUS_PROVIDER_PROFILE`, runtime behavior remains backward-compatible
+with existing `OPENAI_*` and secret-based resolution.
+
+## Outcome
+
+`BL-20260325-071` done condition is satisfied at source level:
+
+- governed execute provider selection can now be driven by repository/runtime
+  profile configuration
+- manual desktop secret extraction is no longer required by design
+- misconfiguration is fail-closed and test-covered

--- a/RUNTIME_CONTRACT.md
+++ b/RUNTIME_CONTRACT.md
@@ -316,3 +316,41 @@ Trello Card
 Argus 当前已经从“只讨论架构”推进到：
 
 > **目录、契约、任务类型、任务样本都已可落盘；下一步应直接用模拟 Trello 卡片跑第一次标准任务转译。**
+
+---
+
+## 13. Provider Profile 选择契约（BL-071）
+
+为避免每次执行都手工从桌面文件提取 provider base/key，delegate 层现在支持
+显式 provider profile 选择：
+
+- 选择变量：`ARGUS_PROVIDER_PROFILE`
+- profile 文件：`ARGUS_PROVIDER_PROFILES_FILE`
+  - 未设置时默认读取：`contracts/provider_profiles.json`
+  - 可参考模板：`contracts/provider_profiles.example.json`
+
+### profile JSON 约定
+
+支持两种结构：
+
+- 顶层直接是 profile map
+- 顶层 `{ "profiles": { ... } }`
+
+每个 profile 可配置：
+
+- `api_base` / `openai_api_base` / `base_url`
+- `model_name` / `openai_model_name` / `model`
+- `wire_api`
+- `fallback_chat_urls`
+- `fallback_response_urls`
+- `fallback_api_bases`
+- API key 任选其一：
+  - `api_key`（不推荐明文）
+  - `api_key_env`（推荐）
+  - `api_key_secret`（容器 secret）
+
+### 运行规则
+
+1. 未设置 `ARGUS_PROVIDER_PROFILE` 时，保持旧版环境变量解析行为不变。  
+2. 设置了 profile 时，profile 中给出的值覆盖默认环境解析结果。  
+3. profile 引用的 `api_key_env` / `api_key_secret` 缺失时，fail-closed 并报错，避免静默回落到错误 provider。  

--- a/contracts/provider_profiles.example.json
+++ b/contracts/provider_profiles.example.json
@@ -1,0 +1,19 @@
+{
+  "profiles": {
+    "primary_openai": {
+      "api_base": "https://api.openai.com/v1",
+      "model_name": "gpt-5-codex",
+      "wire_api": "responses",
+      "api_key_env": "OPENAI_API_KEY"
+    },
+    "aixj_vip_backup": {
+      "api_base": "https://aixj.vip/v1",
+      "model_name": "gpt-5-codex",
+      "wire_api": "responses",
+      "api_key_env": "OPENAI_API_KEY_AIXJ_VIP",
+      "fallback_api_bases": [
+        "https://aixj.vip"
+      ]
+    }
+  }
+}

--- a/skills/delegate_task.py
+++ b/skills/delegate_task.py
@@ -47,6 +47,7 @@ REQUIRED_MANAGER_MOUNTS = (
     "/app/dispatcher",
     "/app/agents",
 )
+DEFAULT_PROVIDER_PROFILES_RELATIVE_PATH = Path("contracts/provider_profiles.json")
 
 def resolve_base_dir():
     return Path(os.environ.get("ARGUS_BASE_DIR", str(DEFAULT_BASE_DIR))).resolve()
@@ -255,6 +256,151 @@ def first_env(*names):
     return None
 
 
+def first_profile_value(profile, *keys):
+    for key in keys:
+        value = profile.get(key)
+        if isinstance(value, str):
+            normalized = value.strip()
+            if normalized:
+                return normalized
+    return None
+
+
+def first_profile_raw(profile, *keys):
+    for key in keys:
+        if key in profile:
+            return profile.get(key)
+    return None
+
+
+def normalize_csv_env_value(value):
+    if value is None:
+        return None
+    if isinstance(value, str):
+        normalized = value.strip()
+        return normalized or None
+    if isinstance(value, (list, tuple)):
+        items = []
+        for item in value:
+            normalized = str(item).strip()
+            if normalized:
+                items.append(normalized)
+        if items:
+            return ",".join(items)
+    return None
+
+
+def resolve_provider_profiles_path():
+    configured = first_env("ARGUS_PROVIDER_PROFILES_FILE")
+    if configured:
+        path = Path(configured).expanduser()
+        if not path.is_absolute():
+            path = resolve_base_dir() / path
+        return path
+    return resolve_base_dir() / DEFAULT_PROVIDER_PROFILES_RELATIVE_PATH
+
+
+def load_provider_profile(profile_name):
+    profiles_path = resolve_provider_profiles_path()
+    if not profiles_path.exists():
+        raise RuntimeError(
+            f"ARGUS_PROVIDER_PROFILE={profile_name} but provider profiles file "
+            f"is missing: {profiles_path}"
+        )
+
+    try:
+        payload = json.loads(profiles_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise RuntimeError(f"Failed parsing provider profiles file {profiles_path}: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Provider profiles file must contain a JSON object: {profiles_path}")
+
+    profiles = payload.get("profiles", payload)
+    if not isinstance(profiles, dict):
+        raise RuntimeError(
+            "Provider profiles payload must be an object or contain an object under key 'profiles'"
+        )
+
+    profile = profiles.get(profile_name)
+    if not isinstance(profile, dict):
+        available = ", ".join(sorted(str(name) for name in profiles.keys())) or "<none>"
+        raise RuntimeError(
+            f"Provider profile '{profile_name}' not found in {profiles_path}. "
+            f"Available profiles: {available}"
+        )
+    return profile, profiles_path
+
+
+def resolve_profile_api_key(profile_name, profile):
+    direct_key = first_profile_value(profile, "api_key", "openai_api_key")
+    if direct_key:
+        return direct_key
+
+    env_name = first_profile_value(profile, "api_key_env")
+    if env_name:
+        env_value = first_env(env_name)
+        if env_value:
+            return env_value
+        raise RuntimeError(
+            f"Provider profile '{profile_name}' requires env var '{env_name}' for API key, "
+            "but it is not set"
+        )
+
+    secret_name = first_profile_value(profile, "api_key_secret")
+    if secret_name:
+        secret_value = read_secret(secret_name)
+        if secret_value:
+            return secret_value
+        raise RuntimeError(
+            f"Provider profile '{profile_name}' requires docker secret '{secret_name}' for API key, "
+            "but it is not available"
+        )
+    return None
+
+
+def resolve_provider_profile_env(profile_name):
+    profile, profiles_path = load_provider_profile(profile_name)
+    profile_env = {
+        "OPENAI_API_KEY": resolve_profile_api_key(profile_name, profile),
+        "OPENAI_API_BASE": first_profile_value(profile, "api_base", "openai_api_base", "base_url"),
+        "OPENAI_MODEL_NAME": first_profile_value(profile, "model_name", "openai_model_name", "model"),
+        "ARGUS_LLM_WIRE_API": first_profile_value(
+            profile,
+            "wire_api",
+            "openai_wire_api",
+            "llm_wire_api",
+        ),
+        "ARGUS_LLM_FALLBACK_CHAT_URLS": normalize_csv_env_value(
+            first_profile_raw(
+                profile,
+                "fallback_chat_urls",
+                "llm_fallback_chat_urls",
+                "argus_llm_fallback_chat_urls",
+            )
+        ),
+        "ARGUS_LLM_FALLBACK_RESPONSE_URLS": normalize_csv_env_value(
+            first_profile_raw(
+                profile,
+                "fallback_response_urls",
+                "llm_fallback_response_urls",
+                "argus_llm_fallback_response_urls",
+            )
+        ),
+        "ARGUS_LLM_FALLBACK_API_BASES": normalize_csv_env_value(
+            first_profile_raw(
+                profile,
+                "fallback_api_bases",
+                "llm_fallback_api_bases",
+                "argus_llm_fallback_api_bases",
+            )
+        ),
+        "ARGUS_PROVIDER_PROFILE": profile_name,
+        "ARGUS_PROVIDER_PROFILES_FILE": str(profiles_path),
+    }
+    return {key: value for key, value in profile_env.items() if value is not None}
+
+
 def build_worker_env(worker):
     env = {
         "WORKER_NAME": worker,
@@ -289,6 +435,10 @@ def build_worker_env(worker):
     env["ARGUS_LLM_FALLBACK_CHAT_URLS"] = first_env("ARGUS_LLM_FALLBACK_CHAT_URLS")
     env["ARGUS_LLM_FALLBACK_RESPONSE_URLS"] = first_env("ARGUS_LLM_FALLBACK_RESPONSE_URLS")
     env["ARGUS_LLM_FALLBACK_API_BASES"] = first_env("ARGUS_LLM_FALLBACK_API_BASES")
+    provider_profile = first_env("ARGUS_PROVIDER_PROFILE")
+    if provider_profile:
+        # Profile values override ambient defaults when explicitly selected.
+        env.update(resolve_provider_profile_env(provider_profile))
     return {key: value for key, value in env.items() if value is not None}
 
 

--- a/tests/test_argus_hardening.py
+++ b/tests/test_argus_hardening.py
@@ -18,7 +18,7 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from argus_contracts import validate_output  # noqa: E402
 from dispatcher import worker_runtime  # noqa: E402
-from skills.delegate_task import delegate_task  # noqa: E402
+from skills.delegate_task import build_worker_env, delegate_task  # noqa: E402
 
 WORKER_TASK_TYPES = {
     "architect": "design_architecture",
@@ -185,6 +185,108 @@ class ArgusHardeningTests(unittest.TestCase):
 
     def _client(self, behaviors: dict[str, dict[str, Any]]) -> FakeDockerClient:
         return FakeDockerClient(self.tmpdir, behaviors)
+
+    def test_build_worker_env_uses_selected_provider_profile(self) -> None:
+        profiles_path = self.tmpdir / "contracts" / "provider_profiles.json"
+        profiles_path.parent.mkdir(parents=True, exist_ok=True)
+        profiles_path.write_text(
+            json.dumps(
+                {
+                    "profiles": {
+                        "backup": {
+                            "api_base": "https://backup-provider.invalid/v1",
+                            "model_name": "gpt-5-codex",
+                            "wire_api": "responses",
+                            "api_key_env": "OPENAI_API_KEY_BACKUP",
+                            "fallback_response_urls": [
+                                "https://backup-provider.invalid/v1/responses",
+                                "https://backup-provider.invalid/responses",
+                            ],
+                            "fallback_api_bases": ["https://backup-provider.invalid/v1"],
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with mock.patch.dict(
+            os.environ,
+            {
+                "ARGUS_PROVIDER_PROFILE": "backup",
+                "OPENAI_API_KEY": "primary-key",
+                "OPENAI_API_KEY_BACKUP": "backup-key",
+                "OPENAI_API_BASE": "https://primary-provider.invalid/v1",
+                "OPENAI_MODEL_NAME": "primary-model",
+            },
+            clear=False,
+        ):
+            env = build_worker_env("automation")
+
+        self.assertEqual(env["OPENAI_API_KEY"], "backup-key")
+        self.assertEqual(env["OPENAI_API_BASE"], "https://backup-provider.invalid/v1")
+        self.assertEqual(env["OPENAI_MODEL_NAME"], "gpt-5-codex")
+        self.assertEqual(env["ARGUS_LLM_WIRE_API"], "responses")
+        self.assertEqual(
+            env["ARGUS_LLM_FALLBACK_RESPONSE_URLS"],
+            "https://backup-provider.invalid/v1/responses,https://backup-provider.invalid/responses",
+        )
+        self.assertEqual(env["ARGUS_LLM_FALLBACK_API_BASES"], "https://backup-provider.invalid/v1")
+        self.assertEqual(env["ARGUS_PROVIDER_PROFILE"], "backup")
+        self.assertEqual(Path(env["ARGUS_PROVIDER_PROFILES_FILE"]).resolve(), profiles_path.resolve())
+
+    def test_build_worker_env_profile_key_env_missing_raises(self) -> None:
+        profiles_path = self.tmpdir / "contracts" / "provider_profiles.json"
+        profiles_path.parent.mkdir(parents=True, exist_ok=True)
+        profiles_path.write_text(
+            json.dumps(
+                {
+                    "profiles": {
+                        "backup": {
+                            "api_base": "https://backup-provider.invalid/v1",
+                            "model_name": "gpt-5-codex",
+                            "wire_api": "responses",
+                            "api_key_env": "OPENAI_API_KEY_BACKUP_MISSING",
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with mock.patch.dict(
+            os.environ,
+            {
+                "ARGUS_PROVIDER_PROFILE": "backup",
+                "OPENAI_API_KEY": "primary-key",
+                "OPENAI_API_BASE": "https://primary-provider.invalid/v1",
+                "OPENAI_MODEL_NAME": "primary-model",
+            },
+            clear=False,
+        ):
+            with self.assertRaises(RuntimeError) as ctx:
+                build_worker_env("automation")
+
+        self.assertIn("OPENAI_API_KEY_BACKUP_MISSING", str(ctx.exception))
+
+    def test_build_worker_env_without_profile_keeps_legacy_env_resolution(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "primary-key",
+                "OPENAI_API_BASE": "https://primary-provider.invalid/v1",
+                "OPENAI_MODEL_NAME": "primary-model",
+                "ARGUS_LLM_WIRE_API": "chat_completions",
+            },
+            clear=False,
+        ):
+            env = build_worker_env("automation")
+
+        self.assertEqual(env["OPENAI_API_KEY"], "primary-key")
+        self.assertEqual(env["OPENAI_API_BASE"], "https://primary-provider.invalid/v1")
+        self.assertEqual(env["OPENAI_MODEL_NAME"], "primary-model")
+        self.assertEqual(env["ARGUS_LLM_WIRE_API"], "chat_completions")
+        self.assertNotIn("ARGUS_PROVIDER_PROFILE", env)
 
     def test_failed_status_is_taken_from_output_not_exit_code(self) -> None:
         task = build_task(


### PR DESCRIPTION
## Summary
- add provider profile selection to `build_worker_env` using `ARGUS_PROVIDER_PROFILE` + `ARGUS_PROVIDER_PROFILES_FILE`
- add fail-closed handling for invalid profile and missing key references (`api_key_env`/`api_key_secret`)
- add profile config template and BL-071 report/backlog/worklog updates

## Testing
- python3 -m unittest -v tests/test_argus_hardening.py
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh

Closes #135
