### PR TITLE
feat: harden delivery-status summary path fallback

### DIFF
--- a/PROJECT_BACKLOG.md
+++ b/PROJECT_BACKLOG.md
@@ -2862,3 +2862,20 @@ Allowed enum values:
 - evidence: `scripts/project_delivery_status.py`, `tests/test_project_delivery_status.py`, and `runtime_archives/bl100/tmp/project_delivery_status_post_finalization_alignment.json` confirm post-finalization next-step alignment
 - last_reviewed_at: 2026-03-29
 - opened_at: 2026-03-29
+
+### BL-20260329-166
+- title: Add onboarding summary default-path fallback in delivery status to avoid false unknown state
+- type: debt
+- status: done
+- phase: next
+- priority: p2
+- owner: Oscarling
+- depends_on: BL-20260329-165
+- start_when: Delivery status is already in stable-maintenance stage after formal finalization, but stale/manual `--summary-json` inputs can still point to missing legacy paths and falsely downgrade status to `unknown_waiting_signal`
+- done_when: `project_delivery_status.py` falls back to canonical default onboarding summary when requested path is missing, regression tests cover the fallback branch, and command output remains `ready_for_replay` under missing legacy-path input
+- source: mainline continuation to prioritize run-through reliability and reduce operator footguns during post-finalization maintenance
+- link: /Users/lingguozhong/openclaw-team/PROJECT_DELIVERY_STATUS_SUMMARY_FALLBACK_ALIGNMENT_REPORT.md
+- issue: -
+- evidence: `scripts/project_delivery_status.py`, `tests/test_project_delivery_status.py`, `PROJECT_DELIVERY_STATUS_SUMMARY_FALLBACK_ALIGNMENT_REPORT.md`, and `runtime_archives/bl100/tmp/project_delivery_status_summary_fallback_alignment.json` confirm default-path fallback behavior and preserved ready-state guidance
+- last_reviewed_at: 2026-03-29
+- opened_at: 2026-03-29

--- a/PROJECT_CHAT_AND_WORK_LOG.md
+++ b/PROJECT_CHAT_AND_WORK_LOG.md
@@ -8490,3 +8490,40 @@ Verification snapshot on 2026-03-29:
 
 - `python3 -m unittest -v tests/test_project_delivery_status.py` (passed)
 - `python3 scripts/project_delivery_status.py --backlog PROJECT_BACKLOG.md --summary-json runtime_archives/bl100/tmp/provider_onboarding_gate_history_summary.json --repo-root /Users/lingguozhong/openclaw-team --output-json runtime_archives/bl100/tmp/project_delivery_status_post_finalization_alignment.json --output-md runtime_archives/bl100/tmp/project_delivery_status_post_finalization_alignment.md` (passed)
+
+### 181. BL-20260329-166 Delivery Summary-Path Fallback Alignment (Done)
+
+User objective:
+
+- prioritize run-through continuity on the mainline and avoid false
+  `unknown_waiting_signal` regressions caused by stale manual summary-path
+  inputs.
+
+Main work areas:
+
+- delivery summary fallback hardening:
+  - `scripts/project_delivery_status.py`
+  - introduces canonical summary constant
+    `DEFAULT_ONBOARDING_SUMMARY_JSON`.
+  - when requested `--summary-json` path is missing, automatically falls back
+    to canonical default summary under repo root.
+  - records the effective path in `onboarding_summary_path`.
+- regression coverage:
+  - `tests/test_project_delivery_status.py`
+  - adds
+    `test_build_status_payload_falls_back_to_default_summary_when_requested_path_missing`.
+- governance evidence:
+  - adds
+    `PROJECT_DELIVERY_STATUS_SUMMARY_FALLBACK_ALIGNMENT_REPORT.md`.
+  - adds backlog item `BL-20260329-166` (done).
+
+Key result:
+
+- delivery status now remains `ready_for_replay` in post-finalization
+  maintenance even when operators pass a missing legacy summary path, as long as
+  canonical onboarding summary exists.
+
+Verification snapshot on 2026-03-29:
+
+- `python3 -m unittest -v tests/test_project_delivery_status.py` (passed, 10 tests)
+- `python3 scripts/project_delivery_status.py --summary-json runtime_archives/bl100/provider_onboarding_summary.json --output-json runtime_archives/bl100/tmp/project_delivery_status_summary_fallback_alignment.json --output-md runtime_archives/bl100/tmp/project_delivery_status_summary_fallback_alignment.md` (passed: auto-fallback to canonical summary path and `delivery_state=ready_for_replay`)

