### PR TITLE
feat: onboard opportunity_scan pipeline + first-run SOP and regression evidence

### DIFF
--- a/adapters/local_inbox_adapter.py
+++ b/adapters/local_inbox_adapter.py
@@ -165,12 +165,43 @@ def validate_external_payload(raw_payload: dict[str, Any], inbox_filename: str) 
         raise RuntimeError("regeneration_token requires an explicit origin_id")
 
     request_type = str(raw_payload.get("request_type", "pdf_to_excel_ocr")).strip().lower()
-    if request_type != "pdf_to_excel_ocr":
+    supported_request_types = {"pdf_to_excel_ocr", "opportunity_scan"}
+    if request_type not in supported_request_types:
         raise RuntimeError(f"Unsupported request_type: {request_type}")
 
     inputs = raw_payload.get("input", {})
     if not isinstance(inputs, dict):
         raise RuntimeError("input must be a JSON object")
+
+    if request_type == "opportunity_scan":
+        goal = inputs.get("goal")
+        if not isinstance(goal, str) or len(goal.strip()) < 6:
+            raise RuntimeError(
+                "input.goal is required for opportunity_scan and must be a non-empty string"
+            )
+
+        constraints = inputs.get("constraints", [])
+        if constraints is None:
+            constraints = []
+        if not isinstance(constraints, list):
+            raise RuntimeError("input.constraints must be an array when provided")
+        for index, item in enumerate(constraints):
+            if not isinstance(item, str) or not item.strip():
+                raise RuntimeError(
+                    f"input.constraints[{index}] must be a non-empty string for opportunity_scan"
+                )
+
+        items = inputs.get("items")
+        if not isinstance(items, list) or not items:
+            raise RuntimeError("input.items must be a non-empty array for opportunity_scan")
+        for index, item in enumerate(items):
+            if not isinstance(item, dict):
+                raise RuntimeError(f"input.items[{index}] must be an object for opportunity_scan")
+            name = item.get("name")
+            if not isinstance(name, str) or len(name.strip()) < 2:
+                raise RuntimeError(
+                    f"input.items[{index}].name must be a non-empty string for opportunity_scan"
+                )
 
     payload_hash = _payload_hash(raw_payload)
     dedupe_keys = [f"hash:{payload_hash}"]
@@ -215,6 +246,13 @@ def _next_task_id(base_dir: Path, prefix: str, origin_id: str) -> str:
     raise RuntimeError(f"Unable to allocate task id for prefix {prefix}")
 
 
