### PR TITLE
BL-086: quantify timeout-dominant bottleneck across governed windows

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -1502,3 +1502,37 @@ Allowed enum values:
 - evidence: `JSON_REPAIR_ENGAGED_PATH_CONTROLLED_REPLAY_REPORT.md` records BL-085 controlled replay evidence in `runtime_archives/bl085/`; request trace `tmp/bl085_mock_requests.log` confirms deterministic sequence (`automation_initial_invalid -> automation_repair -> critic_pass`), automation output metadata records `json_output_repair_attempts_used=1`, and execute result reports `processed=1` with `critic_verdict=pass` while output schema contract remains stable
 - last_reviewed_at: 2026-03-26
 - opened_at: 2026-03-26
+
+### BL-20260326-086
+- title: Quantify timeout-dominant failure bottleneck across governed windows and codify mitigation priority
+- type: blocker
+- status: done
+- phase: now
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260326-085
+- start_when: BL-080/081/084 governed evidence repeatedly reports timeout-dominant failure classes, and BL-085 confirms JSON-repair engaged path itself is healthy under controlled replay
+- done_when: A cross-window evidence report quantifies timeout share versus non-timeout classes using archived governed runs and records contract guidance that timeout mitigation remains higher priority than JSON-path tuning while timeout stays dominant
+- source: `RETRY_BUDGET_CONFIDENCE_WINDOW_REPORT.md`, `JSON_REPAIR_ENGAGEMENT_CONFIDENCE_WINDOW_REPORT.md`, and `JSON_REPAIR_ENGAGED_PATH_CONTROLLED_REPLAY_REPORT.md` on 2026-03-26 indicate persistent timeout concentration after retry-budget and JSON-repair hardening
+- link: /Users/lingguozhong/openclaw-team/TIMEOUT_BOTTLENECK_CONFIDENCE_WINDOW_REPORT.md
+- issue: https://github.com/Oscarling/openclaw-team/issues/165
+- evidence: `TIMEOUT_BOTTLENECK_CONFIDENCE_WINDOW_REPORT.md` aggregates BL-080/081/083/084/085 windows into `runtime_archives/bl086/tmp/bl086_timeout_bottleneck_summary.tsv` and `bl086_timeout_bottleneck_metrics.json`; measured timeout concentration is `9/11` failed rows (`81.82%`) with terminal JSON-invalid `0/14`, so contract guidance now prioritizes timeout-path mitigation while keeping baseline budgets unchanged
+- last_reviewed_at: 2026-03-26
+- opened_at: 2026-03-26
+
+### BL-20260326-087
+- title: Run governed timeout failover drill with fallback endpoint profile and rollback criteria
+- type: blocker
+- status: planned
+- phase: next
+- priority: p1
+- owner: Oscarling
+- depends_on: BL-20260326-086
+- start_when: BL-086 confirms timeout remains dominant and runtime contract prioritizes timeout-path mitigation
+- done_when: A governed failover drill validates timeout recovery behavior using fallback endpoint configuration, with activation/rollback criteria and archived execute/runtime/state evidence
+- source: `TIMEOUT_BOTTLENECK_CONFIDENCE_WINDOW_REPORT.md` on 2026-03-26 shows timeout share among failures `81.82%`, indicating next mitigation should test timeout failover path under governance
+- link: -
+- issue: -
+- evidence: -
+- last_reviewed_at: 2026-03-26
+- opened_at: 2026-03-26

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -4901,3 +4901,48 @@ Verification snapshot on 2026-03-26:
   - `runtime_archives/bl085/runtime/automation-runtime.controlled.log`
   - `runtime_archives/bl085/runtime/automation-output.controlled.json`
   - `runtime_archives/bl085/state/preview-trello-69c24cd3c1a2359ddd7a1bf8-687ebc83a153.result.controlled.json`