--- a/PROJECT_DELIVERY_STATUS_SUMMARY_FALLBACK_ALIGNMENT_REPORT.md
+++ b/PROJECT_DELIVERY_STATUS_SUMMARY_FALLBACK_ALIGNMENT_REPORT.md
@@ -1,0 +1,44 @@
+# Project Delivery Status Summary Fallback Alignment Report
+
+Date: 2026-03-29
+Owner: Oscarling
+
+## Objective
+
+Keep the delivery-status mainline "run-through" signal stable when operators pass
+an outdated/missing onboarding summary path, so status no longer falls back to
+`unknown_waiting_signal` in an otherwise completed post-finalization stage.
+
+## Root Cause
+
+`scripts/project_delivery_status.py` only loaded onboarding summary from the
+explicit `--summary-json` path. If that path was missing, onboarding state became
+empty and delivery-state evaluation dropped into `missing_onboarding_signal`,
+even when the canonical default summary file was present and valid.
+
+## Changes
+
+- `scripts/project_delivery_status.py`
+  - added `DEFAULT_ONBOARDING_SUMMARY_JSON` constant as the canonical summary path.
+  - added `_repo_scoped_path(...)` helper to resolve relative paths under
+    `repo_root`.
+  - when the requested summary path is missing, automatically falls back to the
+    canonical default summary path if it exists.
+  - reports the effective summary path via `onboarding_summary_path`.
+- `tests/test_project_delivery_status.py`
+  - added
+    `test_build_status_payload_falls_back_to_default_summary_when_requested_path_missing`
+    to enforce fallback behavior and prevent regression.
+
+## Verification
+
+- `python3 -m unittest -v tests/test_project_delivery_status.py` (passed, 10 tests)
+- `python3 scripts/project_delivery_status.py --summary-json runtime_archives/bl100/provider_onboarding_summary.json --output-json runtime_archives/bl100/tmp/project_delivery_status_summary_fallback_alignment.json --output-md runtime_archives/bl100/tmp/project_delivery_status_summary_fallback_alignment.md` (passed)
+  - output `delivery_state=ready_for_replay`
+  - output `onboarding_summary_path=runtime_archives/bl100/tmp/provider_onboarding_gate_history_summary.json`
+  - output next step remains post-finalization stable-maintenance guidance
+
+## Outcome
+
+Delivery-status output is now resilient to stale summary-path invocations while
+preserving existing ready-state semantics and post-finalization guidance.

