### PR TITLE
feat: align delivery status guidance after formal finalization

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -2845,3 +2845,20 @@ Allowed enum values:
 - evidence: `PR_MAINLINE_DEEPSEEK_CLOSEOUT_HANDOFF.md` captures scope (`BL-099` through `BL-164`), finalization result, verification gates (`premerge/preflight`), and rollback guidance
 - last_reviewed_at: 2026-03-29
 - opened_at: 2026-03-29
+
+### BL-20260329-165
+- title: Align delivery-status next step for post-finalization stable-maintenance stage
+- type: debt
+- status: done
+- phase: next
+- priority: p2
+- owner: Oscarling
+- depends_on: BL-20260329-164
+- start_when: `BL-162` formal finalization is complete but delivery-status ready-path guidance still points to finalization preflight, producing stale operator instructions
+- done_when: `project_delivery_status.py` detects `BL-20260329-162=done` and emits a stable-maintenance next step while preserving ready-state enum compatibility, with regression tests covering the post-finalization branch
+- source: mainline continuation to keep delivery-stage guidance accurate after end-to-end closure
+- link: /Users/lingguozhong/openclaw-team/PROJECT_DELIVERY_STATUS_POST_FINALIZATION_STAGE_ALIGNMENT_REPORT.md
+- issue: -
+- evidence: `scripts/project_delivery_status.py`, `tests/test_project_delivery_status.py`, and `runtime_archives/bl100/tmp/project_delivery_status_post_finalization_alignment.json` confirm post-finalization next-step alignment
+- last_reviewed_at: 2026-03-29
+- opened_at: 2026-03-29

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -8453,3 +8453,40 @@ Verification snapshot on 2026-03-29:
 
 - `python3 scripts/backlog_lint.py` (passed)
 - `bash scripts/premerge_check.sh` (passed, `Failures: 0`)
+
+### 180. BL-20260329-165 Delivery Post-Finalization Guidance Alignment (Done)
+
+User objective:
+
+- continue the mainline after merge/finalization closure and keep delivery board
+  guidance operationally correct without changing existing ready-state enums.
+
+Main work areas:
+
+- post-finalization delivery-stage alignment:
+  - `scripts/project_delivery_status.py`
+  - adds `FINALIZATION_CLOSEOUT_ID=BL-20260329-162`.
+  - when chain is clear + onboarding is ready + `BL-162=done`, next step now
+    reports formal finalization already completed and mainline in
+    stable-maintenance stage.
+  - preserves `delivery_state=ready_for_replay` to avoid consumer contract
+    break.
+- regression coverage:
+  - `tests/test_project_delivery_status.py`
+  - adds
+    `test_build_status_payload_points_to_stable_stage_after_finalization_closeout`.
+- evidence packaging:
+  - adds
+    `PROJECT_DELIVERY_STATUS_POST_FINALIZATION_STAGE_ALIGNMENT_REPORT.md`
+  - writes status snapshot:
+    `runtime_archives/bl100/tmp/project_delivery_status_post_finalization_alignment.json`.
+
+Key result:
+
+- delivery status no longer suggests preflight work after finalization has
+  already succeeded; stage guidance is now accurate for closed-loop mainline.
+
+Verification snapshot on 2026-03-29:
+
+- `python3 -m unittest -v tests/test_project_delivery_status.py` (passed)
+- `python3 scripts/project_delivery_status.py --backlog PROJECT_BACKLOG.md --summary-json runtime_archives/bl100/tmp/provider_onboarding_gate_history_summary.json --repo-root /Users/lingguozhong/openclaw-team --output-json runtime_archives/bl100/tmp/project_delivery_status_post_finalization_alignment.json --output-md runtime_archives/bl100/tmp/project_delivery_status_post_finalization_alignment.md` (passed)

--- a/PROJECT_DELIVERY_STATUS_POST_FINALIZATION_STAGE_ALIGNMENT_REPORT.md
+++ b/PROJECT_DELIVERY_STATUS_POST_FINALIZATION_STAGE_ALIGNMENT_REPORT.md
@@ -1,0 +1,35 @@
+# Project Delivery Status Post-Finalization Stage Alignment Report
+
+## Context
+
+After formal finalization completed (`BL-20260329-162`), delivery status output
+still used a preflight-oriented next step because the ready-path logic only
+distinguished:
+
+- before canary closeout
+- after canary closeout (preflight next step)
+
+It did not yet recognize the post-finalization stage.
+
+## Change
+
+- Updated `scripts/project_delivery_status.py`:
+  - added `FINALIZATION_CLOSEOUT_ID = BL-20260329-162`
+  - in the `onboarding_status=ready` + chain-clear branch:
+    - when `BL-162=done`, next step now reports formal finalization already
+      completed and mainline is in stable-maintenance stage
+    - preserves `delivery_state=ready_for_replay` for compatibility with
+      existing consumers
+- Added regression test:
+  - `test_build_status_payload_points_to_stable_stage_after_finalization_closeout`
+  - file: `tests/test_project_delivery_status.py`
+
+## Result
+
+- Delivery status guidance is now stage-correct after full closure.
+- No enum/contract break for existing ready-state gates.
+
+## Verification
+
+- `python3 -m unittest -v tests/test_project_delivery_status.py` (passed)
+- `python3 scripts/project_delivery_status.py --backlog PROJECT_BACKLOG.md --summary-json runtime_archives/bl100/tmp/provider_onboarding_gate_history_summary.json --repo-root /Users/lingguozhong/openclaw-team --output-json runtime_archives/bl100/tmp/project_delivery_status_post_finalization_alignment.json --output-md runtime_archives/bl100/tmp/project_delivery_status_post_finalization_alignment.md` (passed)