+
+### 96. BL-086 Timeout-Dominant Bottleneck Cross-Window Quantification And Priority Freeze
+
+User objective:
+
+- continue strict no-drift flow
+- keep progressing after BL-085 completion
+- quantify whether timeout is still the top blocker with consolidated evidence
+
+Main work areas:
+
+- activated `BL-20260326-086` and mirrored to issue `#165`
+- aggregated governed replay windows from BL-080/081/083/084/085 into BL-086 summary artifacts:
+  - `runtime_archives/bl086/tmp/bl086_timeout_bottleneck_summary.tsv`
+  - `runtime_archives/bl086/tmp/bl086_timeout_bottleneck_metrics.json`
+- measured cross-window bottleneck concentration:
+  - total rows: `14`
+  - failed rows: `11`
+  - timeout failed rows: `9`
+  - timeout share among failures: `81.82%`
+  - timeout share overall: `64.29%`
+  - terminal JSON-invalid rows: `0/14`
+- updated runtime contract with BL-086 priority guidance:
+  - keep baseline defaults (`ARGUS_AUTOMATION_TRANSIENT_RETRY_ATTEMPTS=1`, `ARGUS_LLM_JSON_REPAIR_ATTEMPTS=1`)
+  - when timeout share remains dominant, prioritize timeout-path mitigation over JSON-path budget tuning
+- completed backlog and queued next blocker:
+  - `BL-20260326-086` marked `done`
+  - queued `BL-20260326-087` (`planned` / `next`) for governed timeout failover drill
+
+Primary output:
+
+- [TIMEOUT_BOTTLENECK_CONFIDENCE_WINDOW_REPORT.md](/Users/lingguozhong/openclaw-team/TIMEOUT_BOTTLENECK_CONFIDENCE_WINDOW_REPORT.md)
+
+Key result:
+
+- consolidated evidence confirms timeout remains the primary reliability blocker
+  after retry-budget and JSON-repair hardening; mitigation priority is now
+  explicitly frozen to timeout path first.
+
+Verification snapshot on 2026-03-26:
+
+- aggregated matrix:
+  - `runtime_archives/bl086/tmp/bl086_timeout_bottleneck_summary.tsv`
+- aggregated metrics:
+  - `runtime_archives/bl086/tmp/bl086_timeout_bottleneck_metrics.json`

--- a/RUNTIME_CONTRACT.md
+++ b/RUNTIME_CONTRACT.md
@@ -452,3 +452,19 @@ malformed-output 回放并归档证据，口径如下：
 4. 该受控回放仅用于验证已触发路径，不改变默认参数：
    - `ARGUS_LLM_JSON_REPAIR_ATTEMPTS=1`
    - `ARGUS_AUTOMATION_TRANSIENT_RETRY_ATTEMPTS=1`
+
+### BL-086 timeout 主瓶颈优先级口径（跨窗口）
+
+当跨窗口证据中 `timeout` 仍是主要失败类别时，运行优先级应固定如下：
+
+1. 默认参数保持不变：  
+   - `ARGUS_AUTOMATION_TRANSIENT_RETRY_ATTEMPTS=1`  
+   - `ARGUS_LLM_JSON_REPAIR_ATTEMPTS=1`
+2. 在进入 JSON 路径参数调优前，先完成 timeout 路径治理：
+   - provider 可用性与时延波动排查
+   - fallback 端点/路由策略验证
+   - timeout 恢复与回放证据归档
+3. 若跨窗口统计满足：
+   - `timeout_share_among_failures >= 0.6`
+   - 且 `json_invalid_terminal_rate` 接近 `0`
+   则默认判定 timeout 为当前首要阻塞项，不将主失败归因于 JSON 修复预算。

--- a/TIMEOUT_BOTTLENECK_CONFIDENCE_WINDOW_REPORT.md
+++ b/TIMEOUT_BOTTLENECK_CONFIDENCE_WINDOW_REPORT.md
@@ -1,0 +1,84 @@
+# Timeout Bottleneck Confidence Window Report
+
+## Objective
+
+Complete `BL-20260326-086` by quantifying timeout-dominant failure concentration
+across governed replay windows, then codify mitigation priority in runtime
+guidance.
+
+## Scope
+
+In scope:
+
+- aggregate archived governed replay evidence from BL-080/081/083/084/085
+- quantify timeout share among failed rows and overall sample
+- confirm whether terminal JSON-invalid remains a meaningful failure class
+- freeze mitigation priority guidance based on measured distribution
+
+Out of scope:
+
+- introducing new provider credentials or endpoints
+- changing default retry/JSON-repair budgets
+
+## Evidence Inputs
+
+Source matrices:
+
+- `runtime_archives/bl080/tmp/bl080_budget_tradeoff_matrix.tsv`
+- `runtime_archives/bl081/tmp/bl081_time_spread_matrix.tsv`
+- `runtime_archives/bl083/tmp/bl083_replay_summary.tsv`
+- `runtime_archives/bl084/tmp/bl084_json_repair_confidence_matrix.tsv`
+- `runtime_archives/bl085/tmp/bl085_controlled_replay_summary.tsv`
+
+BL-086 aggregated outputs:
+
+- `runtime_archives/bl086/tmp/bl086_timeout_bottleneck_summary.tsv`
+- `runtime_archives/bl086/tmp/bl086_timeout_bottleneck_metrics.json`
+
+## Aggregated Results
+
+From `bl086_timeout_bottleneck_metrics.json`:
+
+- sample size: `14`
+- processed: `3`
+- rejected: `11`
+- processed rate: `21.43%`
+- failed rows: `11`
+- timeout failed rows: `9`
+- timeout share among failures: `81.82%`
+- timeout share overall: `64.29%`
+- terminal JSON-invalid rows: `0`
+- terminal JSON-invalid rate: `0%`
+- average wall time: `238.0s`
+- failed error-class distribution:
+  - `timeout`: `9`
+  - `none`: `2`
+
+## Interpretation
+
+- Timeout remains the dominant failure class by a large margin in governed
+  windows after retry-budget and JSON-repair hardening work.
+- JSON-validity terminal failures are currently absent in this confidence
+  window (`0/14`), consistent with BL-083/084/085 evidence that JSON path is no
+  longer the primary blocker.
+- Current reliability uplift is more likely to come from timeout-path mitigation
+  (provider latency/availability handling and failover governance) than from
+  increasing JSON repair or transient retry defaults.
+
+## Decision
+
+Guidance freeze:
+
+- keep baseline defaults:
+  - `ARGUS_AUTOMATION_TRANSIENT_RETRY_ATTEMPTS=1`
+  - `ARGUS_LLM_JSON_REPAIR_ATTEMPTS=1`
+- when failures are timeout-dominant, prioritize timeout mitigation work before
+  tuning JSON-path budgets.
+
+## Outcome
+
+`BL-20260326-086` objective is achieved:
+
+- cross-window timeout concentration is quantified with archived evidence
+- runtime guidance now explicitly prioritizes timeout-path mitigation under
+  timeout-dominant windows