--- a/runtime_archives/bl100/tmp/project_delivery_status_summary_fallback_alignment.json
+++ b/runtime_archives/bl100/tmp/project_delivery_status_summary_fallback_alignment.json
@@ -1,0 +1,56 @@
+{
+  "status": "ok",
+  "delivery_state": "ready_for_replay",
+  "repo_root": "/Users/lingguozhong/openclaw-team",
+  "current_branch": "codex/delivery-summary-fallback-alignment",
+  "backlog": {
+    "path": "PROJECT_BACKLOG.md",
+    "total": 166,
+    "done": 165,
+    "completion_percent": 99.4,
+    "status_counts": {
+      "done": 165,
+      "planned": 1
+    },
+    "phase_counts": {
+      "now": 93,
+      "later": 1,
+      "next": 72
+    }
+  },
+  "critical_provider_chain": {
+    "ids": [
+      "BL-20260326-099"
+    ],
+    "items": [
+      {
+        "id": "BL-20260326-099",
+        "status": "done",
+        "phase": "next",
+        "priority": "p1",
+        "title": "Onboard a new provider/base topology and clear route handshake gate before replay"
+      }
+    ],
+    "is_clear": true,
+    "blockers": []
+  },
+  "onboarding_latest": {
+    "timestamp": "2026-03-29T16:05:39",
+    "stamp": "20260329",
+    "status": "ready",
+    "block_reason": "none",
+    "exit_code": 0,
+    "note_class_counts": {
+      "other": 2
+    },
+    "probe_tsv": "/Users/lingguozhong/openclaw-team/runtime_archives/bl100/tmp/deepseek_desktop/provider_handshake_probe_gate_20260329.tsv",
+    "assessment_json": "/Users/lingguozhong/openclaw-team/runtime_archives/bl100/tmp/deepseek_desktop/provider_handshake_assessment_gate_20260329.json",
+    "assessment_snapshot_json": "/Users/lingguozhong/openclaw-team/runtime_archives/bl100/tmp/provider_handshake_assessment_snapshots/provider_handshake_assessment_gate_20260329_20260329T160539.json"
+  },
+  "onboarding_summary_path": "runtime_archives/bl100/tmp/provider_onboarding_gate_history_summary.json",
+  "blocking_signal": {},
+  "blocking_action": "",
+  "next_steps": [
+    "formal finalization 已完成（git push + Trello Done 已闭环）；当前主线进入稳定维护阶段。"
+  ]
+}

--- a/runtime_archives/bl100/tmp/project_delivery_status_summary_fallback_alignment.md
+++ b/runtime_archives/bl100/tmp/project_delivery_status_summary_fallback_alignment.md
@@ -1,0 +1,16 @@
+# Project Delivery Status
+
+- delivery_state: `ready_for_replay`
+- current_branch: `codex/delivery-summary-fallback-alignment`
+- completion: `165/166` (99.4%)
+
+## Critical Provider Chain
+- `BL-20260326-099` status=`done` phase=`next` priority=`p1` title=Onboard a new provider/base topology and clear route handshake gate before replay
+
+## Onboarding Latest
+- status: `ready`
+- block_reason: `none`
+- timestamp: `2026-03-29T16:05:39`
+
+## Next Steps
+- formal finalization 已完成（git push + Trello Done 已闭环）；当前主线进入稳定维护阶段。

--- a/scripts/project_delivery_status.py
+++ b/scripts/project_delivery_status.py
@@ -12,6 +12,7 @@ from typing import Any
 CRITICAL_PROVIDER_CHAIN_IDS = [
     "BL-20260326-099",
 ]