--- a/runtime_archives/bl100/tmp/project_delivery_status_post_finalization_alignment.json
+++ b/runtime_archives/bl100/tmp/project_delivery_status_post_finalization_alignment.json
@@ -1,0 +1,56 @@
+{
+  "status": "ok",
+  "delivery_state": "ready_for_replay",
+  "repo_root": "/Users/lingguozhong/openclaw-team",
+  "current_branch": "codex/post-finalization-status-alignment",
+  "backlog": {
+    "path": "PROJECT_BACKLOG.md",
+    "total": 165,
+    "done": 164,
+    "completion_percent": 99.39,
+    "status_counts": {
+      "done": 164,
+      "planned": 1
+    },
+    "phase_counts": {
+      "now": 93,
+      "later": 1,
+      "next": 71
+    }
+  },
+  "critical_provider_chain": {
+    "ids": [
+      "BL-20260326-099"
+    ],
+    "items": [
+      {
+        "id": "BL-20260326-099",
+        "status": "done",
+        "phase": "next",
+        "priority": "p1",
+        "title": "Onboard a new provider/base topology and clear route handshake gate before replay"
+      }
+    ],
+    "is_clear": true,
+    "blockers": []
+  },
+  "onboarding_latest": {
+    "timestamp": "2026-03-29T16:05:39",
+    "stamp": "20260329",
+    "status": "ready",
+    "block_reason": "none",
+    "exit_code": 0,
+    "note_class_counts": {
+      "other": 2
+    },
+    "probe_tsv": "/Users/lingguozhong/openclaw-team/runtime_archives/bl100/tmp/deepseek_desktop/provider_handshake_probe_gate_20260329.tsv",
+    "assessment_json": "/Users/lingguozhong/openclaw-team/runtime_archives/bl100/tmp/deepseek_desktop/provider_handshake_assessment_gate_20260329.json",
+    "assessment_snapshot_json": "/Users/lingguozhong/openclaw-team/runtime_archives/bl100/tmp/provider_handshake_assessment_snapshots/provider_handshake_assessment_gate_20260329_20260329T160539.json"
+  },
+  "onboarding_summary_path": "runtime_archives/bl100/tmp/provider_onboarding_gate_history_summary.json",
+  "blocking_signal": {},
+  "blocking_action": "",
+  "next_steps": [
+    "formal finalization 已完成（git push + Trello Done 已闭环）；当前主线进入稳定维护阶段。"
+  ]
+}

--- a/runtime_archives/bl100/tmp/project_delivery_status_post_finalization_alignment.md
+++ b/runtime_archives/bl100/tmp/project_delivery_status_post_finalization_alignment.md
@@ -1,0 +1,16 @@
+# Project Delivery Status
+
+- delivery_state: `ready_for_replay`
+- current_branch: `codex/post-finalization-status-alignment`
+- completion: `164/165` (99.39%)
+
+## Critical Provider Chain
+- `BL-20260326-099` status=`done` phase=`next` priority=`p1` title=Onboard a new provider/base topology and clear route handshake gate before replay
+
+## Onboarding Latest
+- status: `ready`
+- block_reason: `none`
+- timestamp: `2026-03-29T16:05:39`
+
+## Next Steps
+- formal finalization 已完成（git push + Trello Done 已闭环）；当前主线进入稳定维护阶段。

--- a/scripts/project_delivery_status.py
+++ b/scripts/project_delivery_status.py
@@ -13,6 +13,7 @@ CRITICAL_PROVIDER_CHAIN_IDS = [
     "BL-20260326-099",
 ]
 REPLAY_CANARY_CLOSEOUT_ID = "BL-20260329-160"