--- a/runtime_archives/bl086/tmp/bl086_timeout_bottleneck_metrics.json
+++ b/runtime_archives/bl086/tmp/bl086_timeout_bottleneck_metrics.json
@@ -1,0 +1,17 @@
+{
+  "sample_size": 14,
+  "processed": 3,
+  "rejected": 11,
+  "processed_rate": 0.2143,
+  "failed_rows": 11,
+  "timeout_failed_rows": 9,
+  "timeout_share_among_failures": 0.8182,
+  "timeout_share_overall": 0.6429,
+  "json_invalid_terminal_rows": 0,
+  "json_invalid_terminal_rate": 0.0,
+  "avg_wall_seconds": 238.0,
+  "failed_error_class_distribution": {
+    "none": 2,
+    "timeout": 9
+  }
+}

--- a/runtime_archives/bl086/tmp/bl086_timeout_bottleneck_summary.tsv
+++ b/runtime_archives/bl086/tmp/bl086_timeout_bottleneck_summary.tsv
@@ -1,0 +1,15 @@
+source	run_id	processed	rejected	critic_verdict	auto_error_class	json_invalid_terminal	wall_seconds
+bl080	b1-run01	0	1	needs_revision	none	no	107
+bl080	b1-run02	0	1	needs_revision	timeout	no	241
+bl080	b2-run01	0	1	needs_revision	timeout	no	250
+bl080	b2-run02	0	1	fail	none	no	375
+bl081	s01	0	1	needs_revision	timeout	no	241
+bl081	s02	0	1	needs_revision	timeout	no	362
+bl081	s03	0	1	needs_revision	timeout	no	241
+bl081	s04	1	0	pass	none	no	116
+bl083	run01-b2	1	0	pass	none	no	131
+bl084	s01	0	1	needs_revision	timeout	no	241
+bl084	s02	0	1	needs_revision	timeout	no	306
+bl084	s03	0	1	needs_revision	timeout	no	242
+bl084	s04	0	1	needs_revision	timeout	no	241
+bl085	controlled-01	1	0	pass	none	no	


### PR DESCRIPTION
## Summary
- complete BL-086 by aggregating BL-080/081/083/084/085 governed evidence into a single timeout bottleneck view
- add BL-086 report and archive summary/metrics artifacts under runtime_archives/bl086
- update runtime contract to freeze timeout-first mitigation priority while timeout remains dominant

## Aggregated Metrics
- sample_size: 14
- processed: 3
- rejected: 11
- timeout_failed_rows: 9/11 (81.82% of failures)
- timeout_share_overall: 9/14 (64.29%)
- json_invalid_terminal_rows: 0/14

## Evidence
- report: TIMEOUT_BOTTLENECK_CONFIDENCE_WINDOW_REPORT.md
- summary: runtime_archives/bl086/tmp/bl086_timeout_bottleneck_summary.tsv
- metrics: runtime_archives/bl086/tmp/bl086_timeout_bottleneck_metrics.json

## Validation
- python3 scripts/backlog_lint.py
- python3 scripts/backlog_sync.py
- bash scripts/premerge_check.sh

Closes #165