+DEFAULT_ONBOARDING_SUMMARY_JSON = "runtime_archives/bl100/tmp/provider_onboarding_gate_history_summary.json"
 REPLAY_CANARY_CLOSEOUT_ID = "BL-20260329-160"
 FINALIZATION_CLOSEOUT_ID = "BL-20260329-162"
 BLOCKING_ACTIONS_BY_REASON = {
@@ -34,6 +35,12 @@ def _load_json(path: Path) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise RuntimeError(f"{path} must contain a JSON object")
     return payload
+
+
+def _repo_scoped_path(path: Path, repo_root: Path) -> Path:
+    if path.is_absolute():
+        return path
+    return repo_root / path
 
 
 def _parse_backlog(backlog_path: Path) -> list[dict[str, str]]:
@@ -242,8 +249,19 @@ def build_status_payload(
 
     onboarding_summary: dict[str, Any] | None = None
     onboarding_latest: dict[str, Any] | None = None
-    if summary_json_path.exists():
-        onboarding_summary = _load_json(summary_json_path)
+    summary_json_path_display = summary_json_path
+    summary_json_path_fs = _repo_scoped_path(summary_json_path, repo_root)
+    default_summary_path_display = Path(DEFAULT_ONBOARDING_SUMMARY_JSON)
+    default_summary_path_fs = _repo_scoped_path(default_summary_path_display, repo_root)
+    if (
+        not summary_json_path_fs.exists()
+        and summary_json_path_display != default_summary_path_display
+        and default_summary_path_fs.exists()
+    ):
+        summary_json_path_display = default_summary_path_display
+        summary_json_path_fs = default_summary_path_fs
+    if summary_json_path_fs.exists():
+        onboarding_summary = _load_json(summary_json_path_fs)
         latest = onboarding_summary.get("latest")
         if isinstance(latest, dict):
             onboarding_latest = latest
@@ -272,7 +290,7 @@ def build_status_payload(
         },
         "critical_provider_chain": chain_summary,
         "onboarding_latest": onboarding_latest or {},
-        "onboarding_summary_path": str(summary_json_path),
+        "onboarding_summary_path": str(summary_json_path_display),
         "blocking_signal": blocking_signal,
         "blocking_action": blocking_action,
         "next_steps": next_steps,
@@ -324,7 +342,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--backlog", default="PROJECT_BACKLOG.md", help="Path to backlog markdown file.")
     parser.add_argument(
         "--summary-json",
-        default="runtime_archives/bl100/tmp/provider_onboarding_gate_history_summary.json",
+        default=DEFAULT_ONBOARDING_SUMMARY_JSON,
         help="Path to provider onboarding summary json.",
     )
     parser.add_argument("--repo-root", default=".", help="Repository root used for branch detection.")

--- a/tests/test_project_delivery_status.py
+++ b/tests/test_project_delivery_status.py
@@ -284,6 +284,40 @@ class ProjectDeliveryStatusTests(unittest.TestCase):
             self.assertIn("no latest onboarding summary found", md)
             self.assertIn("blocking_stage", md)
 
+    def test_build_status_payload_falls_back_to_default_summary_when_requested_path_missing(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="project-delivery-status-") as tmp:
+            root = Path(tmp)
+            backlog_path = root / "PROJECT_BACKLOG.md"
+            requested_missing_path = Path("runtime_archives/bl100/provider_onboarding_summary.json")
+            default_summary_path = root / status.DEFAULT_ONBOARDING_SUMMARY_JSON
+            default_summary_path.parent.mkdir(parents=True, exist_ok=True)
+
+            chain_status = {item_id: "done" for item_id in status.CRITICAL_PROVIDER_CHAIN_IDS}
+            backlog_path.write_text(_backlog_markdown(chain_status=chain_status), encoding="utf-8")
+            default_summary_path.write_text(
+                json.dumps(
+                    {
+                        "latest": {
+                            "status": "ready",
+                            "block_reason": "none",
+                            "timestamp": "2026-03-29T16:05:39",
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            payload = status.build_status_payload(
+                backlog_path=backlog_path,
+                summary_json_path=requested_missing_path,
+                repo_root=root,
+                current_branch="main",
+            )
+
+            self.assertEqual(payload["delivery_state"], "ready_for_replay")
+            self.assertEqual(payload["onboarding_summary_path"], status.DEFAULT_ONBOARDING_SUMMARY_JSON)
+            self.assertEqual(payload["onboarding_latest"]["status"], "ready")
+
     def test_main_require_ready_returns_2_when_not_ready(self) -> None:
         args = SimpleNamespace(
             backlog="PROJECT_BACKLOG.md",


### PR DESCRIPTION
## Summary
- add canonical onboarding summary default constant and repo-scoped fallback loading in scripts/project_delivery_status.py
- avoid false unknown_waiting_signal when a stale or missing legacy --summary-json path is passed
- add regression test for fallback branch and record BL-20260329-166 closeout evidence

## Verification
- python3 -m unittest -v tests/test_project_delivery_status.py
- python3 scripts/backlog_lint.py
- bash scripts/premerge_check.sh
- python3 scripts/project_delivery_status.py --summary-json runtime_archives/bl100/provider_onboarding_summary.json --output-json runtime_archives/bl100/tmp/project_delivery_status_summary_fallback_alignment.json --output-md runtime_archives/bl100/tmp/project_delivery_status_summary_fallback_alignment.md