+FINALIZATION_CLOSEOUT_ID = "BL-20260329-162"
 BLOCKING_ACTIONS_BY_REASON = {
     "provider_account_arrearage": (
         "暂停 replay 重试，先恢复 provider account 账务状态（Arrearage/overdue-payment）后再重跑 onboarding gate。"
@@ -184,7 +185,12 @@ def _build_delivery_state(
 
     if onboarding_status == "ready":
         canary_closeout = chain_index.get(REPLAY_CANARY_CLOSEOUT_ID)
-        if canary_closeout and canary_closeout.get("status", "") == "done":
+        finalization_closeout = chain_index.get(FINALIZATION_CLOSEOUT_ID)
+        if finalization_closeout and finalization_closeout.get("status", "") == "done":
+            next_steps.append(
+                "formal finalization 已完成（git push + Trello Done 已闭环）；当前主线进入稳定维护阶段。"
+            )
+        elif canary_closeout and canary_closeout.get("status", "") == "done":
             next_steps.append(
                 "controlled replay 与 canary 已完成，进入 finalization preflight（配置 GIT_PUSH_REMOTE/GIT_PUSH_BRANCH/TRELLO_* 并清理工作区）。"
             )

--- a/tests/test_project_delivery_status.py
+++ b/tests/test_project_delivery_status.py
@@ -152,6 +152,46 @@ class ProjectDeliveryStatusTests(unittest.TestCase):
             self.assertIn("finalization preflight", joined)
             self.assertNotIn("进入 controlled replay 与 canary 收尾流程。", joined)
 
+    def test_build_status_payload_points_to_stable_stage_after_finalization_closeout(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="project-delivery-status-") as tmp:
+            root = Path(tmp)
+            backlog_path = root / "PROJECT_BACKLOG.md"
+            summary_path = root / "summary.json"
+
+            chain_status = {item_id: "done" for item_id in status.CRITICAL_PROVIDER_CHAIN_IDS}
+            backlog_text = _backlog_markdown(chain_status=chain_status)
+            backlog_text += (
+                "\n### BL-20260329-160\n"
+                "- title: DeepSeek canary closeout\n"
+                "- status: done\n"
+                "- phase: next\n"
+                "- priority: p1\n"
+                "- depends_on: BL-20260329-159\n"
+                "\n### BL-20260329-162\n"
+                "- title: Formal finalization completion\n"
+                "- status: done\n"
+                "- phase: next\n"
+                "- priority: p1\n"
+                "- depends_on: BL-20260329-161\n"
+            )
+            backlog_path.write_text(backlog_text, encoding="utf-8")
+            summary_path.write_text(
+                json.dumps({"latest": {"status": "ready", "block_reason": "", "timestamp": "2026-03-29T17:20:00"}}),
+                encoding="utf-8",
+            )
+
+            payload = status.build_status_payload(
+                backlog_path=backlog_path,
+                summary_json_path=summary_path,
+                repo_root=root,
+                current_branch="main",
+            )
+
+            self.assertEqual(payload["delivery_state"], "ready_for_replay")
+            joined = " ".join(payload["next_steps"])
+            self.assertIn("formal finalization 已完成", joined)
+            self.assertNotIn("finalization preflight", joined)
+
     def test_build_status_payload_mentions_arrearage_when_handshake_ready_but_bl099_blocked(self) -> None:
         with tempfile.TemporaryDirectory(prefix="project-delivery-status-") as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
This PR aligns delivery-status next-step guidance for the stage after formal finalization has already completed.

Before this change, the ready-path still suggested finalization preflight even when `BL-20260329-162` was done.
After this change, status guidance reports the closed-loop state directly.

## What Changed
- `scripts/project_delivery_status.py`
  - adds `FINALIZATION_CLOSEOUT_ID = BL-20260329-162`
  - in the chain-clear + onboarding-ready branch:
    - if `BL-162=done`, emit stable-maintenance guidance
    - keep `delivery_state=ready_for_replay` for consumer compatibility
- `tests/test_project_delivery_status.py`
  - adds `test_build_status_payload_points_to_stable_stage_after_finalization_closeout`
- governance/evidence updates:
  - `PROJECT_DELIVERY_STATUS_POST_FINALIZATION_STAGE_ALIGNMENT_REPORT.md`
  - `PROJECT_BACKLOG.md` adds `BL-20260329-165` (done)
  - `PROJECT_CHAT_AND_WORK_LOG.md` adds entry 180

## Validation
- `python3 -m unittest -v tests/test_project_delivery_status.py` (pass)
- `python3 scripts/project_delivery_status.py --backlog PROJECT_BACKLOG.md --summary-json runtime_archives/bl100/tmp/provider_onboarding_gate_history_summary.json --repo-root /Users/lingguozhong/openclaw-team --output-json runtime_archives/bl100/tmp/project_delivery_status_post_finalization_alignment.json --output-md runtime_archives/bl100/tmp/project_delivery_status_post_finalization_alignment.md` (pass)
- `python3 scripts/backlog_lint.py` (pass)
- `bash scripts/premerge_check.sh` (pass, `Failures: 0`)