+def _slugify_identifier(value: str, *, fallback: str = "inbox", max_len: int = 48) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", str(value or "").strip().lower()).strip("-")
+    if not slug:
+        slug = fallback
+    return slug[:max_len]
+
+
 def normalize_local_inbox_payload(
     raw_payload: dict[str, Any],
     *,
@@ -236,16 +274,6 @@ def normalize_local_inbox_payload(
     source_input = validated["source_input"]
     automation_description = _condense_automation_description(description)
 
-    input_dir = str(inputs.get("input_dir", "~/Desktop/pdf样本")).strip()
-    output_xlsx = str(
-        inputs.get("output_xlsx", "artifacts/outputs/phase8a/pdf_to_excel_from_inbox.xlsx")
-    ).strip()
-    ocr_mode = str(inputs.get("ocr", "auto")).strip().lower()
-    dry_run = bool(inputs.get("dry_run", False))
-
-    automation_artifact = "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py"
-    review_artifact = "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md"
-
     source = {
         "kind": "local_inbox",
         "origin_id": origin_id,
@@ -257,7 +285,174 @@ def normalize_local_inbox_payload(
     source.update({k: v for k, v in source_input.items() if k not in {"kind"}})
     if regeneration_token:
         source["regeneration_token"] = regeneration_token
-    priority = _normalize_priority(raw_payload.get("priority"))
+    priority = _normalize_priority(raw_payload.get("priority", metadata.get("priority")))
+
+    if request_type == "opportunity_scan":
+        goal = str(
+            inputs.get(
+                "goal",
+                "Evaluate listed opportunities and provide decision-ready GO/WATCH/NO-GO guidance.",
+            )
+        ).strip()
+        constraints: list[str] = []
+        for item in inputs.get("constraints", []) or []:
+            if isinstance(item, str):
+                normalized = item.strip()
+                if normalized:
+                    constraints.append(normalized)
+        opportunity_items = [
+            item for item in inputs.get("items", []) if isinstance(item, dict)
+        ]
+
+        slug = _slugify_identifier(origin_id, fallback="opportunity")
+        suffix = payload_hash[:8]
+        analysis_artifact = f"artifacts/analysis/opportunity_scan_{slug}_{suffix}.md"
+        review_artifact = f"artifacts/reviews/opportunity_scan_{slug}_{suffix}_review.md"
+
+        auto_task = {
+            "task_id": _next_task_id(base_dir, "AUTO", origin_id),
+            "worker": "automation",
+            "task_type": "generate_script",
+            "objective": (
+                f"{title}. Generate exactly one structured opportunity analysis report "
+                "artifact based on the provided goal, constraints, and items. "
+                "The report must support practical go/watch/no-go decisions."
+            ),
+            "inputs": {
+                "params": {
+                    "origin_id": origin_id,
+                    "title": title,
+                    "description": automation_description,
+                    "labels": labels,
+                    "goal": goal,
+                    "constraints": constraints,
+                    "items": opportunity_items,
+                    "contract_hints": {
+                        "analysis_completeness": (
+                            "Analyze every listed opportunity item individually before writing "
+                            "a combined recommendation."
+                        ),
+                        "decision_labels": (
+                            "Each item needs exactly one decision label from GO, WATCH, NO-GO."
+                        ),
+                        "actionability": (
+                            "Provide a ranked recommendation and concrete next steps that can "
+                            "be executed within a short validation window."
+                        ),
+                        "evidence_grounding": (
+                            "Use only provided evidence/risks and explicit reasoning; avoid "
+                            "invented market facts."
+                        ),
+                    },
+                }
+            },
+            "expected_outputs": [
+                {"path": analysis_artifact, "type": "doc"},
+            ],
+            "constraints": [
+                "Follow the local inbox normalized request",
+                "Produce only the expected analysis artifact",
+                "Analyze every opportunity item and assign exactly one verdict from GO/WATCH/NO-GO",
+                "Report concrete risks and practical rationale for each verdict",
+                "Include ranked priorities and actionable next steps",
+                "No external writeback or side effects are required for this analysis task",
+            ],
+            "priority": priority,
+            "source": source,
+            "acceptance_criteria": [
+                "Produce the expected analysis artifact at expected_outputs[0].path",
+                "Every input item is analyzed with explicit strengths, risks, and one decision label (GO/WATCH/NO-GO)",
+                "Output includes a clear ranking and practical next-step actions",
+                "Reasoning remains grounded in provided input evidence and constraints",
+            ],
+            "metadata": {
+                "integration_phase": "8B",
+                "pipeline": "inbox->adapter->manager->automation->critic",
+                "request_type": request_type,
+                "payload_hash": payload_hash,
+                "regeneration_token": regeneration_token,
+                "labels": labels,
+                "external_metadata": metadata,
+                "automation_contract_profile": "structured_opportunity_scan_report_with_decision_verdicts",
+            },
+        }
+
+        critic_task = {
+            "task_id": _next_task_id(base_dir, "CRITIC", origin_id),
+            "worker": "critic",
+            "task_type": "review_artifact",
+            "objective": (
+                "Review the generated opportunity analysis report and determine whether it is "
+                "decision-ready. Provide verdict pass/fail/needs_revision with concrete issues."
+            ),
+            "inputs": {
+                "artifacts": [
+                    {"path": analysis_artifact, "type": "doc"},
+                ],
+                "params": {
+                    "origin_id": origin_id,
+                    "title": title,
+                    "description": description,
+                    "labels": labels,
+                    "review_scope": {
+                        "primary_artifact": analysis_artifact,
+                        "required_item_verdicts": ["GO", "WATCH", "NO-GO"],
+                        "goal": (
+                            "Ensure the report can guide real-world prioritization decisions "
+                            "instead of generic brainstorming output."
+                        ),
+                    },
+                },
+            },
+            "expected_outputs": [
+                {"path": review_artifact, "type": "review"},
+            ],
+            "constraints": [
+                "Review must be grounded in the produced analysis artifact",
+                "Check item-by-item completeness, verdict clarity, ranking quality, and actionability",
+                "Return a clear verdict: pass, fail, or needs_revision",
+                "Include metadata.verdict in output",
+                "Generate review artifact markdown for expected_outputs[0].path",
+            ],
+            "priority": priority,
+            "source": source,
+            "acceptance_criteria": [
+                "Produce a review artifact with explicit verdict (pass/fail/needs_revision)",
+            ],
+            "metadata": {
+                "integration_phase": "8B",
+                "pipeline": "inbox->adapter->manager->automation->critic",
+                "request_type": request_type,
+                "payload_hash": payload_hash,
+                "regeneration_token": regeneration_token,
+                "labels": labels,
+                "external_metadata": metadata,
+            },
+        }
+
+        return StandardizedInboxTask(
+            origin_id=origin_id,
+            payload_hash=payload_hash,
+            dedupe_keys=dedupe_keys,
+            regeneration_token=regeneration_token,
+            source=source,
+            title=title,
+            description=description,
+            labels=labels,
+            metadata=metadata,
+            automation_task=auto_task,
+            critic_task=critic_task,
+        )
+
+    input_dir = str(inputs.get("input_dir", "~/Desktop/pdf样本")).strip()
+    output_xlsx = str(
+        inputs.get("output_xlsx", "artifacts/outputs/phase8a/pdf_to_excel_from_inbox.xlsx")
+    ).strip()
+    ocr_mode = str(inputs.get("ocr", "auto")).strip().lower()
+    dry_run = bool(inputs.get("dry_run", False))
+
+    automation_artifact = "artifacts/scripts/pdf_to_excel_ocr_inbox_runner.py"
+    review_artifact = "artifacts/reviews/pdf_to_excel_ocr_inbox_review.md"
 
     auto_task = {
         "task_id": _next_task_id(base_dir, "AUTO", origin_id),

--- a/docs/OPPORTUNITY_SCAN_FIRST_RUN_SOP.md
+++ b/docs/OPPORTUNITY_SCAN_FIRST_RUN_SOP.md
@@ -1,0 +1,164 @@
+# Opportunity Scan First-Run SOP
+
+## 1. Purpose
+
+Use this SOP to run the first real-model validation for `request_type=opportunity_scan` through the governed pipeline:
+
+`inbox -> ingest -> preview -> approval -> execute`.
+
+This SOP is for **real execution** (`--test-mode off`) and includes pass/fail criteria.
+
+---
+
+## 2. Preconditions
+
+1. Run on a topic branch (not `main`).
+2. `opportunity_scan` adapter code and tests are already landed on current branch.
+3. Docker worker runtime is available.
+4. LLM provider key/base/model are prepared (for example DeepSeek OpenAI-compatible endpoint).
+5. `project_delivery_status` remains healthy (`ready_for_replay` expected for current stage).
+
+---
+
+## 3. Input Contract (Minimum)
+
+Place a JSON file in `inbox/` with:
+
+- `title`: non-empty string
+- `description`: non-empty string
+- `request_type`: `opportunity_scan`
+- `input.goal`: non-empty string
+- `input.constraints`: string array (optional but recommended)
+- `input.items`: non-empty array of objects
+- `input.items[].name`: non-empty string
+- `origin_id`: strongly recommended for traceability/replay
+
+Example path:
+
+- `inbox/opportunity_scan_real_001.json`
+
+---
+
+## 4. First-Run Commands
+
+## 4.1 Ingest
+
+```bash
+python3 skills/ingest_tasks.py --once
+```
+
+Expected:
+
+- `processed >= 1`
+- `preview_created >= 1`
+- `decision=preview_created_pending_approval`
+
+Capture:
+
+- `preview_id`
+- `preview_file`
+
+## 4.2 Approve Preview
+
+Create:
+
+- `approvals/<preview_id>.json`
+
+Payload template:
+
+```json
+{
+  "preview_id": "<preview_id>",
+  "approved": true,
+  "approved_by": "manual-first-run",
+  "approved_at": "2026-03-29T12:00:00Z",
+  "note": "Opportunity scan real-model first run"
+}
+```
+
+## 4.3 Execute (Real Model)
+
+```bash
+OPENAI_API_KEY="<provider_key>" \
+OPENAI_API_BASE="https://api.deepseek.com/v1" \
+OPENAI_MODEL_NAME="deepseek-chat" \
+ARGUS_LLM_WIRE_API="chat_completions" \
+python3 skills/execute_approved_previews.py --once --preview-id <preview_id> --test-mode off
+```
+
+If previous failed attempt marked preview as executed, replay with:
+
+```bash
+... python3 skills/execute_approved_previews.py --once --preview-id <preview_id> --test-mode off --allow-replay
+```
+
+---
+
+## 5. Success Criteria (Pass Gate)
+
+A run is considered successful when all are true:
+
+1. `execute_approved_previews` reports:
+   - `processed=1`
+   - `rejected=0`
+2. approval sidecar shows:
+   - `status=processed`
+   - `critic_verdict=pass` or an acceptable governed verdict for your stage
+3. analysis and review artifacts both exist:
+   - `artifacts/analysis/opportunity_scan_*.md`
+   - `artifacts/reviews/opportunity_scan_*_review.md`
+4. runtime logs confirm real endpoint execution (not test payload):
+   - `workspaces/automation/<AUTO_TASK_ID>/runtime.log`
+   - `workspaces/critic/<CRITIC_TASK_ID>/runtime.log`
+
+---
+
+## 6. Quality Checklist (Analysis Artifact)
+
+Check the analysis report for:
+
+1. Item-by-item analysis is complete (no missing candidate).
+2. Each item has explicit decision label (`GO` / `WATCH` / `NO-GO`).
+3. Ranking is present and consistent with verdict rationale.
+4. 7-day actions are concrete (not generic slogans).
+5. Risks are explicit and tied to provided evidence/constraints.
+
+---
+
+## 7. Quality Checklist (Critic Artifact)
+
+Check review report for:
+
+1. Clear verdict (`pass` / `needs_revision` / `fail`).
+2. Findings point to concrete strengths/issues.
+3. Rationale is decision-oriented (not generic restatement).
+4. Reviewer validates actionability and prioritization quality.
+
+---
+
+## 8. 3-Sample Regression Mode
+
+After first run passes, validate stability with 3 different samples:
+
+1. Prepare three different `origin_id` + scenario payloads.
+2. Repeat Steps 4.1–4.3 for each sample.
+3. Build comparison table with:
+   - preview id
+   - critic verdict
+   - GO/WATCH/NO-GO distribution
+   - top priority candidate
+   - artifact paths
+   - runtime duration (automation/critic)
+
+Regression pass recommendation:
+
+- 3/3 runs `processed` with governed verdicts and complete artifacts.
+
+---
+
+## 9. Branch Hygiene
+
+1. Commit code/doc changes only (no accidental secret material).
+2. Keep runtime evidence in governed folders; do not force-reset shared history.
+3. Push topic branch and open PR for review.
+

--- a/docs/OPPORTUNITY_SCAN_REGRESSION_20260329.md
+++ b/docs/OPPORTUNITY_SCAN_REGRESSION_20260329.md
@@ -1,0 +1,29 @@
+# Opportunity Scan Regression Report (2026-03-29)
+
+Real-model 3-sample regression for `request_type=opportunity_scan`.
+
+| Sample | Title | Preview ID | Critic Verdict | GO/WATCH/NO-GO | Top Priority | Auto/critic runtime | Endpoint |
+|---|---|---|---|---|---|---|---|
+| 1 | 商机扫描回归A：轻交付数字服务 | preview-manual-opportunity-scan-regression-101-026d8ee7fd7f | pass | 1/1/1 | 本地商家短视频脚本代写 (GO) - Highest priority due to clear path and verifiability. | 36.5s / 23.5s | https://api.deepseek.com/v1/chat/completions |
+| 2 | 商机扫描回归B：AI工具化微产品 | preview-manual-opportunity-scan-regression-102-ea1ff3ee6327 | pass | 1/1/1 | 简历关键词匹配打分器 (GO) – Highest priority due to best fit for低成本、快速反馈。 | 47.9s / 32.7s | https://api.deepseek.com/v1/chat/completions |
+| 3 | 商机扫描回归C：本地化执行服务 | preview-manual-opportunity-scan-regression-103-ffb2f21a7076 | pass | 1/1/1 | 企业招聘JD优化代写 (GO) - 最优选择：竞争低、交付简单、复购潜力高。 | 43.4s / 29.3s | https://api.deepseek.com/v1/chat/completions |
+
+## Artifacts
+
+### Sample 1
+- Analysis: `artifacts/analysis/opportunity_scan_manual-opportunity-scan-regression-101_026d8ee7.md`
+- Review: `artifacts/reviews/opportunity_scan_manual-opportunity-scan-regression-101_026d8ee7_review.md`
+
+### Sample 2
+- Analysis: `artifacts/analysis/opportunity_scan_manual-opportunity-scan-regression-102_ea1ff3ee.md`
+- Review: `artifacts/reviews/opportunity_scan_manual-opportunity-scan-regression-102_ea1ff3ee_review.md`
+
+### Sample 3
+- Analysis: `artifacts/analysis/opportunity_scan_manual-opportunity-scan-regression-103_ffb2f21a.md`
+- Review: `artifacts/reviews/opportunity_scan_manual-opportunity-scan-regression-103_ffb2f21a_review.md`
+
+## Summary
+
+- All 3 samples processed successfully in real-model mode.
+- All 3 critic verdicts are `pass`.
+- Each sample produced both analysis and review artifacts.

--- a/docs/OPPORTUNITY_SCAN_STRESS_REGRESSION_20260329.md
+++ b/docs/OPPORTUNITY_SCAN_STRESS_REGRESSION_20260329.md
@@ -1,0 +1,40 @@
+# Opportunity Scan Stress Regression Report (2026-03-29)
+
+Real-model pressure regression with 5 additional samples (`--test-mode off`).
+
+| Sample | Title | Preview ID | Critic Verdict | GO/WATCH/NO-GO | Top Priority | Auto/Critic Runtime | Endpoint |
+|---|---|---|---|---|---|---|---|
+| 1 | 压力回归201：本地门店增收服务组合 | preview-manual-opportunity-scan-stress-201-7eeca88e8c53 | pass | 1/1/1 | 门店抖音团购文案改写服务 (GO) | 42.0s / 27.2s | https://api.deepseek.com/v1/chat/completions |
+| 2 | 压力回归202：求职与人效微产品 | preview-manual-opportunity-scan-stress-202-8ec4fd24e6ca | pass | 1/1/1 | 面试问答个性化训练器 (GO) – Highest priority due to best fit for quick launch and feedback. | 47.8s / 28.3s | https://api.deepseek.com/v1/chat/completions |
+| 3 | 压力回归203：内容变现轻服务 | preview-manual-opportunity-scan-stress-203-68140c7c9e27 | pass | 1/1/1 | 公众号选题库定制服务 (GO) - Highest priority: optimal balance of price, repurchase potential, and alignment with constraints. | 47.9s / 32.6s | https://api.deepseek.com/v1/chat/completions |
+| 4 | 压力回归204：跨境卖家支持服务 | preview-manual-opportunity-scan-stress-204-4c55433b4dae | pass | 1/1/1 | GO - 亚马逊Listing首图文案优化 (最高优先级) | 50.9s / 31.9s | https://api.deepseek.com/v1/chat/completions |
+| 5 | 压力回归205：教育培训辅助服务 | preview-manual-opportunity-scan-stress-205-63ec2e93527a | pass | 1/1/1 | GO - 教培机构朋友圈招生文案包: Top priority due to alignment with all constraints and quick validation path. | 40.5s / 21.1s | https://api.deepseek.com/v1/chat/completions |
+
+## Artifacts
+
+### Sample 1
+- Analysis: `artifacts/analysis/opportunity_scan_manual-opportunity-scan-stress-201_7eeca88e.md`
+- Review: `artifacts/reviews/opportunity_scan_manual-opportunity-scan-stress-201_7eeca88e_review.md`
+
+### Sample 2
+- Analysis: `artifacts/analysis/opportunity_scan_manual-opportunity-scan-stress-202_8ec4fd24.md`
+- Review: `artifacts/reviews/opportunity_scan_manual-opportunity-scan-stress-202_8ec4fd24_review.md`
+
+### Sample 3
+- Analysis: `artifacts/analysis/opportunity_scan_manual-opportunity-scan-stress-203_68140c7c.md`
+- Review: `artifacts/reviews/opportunity_scan_manual-opportunity-scan-stress-203_68140c7c_review.md`
+
+### Sample 4
+- Analysis: `artifacts/analysis/opportunity_scan_manual-opportunity-scan-stress-204_4c55433b.md`
+- Review: `artifacts/reviews/opportunity_scan_manual-opportunity-scan-stress-204_4c55433b_review.md`
+
+### Sample 5
+- Analysis: `artifacts/analysis/opportunity_scan_manual-opportunity-scan-stress-205_63ec2e93.md`
+- Review: `artifacts/reviews/opportunity_scan_manual-opportunity-scan-stress-205_63ec2e93_review.md`
+
+## Summary
+
+- Processed: 5/5
+- Critic verdict `pass`: 5/5
+- Rejected: 0/5
+- Endpoint consistency: all runs used `https://api.deepseek.com/v1/chat/completions`

--- a/tests/test_local_inbox_adapter.py
+++ b/tests/test_local_inbox_adapter.py
@@ -38,6 +38,44 @@ class LocalInboxAdapterTests(unittest.TestCase):
             payload["regeneration_token"] = regeneration_token
         return payload
 
+    def _sample_opportunity_payload(self, *, origin_id: str | None) -> dict:
+        payload = {
+            "title": "商机扫描：低成本可执行副业机会评估",
+            "description": (
+                "请评估以下候选项目，判断是否适合普通人低成本启动，并给出明确的 "
+                "go/watch/no-go 建议。"
+            ),
+            "labels": ["manual", "analysis", "reviewable"],
+            "request_type": "opportunity_scan",
+            "input": {
+                "goal": "筛选低成本、个人可执行、7天内可验证的赚钱机会",
+                "constraints": [
+                    "启动成本低",
+                    "普通人可执行",
+                    "不依赖团队",
+                    "7天内可以做初步验证",
+                ],
+                "items": [
+                    {
+                        "name": "AI简历优化服务",
+                        "category": "AI服务",
+                        "target_user": "求职者",
+                        "competition_level": "medium",
+                    },
+                    {
+                        "name": "短视频爆款标题优化服务",
+                        "category": "内容服务",
+                        "target_user": "短视频创作者",
+                        "competition_level": "high",
+                    },
+                ],
+            },
+            "metadata": {"source_system": "manual_test", "priority": "normal"},
+        }
+        if origin_id is not None:
+            payload["origin_id"] = origin_id
+        return payload
+
     def test_condense_automation_description_preserves_meaningful_context(self) -> None:
         description = """
 Purpose:
@@ -307,6 +345,84 @@ Execution contract: treat this as a best-effort, evidence-backed PDF extraction/
             task.critic_task["metadata"]["regeneration_token"],
             "regen-20260324-a",
         )
+
+    def test_validate_external_payload_accepts_opportunity_scan(self) -> None:
+        raw_payload = self._sample_opportunity_payload(origin_id="manual:opportunity-001")
+
+        validated = local_inbox_adapter.validate_external_payload(
+            raw_payload,
+            inbox_filename="opportunity_scan_001.json",
+        )
+
+        self.assertEqual(validated["request_type"], "opportunity_scan")
+        self.assertEqual(validated["origin_id"], "manual:opportunity-001")
+        self.assertEqual(validated["inputs"]["goal"], "筛选低成本、个人可执行、7天内可验证的赚钱机会")
+        self.assertEqual(len(validated["inputs"]["items"]), 2)
+
+    def test_validate_external_payload_rejects_opportunity_scan_without_items(self) -> None:
+        raw_payload = self._sample_opportunity_payload(origin_id="manual:opportunity-001")
+        raw_payload["input"]["items"] = []
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "input.items must be a non-empty array for opportunity_scan",
+        ):
+            local_inbox_adapter.validate_external_payload(
+                raw_payload,
+                inbox_filename="opportunity_scan_001.json",
+            )
+
+    def test_normalize_local_inbox_payload_builds_opportunity_scan_tasks(self) -> None:
+        raw_payload = self._sample_opportunity_payload(origin_id="manual:opportunity-001")
+
+        with tempfile.TemporaryDirectory(prefix="local-inbox-opportunity-adapter-") as tmp:
+            base_dir = Path(tmp)
+            task = local_inbox_adapter.normalize_local_inbox_payload(
+                raw_payload,
+                inbox_filename="opportunity_scan_001.json",
+                base_dir=base_dir,
+            )
+
+        auto_task = task.automation_task
+        critic_task = task.critic_task
+
+        self.assertEqual(auto_task["worker"], "automation")
+        self.assertEqual(auto_task["task_type"], "generate_script")
+        self.assertEqual(auto_task["metadata"]["request_type"], "opportunity_scan")
+        self.assertEqual(
+            auto_task["metadata"]["automation_contract_profile"],
+            "structured_opportunity_scan_report_with_decision_verdicts",
+        )
+        self.assertEqual(auto_task["expected_outputs"][0]["type"], "doc")
+        self.assertTrue(
+            auto_task["expected_outputs"][0]["path"].startswith("artifacts/analysis/opportunity_scan_")
+        )
+        self.assertIn(
+            "GO, WATCH, NO-GO",
+            auto_task["inputs"]["params"]["contract_hints"]["decision_labels"],
+        )
+        self.assertIn(
+            "ranked recommendation",
+            auto_task["inputs"]["params"]["contract_hints"]["actionability"],
+        )
+        self.assertIn(
+            "Analyze every opportunity item",
+            "\n".join(auto_task["constraints"]),
+        )
+        self.assertEqual(validate_task(auto_task), [])
+
+        self.assertEqual(critic_task["worker"], "critic")
+        self.assertEqual(critic_task["task_type"], "review_artifact")
+        self.assertEqual(critic_task["metadata"]["request_type"], "opportunity_scan")
+        self.assertEqual(critic_task["inputs"]["artifacts"][0]["type"], "doc")
+        self.assertEqual(
+            critic_task["inputs"]["artifacts"][0]["path"],
+            auto_task["expected_outputs"][0]["path"],
+        )
+        self.assertTrue(
+            critic_task["expected_outputs"][0]["path"].startswith("artifacts/reviews/opportunity_scan_")
+        )
+        self.assertEqual(validate_task(critic_task), [])
 
     def test_validate_external_payload_rejects_regeneration_without_explicit_origin(self) -> None:
         raw_payload = self._sample_payload(origin_id=None, regeneration_token="regen-20260324-a")


### PR DESCRIPTION
## Summary

This PR introduces governed support for `request_type=opportunity_scan` and documents how to run and evaluate real-model executions.

### Code changes
- Add `opportunity_scan` support in local inbox adapter validation and normalization.
- Build dedicated automation/critic tasks for opportunity-scan requests.
- Keep existing `pdf_to_excel_ocr` behavior intact.

### Test changes
- Add adapter tests for:
  - accepted `opportunity_scan` payload
  - rejection when `input.items` is empty
  - normalized automation/critic task shape and contract compatibility

### Documentation
- Add first-run SOP for opportunity_scan real-model execution.
- Add 3-sample real-model regression report with artifacts and timing.

## Validation

### Unit / contract checks
- `python3 -m unittest -v tests/test_local_inbox_adapter.py`
- `python3 -m unittest -v tests/test_trello_readonly_ingress.py`
- `python3 scripts/backlog_lint.py`
- `python3 -m unittest -v tests/test_backlog_lint.py`
- `python3 -m unittest -v tests/test_argus_hardening.py`
- `python3 -m unittest -v tests/test_processed_finalization.py`

### Real-model execution (DeepSeek OpenAI-compatible)
- First real run executed with `--test-mode off`, result: `critic_verdict=pass`
  - `preview-manual-opportunity-scan-real-001-34a1996e9ed7`
- 3-sample regression executed with `--test-mode off`, all `pass`
  - `preview-manual-opportunity-scan-regression-101-026d8ee7fd7f`
  - `preview-manual-opportunity-scan-regression-102-ea1ff3ee6327`
  - `preview-manual-opportunity-scan-regression-103-ffb2f21a7076`

## Notes
- Branch follows repository policy (topic branch, no direct main edits).
- Delivery status remains `ready_for_replay` after changes.
